### PR TITLE
Use inferred union variant names in more cases

### DIFF
--- a/typify-impl/src/enums.rs
+++ b/typify-impl/src/enums.rs
@@ -609,7 +609,14 @@ impl TypeSpace {
             // account for types such as Uuid whose names come from outside of
             // the schema... but you can't win them all.
             .map(schema_is_named)
+            // Fall back to `VariantN` naming if any variants do not have names
+            // inferred.
             .collect::<Option<Vec<_>>>()
+            // Fall back to `VariantN` naming if any variants have the same
+            // name.
+            .filter(|variant_names| {
+                variant_names.len() == variant_names.iter().collect::<HashSet<_>>().len()
+            })
             // Prune the common prefixes from all variant names. If this
             // results in any of them being empty, we don't use these names.
             .and_then(|variant_names| {

--- a/typify-impl/src/value.rs
+++ b/typify-impl/src/value.rs
@@ -1089,7 +1089,7 @@ mod tests {
                 .map(|x| x.to_string()),
             Some(
                 quote! {
-                    super::Test::Variant0
+                    super::Test::Null
                 }
                 .to_string()
             )
@@ -1100,7 +1100,7 @@ mod tests {
                 .map(|x| x.to_string()),
             Some(
                 quote! {
-                    super::Test::Variant1("xx".to_string(), "yy".to_string())
+                    super::Test::Array("xx".to_string(), "yy".to_string())
                 }
                 .to_string()
             )
@@ -1117,7 +1117,7 @@ mod tests {
                 .map(|x| x.to_string()),
             Some(
                 quote! {
-                    super::Test::Variant2 {
+                    super::Test::Object {
                         cc: "xx".to_string(),
                         dd: "yy".to_string()
                     }
@@ -1147,7 +1147,7 @@ mod tests {
                 .map(|x| x.to_string()),
             Some(
                 quote! {
-                    Test::Variant0
+                    Test::Null
                 }
                 .to_string()
             )
@@ -1158,7 +1158,7 @@ mod tests {
                 .map(|x| x.to_string()),
             Some(
                 quote! {
-                    Test::Variant1("xx".to_string(), "yy".to_string())
+                    Test::Array("xx".to_string(), "yy".to_string())
                 }
                 .to_string()
             )
@@ -1175,7 +1175,7 @@ mod tests {
                 .map(|x| x.to_string()),
             Some(
                 quote! {
-                    Test::Variant2 {
+                    Test::Object {
                         cc: "xx".to_string(),
                         dd: "yy".to_string()
                     }

--- a/typify-impl/tests/github.out
+++ b/typify-impl/tests/github.out
@@ -27793,8 +27793,8 @@ impl ::std::convert::From<&ForkEventForkee> for ForkEventForkee {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ForkEventForkeeCreatedAt {
-    Variant0(i64),
-    Variant1(::chrono::DateTime<::chrono::offset::Utc>),
+    Integer(i64),
+    DateTime(::chrono::DateTime<::chrono::offset::Utc>),
 }
 impl ::std::convert::From<&Self> for ForkEventForkeeCreatedAt {
     fn from(value: &ForkEventForkeeCreatedAt) -> Self {
@@ -27805,9 +27805,9 @@ impl ::std::str::FromStr for ForkEventForkeeCreatedAt {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Integer(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::DateTime(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -27838,19 +27838,19 @@ impl ::std::convert::TryFrom<::std::string::String> for ForkEventForkeeCreatedAt
 impl ::std::fmt::Display for ForkEventForkeeCreatedAt {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Integer(x) => x.fmt(f),
+            Self::DateTime(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<i64> for ForkEventForkeeCreatedAt {
     fn from(value: i64) -> Self {
-        Self::Variant0(value)
+        Self::Integer(value)
     }
 }
 impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>> for ForkEventForkeeCreatedAt {
     fn from(value: ::chrono::DateTime<::chrono::offset::Utc>) -> Self {
-        Self::Variant1(value)
+        Self::DateTime(value)
     }
 }
 #[doc = "`ForkEventForkeePermissions`"]
@@ -27926,9 +27926,9 @@ impl ::std::convert::From<&ForkEventForkeePermissions> for ForkEventForkeePermis
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ForkEventForkeePushedAt {
-    Variant0(i64),
-    Variant1(::chrono::DateTime<::chrono::offset::Utc>),
-    Variant2,
+    Integer(i64),
+    DateTime(::chrono::DateTime<::chrono::offset::Utc>),
+    Null,
 }
 impl ::std::convert::From<&Self> for ForkEventForkeePushedAt {
     fn from(value: &ForkEventForkeePushedAt) -> Self {
@@ -27937,12 +27937,12 @@ impl ::std::convert::From<&Self> for ForkEventForkeePushedAt {
 }
 impl ::std::convert::From<i64> for ForkEventForkeePushedAt {
     fn from(value: i64) -> Self {
-        Self::Variant0(value)
+        Self::Integer(value)
     }
 }
 impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>> for ForkEventForkeePushedAt {
     fn from(value: ::chrono::DateTime<::chrono::offset::Utc>) -> Self {
-        Self::Variant1(value)
+        Self::DateTime(value)
     }
 }
 #[doc = "`GithubAppAuthorizationEvent`"]
@@ -29145,8 +29145,8 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationCreatedActio
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum InstallationCreatedAt {
-    Variant0(::chrono::DateTime<::chrono::offset::Utc>),
-    Variant1(i64),
+    DateTime(::chrono::DateTime<::chrono::offset::Utc>),
+    Integer(i64),
 }
 impl ::std::convert::From<&Self> for InstallationCreatedAt {
     fn from(value: &InstallationCreatedAt) -> Self {
@@ -29157,9 +29157,9 @@ impl ::std::str::FromStr for InstallationCreatedAt {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::DateTime(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Integer(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -29190,19 +29190,19 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationCreatedAt {
 impl ::std::fmt::Display for InstallationCreatedAt {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::DateTime(x) => x.fmt(f),
+            Self::Integer(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>> for InstallationCreatedAt {
     fn from(value: ::chrono::DateTime<::chrono::offset::Utc>) -> Self {
-        Self::Variant0(value)
+        Self::DateTime(value)
     }
 }
 impl ::std::convert::From<i64> for InstallationCreatedAt {
     fn from(value: i64) -> Self {
-        Self::Variant1(value)
+        Self::Integer(value)
     }
 }
 #[doc = "`InstallationCreatedRepositoriesItem`"]
@@ -34410,8 +34410,8 @@ impl ::std::convert::From<&InstallationSuspendInstallation> for InstallationSusp
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum InstallationSuspendInstallationCreatedAt {
-    Variant0(::chrono::DateTime<::chrono::offset::Utc>),
-    Variant1(i64),
+    DateTime(::chrono::DateTime<::chrono::offset::Utc>),
+    Integer(i64),
 }
 impl ::std::convert::From<&Self> for InstallationSuspendInstallationCreatedAt {
     fn from(value: &InstallationSuspendInstallationCreatedAt) -> Self {
@@ -34422,9 +34422,9 @@ impl ::std::str::FromStr for InstallationSuspendInstallationCreatedAt {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::DateTime(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Integer(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -34455,8 +34455,8 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationSuspendInsta
 impl ::std::fmt::Display for InstallationSuspendInstallationCreatedAt {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::DateTime(x) => x.fmt(f),
+            Self::Integer(x) => x.fmt(f),
         }
     }
 }
@@ -34464,12 +34464,12 @@ impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
     for InstallationSuspendInstallationCreatedAt
 {
     fn from(value: ::chrono::DateTime<::chrono::offset::Utc>) -> Self {
-        Self::Variant0(value)
+        Self::DateTime(value)
     }
 }
 impl ::std::convert::From<i64> for InstallationSuspendInstallationCreatedAt {
     fn from(value: i64) -> Self {
-        Self::Variant1(value)
+        Self::Integer(value)
     }
 }
 #[doc = "`InstallationSuspendInstallationEventsItem`"]
@@ -38461,8 +38461,8 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationSuspendInsta
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum InstallationSuspendInstallationUpdatedAt {
-    Variant0(::chrono::DateTime<::chrono::offset::Utc>),
-    Variant1(i64),
+    DateTime(::chrono::DateTime<::chrono::offset::Utc>),
+    Integer(i64),
 }
 impl ::std::convert::From<&Self> for InstallationSuspendInstallationUpdatedAt {
     fn from(value: &InstallationSuspendInstallationUpdatedAt) -> Self {
@@ -38473,9 +38473,9 @@ impl ::std::str::FromStr for InstallationSuspendInstallationUpdatedAt {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::DateTime(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Integer(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -38506,8 +38506,8 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationSuspendInsta
 impl ::std::fmt::Display for InstallationSuspendInstallationUpdatedAt {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::DateTime(x) => x.fmt(f),
+            Self::Integer(x) => x.fmt(f),
         }
     }
 }
@@ -38515,12 +38515,12 @@ impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
     for InstallationSuspendInstallationUpdatedAt
 {
     fn from(value: ::chrono::DateTime<::chrono::offset::Utc>) -> Self {
-        Self::Variant0(value)
+        Self::DateTime(value)
     }
 }
 impl ::std::convert::From<i64> for InstallationSuspendInstallationUpdatedAt {
     fn from(value: i64) -> Self {
-        Self::Variant1(value)
+        Self::Integer(value)
     }
 }
 #[doc = "`InstallationSuspendRepositoriesItem`"]
@@ -38921,8 +38921,8 @@ impl ::std::convert::From<&InstallationUnsuspendInstallation>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum InstallationUnsuspendInstallationCreatedAt {
-    Variant0(::chrono::DateTime<::chrono::offset::Utc>),
-    Variant1(i64),
+    DateTime(::chrono::DateTime<::chrono::offset::Utc>),
+    Integer(i64),
 }
 impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationCreatedAt {
     fn from(value: &InstallationUnsuspendInstallationCreatedAt) -> Self {
@@ -38933,9 +38933,9 @@ impl ::std::str::FromStr for InstallationUnsuspendInstallationCreatedAt {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::DateTime(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Integer(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -38968,8 +38968,8 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationUnsuspendIns
 impl ::std::fmt::Display for InstallationUnsuspendInstallationCreatedAt {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::DateTime(x) => x.fmt(f),
+            Self::Integer(x) => x.fmt(f),
         }
     }
 }
@@ -38977,12 +38977,12 @@ impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
     for InstallationUnsuspendInstallationCreatedAt
 {
     fn from(value: ::chrono::DateTime<::chrono::offset::Utc>) -> Self {
-        Self::Variant0(value)
+        Self::DateTime(value)
     }
 }
 impl ::std::convert::From<i64> for InstallationUnsuspendInstallationCreatedAt {
     fn from(value: i64) -> Self {
-        Self::Variant1(value)
+        Self::Integer(value)
     }
 }
 #[doc = "`InstallationUnsuspendInstallationEventsItem`"]
@@ -42762,8 +42762,8 @@ impl ::std::convert::TryFrom<::std::string::String>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum InstallationUnsuspendInstallationUpdatedAt {
-    Variant0(::chrono::DateTime<::chrono::offset::Utc>),
-    Variant1(i64),
+    DateTime(::chrono::DateTime<::chrono::offset::Utc>),
+    Integer(i64),
 }
 impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationUpdatedAt {
     fn from(value: &InstallationUnsuspendInstallationUpdatedAt) -> Self {
@@ -42774,9 +42774,9 @@ impl ::std::str::FromStr for InstallationUnsuspendInstallationUpdatedAt {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::DateTime(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Integer(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -42809,8 +42809,8 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationUnsuspendIns
 impl ::std::fmt::Display for InstallationUnsuspendInstallationUpdatedAt {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::DateTime(x) => x.fmt(f),
+            Self::Integer(x) => x.fmt(f),
         }
     }
 }
@@ -42818,12 +42818,12 @@ impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
     for InstallationUnsuspendInstallationUpdatedAt
 {
     fn from(value: ::chrono::DateTime<::chrono::offset::Utc>) -> Self {
-        Self::Variant0(value)
+        Self::DateTime(value)
     }
 }
 impl ::std::convert::From<i64> for InstallationUnsuspendInstallationUpdatedAt {
     fn from(value: i64) -> Self {
-        Self::Variant1(value)
+        Self::Integer(value)
     }
 }
 #[doc = "`InstallationUnsuspendRepositoriesItem`"]
@@ -42904,8 +42904,8 @@ impl ::std::convert::From<&InstallationUnsuspendRepositoriesItem>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum InstallationUpdatedAt {
-    Variant0(::chrono::DateTime<::chrono::offset::Utc>),
-    Variant1(i64),
+    DateTime(::chrono::DateTime<::chrono::offset::Utc>),
+    Integer(i64),
 }
 impl ::std::convert::From<&Self> for InstallationUpdatedAt {
     fn from(value: &InstallationUpdatedAt) -> Self {
@@ -42916,9 +42916,9 @@ impl ::std::str::FromStr for InstallationUpdatedAt {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::DateTime(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Integer(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -42949,19 +42949,19 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationUpdatedAt {
 impl ::std::fmt::Display for InstallationUpdatedAt {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::DateTime(x) => x.fmt(f),
+            Self::Integer(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>> for InstallationUpdatedAt {
     fn from(value: ::chrono::DateTime<::chrono::offset::Utc>) -> Self {
-        Self::Variant0(value)
+        Self::DateTime(value)
     }
 }
 impl ::std::convert::From<i64> for InstallationUpdatedAt {
     fn from(value: i64) -> Self {
-        Self::Variant1(value)
+        Self::Integer(value)
     }
 }
 #[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) itself."]
@@ -55826,8 +55826,8 @@ impl ::std::convert::TryFrom<::std::string::String> for MembershipRemovedScope {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum MembershipRemovedTeam {
-    Variant0(Team),
-    Variant1 {
+    Team(Team),
+    Object {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         deleted: ::std::option::Option<bool>,
         id: i64,
@@ -55841,7 +55841,7 @@ impl ::std::convert::From<&Self> for MembershipRemovedTeam {
 }
 impl ::std::convert::From<Team> for MembershipRemovedTeam {
     fn from(value: Team) -> Self {
-        Self::Variant0(value)
+        Self::Team(value)
     }
 }
 #[doc = "`MetaDeleted`"]
@@ -65493,8 +65493,8 @@ impl ::std::convert::From<&PublicEventRepository> for PublicEventRepository {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum PublicEventRepositoryCreatedAt {
-    Variant0(i64),
-    Variant1(::chrono::DateTime<::chrono::offset::Utc>),
+    Integer(i64),
+    DateTime(::chrono::DateTime<::chrono::offset::Utc>),
 }
 impl ::std::convert::From<&Self> for PublicEventRepositoryCreatedAt {
     fn from(value: &PublicEventRepositoryCreatedAt) -> Self {
@@ -65505,9 +65505,9 @@ impl ::std::str::FromStr for PublicEventRepositoryCreatedAt {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Integer(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::DateTime(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -65538,21 +65538,21 @@ impl ::std::convert::TryFrom<::std::string::String> for PublicEventRepositoryCre
 impl ::std::fmt::Display for PublicEventRepositoryCreatedAt {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Integer(x) => x.fmt(f),
+            Self::DateTime(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<i64> for PublicEventRepositoryCreatedAt {
     fn from(value: i64) -> Self {
-        Self::Variant0(value)
+        Self::Integer(value)
     }
 }
 impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
     for PublicEventRepositoryCreatedAt
 {
     fn from(value: ::chrono::DateTime<::chrono::offset::Utc>) -> Self {
-        Self::Variant1(value)
+        Self::DateTime(value)
     }
 }
 #[doc = "`PublicEventRepositoryPermissions`"]
@@ -65628,9 +65628,9 @@ impl ::std::convert::From<&PublicEventRepositoryPermissions> for PublicEventRepo
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum PublicEventRepositoryPushedAt {
-    Variant0(i64),
-    Variant1(::chrono::DateTime<::chrono::offset::Utc>),
-    Variant2,
+    Integer(i64),
+    DateTime(::chrono::DateTime<::chrono::offset::Utc>),
+    Null,
 }
 impl ::std::convert::From<&Self> for PublicEventRepositoryPushedAt {
     fn from(value: &PublicEventRepositoryPushedAt) -> Self {
@@ -65639,14 +65639,14 @@ impl ::std::convert::From<&Self> for PublicEventRepositoryPushedAt {
 }
 impl ::std::convert::From<i64> for PublicEventRepositoryPushedAt {
     fn from(value: i64) -> Self {
-        Self::Variant0(value)
+        Self::Integer(value)
     }
 }
 impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
     for PublicEventRepositoryPushedAt
 {
     fn from(value: ::chrono::DateTime<::chrono::offset::Utc>) -> Self {
-        Self::Variant1(value)
+        Self::DateTime(value)
     }
 }
 #[doc = "`PullRequest`"]
@@ -80228,8 +80228,8 @@ impl ::std::convert::From<&RepositoryArchivedRepository> for RepositoryArchivedR
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum RepositoryArchivedRepositoryCreatedAt {
-    Variant0(i64),
-    Variant1(::chrono::DateTime<::chrono::offset::Utc>),
+    Integer(i64),
+    DateTime(::chrono::DateTime<::chrono::offset::Utc>),
 }
 impl ::std::convert::From<&Self> for RepositoryArchivedRepositoryCreatedAt {
     fn from(value: &RepositoryArchivedRepositoryCreatedAt) -> Self {
@@ -80240,9 +80240,9 @@ impl ::std::str::FromStr for RepositoryArchivedRepositoryCreatedAt {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Integer(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::DateTime(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -80273,21 +80273,21 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryArchivedReposi
 impl ::std::fmt::Display for RepositoryArchivedRepositoryCreatedAt {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Integer(x) => x.fmt(f),
+            Self::DateTime(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<i64> for RepositoryArchivedRepositoryCreatedAt {
     fn from(value: i64) -> Self {
-        Self::Variant0(value)
+        Self::Integer(value)
     }
 }
 impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
     for RepositoryArchivedRepositoryCreatedAt
 {
     fn from(value: ::chrono::DateTime<::chrono::offset::Utc>) -> Self {
-        Self::Variant1(value)
+        Self::DateTime(value)
     }
 }
 #[doc = "`RepositoryArchivedRepositoryPermissions`"]
@@ -80365,9 +80365,9 @@ impl ::std::convert::From<&RepositoryArchivedRepositoryPermissions>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum RepositoryArchivedRepositoryPushedAt {
-    Variant0(i64),
-    Variant1(::chrono::DateTime<::chrono::offset::Utc>),
-    Variant2,
+    Integer(i64),
+    DateTime(::chrono::DateTime<::chrono::offset::Utc>),
+    Null,
 }
 impl ::std::convert::From<&Self> for RepositoryArchivedRepositoryPushedAt {
     fn from(value: &RepositoryArchivedRepositoryPushedAt) -> Self {
@@ -80376,14 +80376,14 @@ impl ::std::convert::From<&Self> for RepositoryArchivedRepositoryPushedAt {
 }
 impl ::std::convert::From<i64> for RepositoryArchivedRepositoryPushedAt {
     fn from(value: i64) -> Self {
-        Self::Variant0(value)
+        Self::Integer(value)
     }
 }
 impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
     for RepositoryArchivedRepositoryPushedAt
 {
     fn from(value: ::chrono::DateTime<::chrono::offset::Utc>) -> Self {
-        Self::Variant1(value)
+        Self::DateTime(value)
     }
 }
 #[doc = "`RepositoryCreated`"]
@@ -80533,8 +80533,8 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryCreatedAction 
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum RepositoryCreatedAt {
-    Variant0(i64),
-    Variant1(::chrono::DateTime<::chrono::offset::Utc>),
+    Integer(i64),
+    DateTime(::chrono::DateTime<::chrono::offset::Utc>),
 }
 impl ::std::convert::From<&Self> for RepositoryCreatedAt {
     fn from(value: &RepositoryCreatedAt) -> Self {
@@ -80545,9 +80545,9 @@ impl ::std::str::FromStr for RepositoryCreatedAt {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Integer(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::DateTime(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -80578,19 +80578,19 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryCreatedAt {
 impl ::std::fmt::Display for RepositoryCreatedAt {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Integer(x) => x.fmt(f),
+            Self::DateTime(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<i64> for RepositoryCreatedAt {
     fn from(value: i64) -> Self {
-        Self::Variant0(value)
+        Self::Integer(value)
     }
 }
 impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>> for RepositoryCreatedAt {
     fn from(value: ::chrono::DateTime<::chrono::offset::Utc>) -> Self {
-        Self::Variant1(value)
+        Self::DateTime(value)
     }
 }
 #[doc = "`RepositoryDeleted`"]
@@ -82154,8 +82154,8 @@ impl ::std::convert::From<&RepositoryPrivatizedRepository> for RepositoryPrivati
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum RepositoryPrivatizedRepositoryCreatedAt {
-    Variant0(i64),
-    Variant1(::chrono::DateTime<::chrono::offset::Utc>),
+    Integer(i64),
+    DateTime(::chrono::DateTime<::chrono::offset::Utc>),
 }
 impl ::std::convert::From<&Self> for RepositoryPrivatizedRepositoryCreatedAt {
     fn from(value: &RepositoryPrivatizedRepositoryCreatedAt) -> Self {
@@ -82166,9 +82166,9 @@ impl ::std::str::FromStr for RepositoryPrivatizedRepositoryCreatedAt {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Integer(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::DateTime(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -82199,21 +82199,21 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryPrivatizedRepo
 impl ::std::fmt::Display for RepositoryPrivatizedRepositoryCreatedAt {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Integer(x) => x.fmt(f),
+            Self::DateTime(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<i64> for RepositoryPrivatizedRepositoryCreatedAt {
     fn from(value: i64) -> Self {
-        Self::Variant0(value)
+        Self::Integer(value)
     }
 }
 impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
     for RepositoryPrivatizedRepositoryCreatedAt
 {
     fn from(value: ::chrono::DateTime<::chrono::offset::Utc>) -> Self {
-        Self::Variant1(value)
+        Self::DateTime(value)
     }
 }
 #[doc = "`RepositoryPrivatizedRepositoryPermissions`"]
@@ -82291,9 +82291,9 @@ impl ::std::convert::From<&RepositoryPrivatizedRepositoryPermissions>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum RepositoryPrivatizedRepositoryPushedAt {
-    Variant0(i64),
-    Variant1(::chrono::DateTime<::chrono::offset::Utc>),
-    Variant2,
+    Integer(i64),
+    DateTime(::chrono::DateTime<::chrono::offset::Utc>),
+    Null,
 }
 impl ::std::convert::From<&Self> for RepositoryPrivatizedRepositoryPushedAt {
     fn from(value: &RepositoryPrivatizedRepositoryPushedAt) -> Self {
@@ -82302,14 +82302,14 @@ impl ::std::convert::From<&Self> for RepositoryPrivatizedRepositoryPushedAt {
 }
 impl ::std::convert::From<i64> for RepositoryPrivatizedRepositoryPushedAt {
     fn from(value: i64) -> Self {
-        Self::Variant0(value)
+        Self::Integer(value)
     }
 }
 impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
     for RepositoryPrivatizedRepositoryPushedAt
 {
     fn from(value: ::chrono::DateTime<::chrono::offset::Utc>) -> Self {
-        Self::Variant1(value)
+        Self::DateTime(value)
     }
 }
 #[doc = "`RepositoryPublicized`"]
@@ -82629,8 +82629,8 @@ impl ::std::convert::From<&RepositoryPublicizedRepository> for RepositoryPublici
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum RepositoryPublicizedRepositoryCreatedAt {
-    Variant0(i64),
-    Variant1(::chrono::DateTime<::chrono::offset::Utc>),
+    Integer(i64),
+    DateTime(::chrono::DateTime<::chrono::offset::Utc>),
 }
 impl ::std::convert::From<&Self> for RepositoryPublicizedRepositoryCreatedAt {
     fn from(value: &RepositoryPublicizedRepositoryCreatedAt) -> Self {
@@ -82641,9 +82641,9 @@ impl ::std::str::FromStr for RepositoryPublicizedRepositoryCreatedAt {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Integer(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::DateTime(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -82674,21 +82674,21 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryPublicizedRepo
 impl ::std::fmt::Display for RepositoryPublicizedRepositoryCreatedAt {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Integer(x) => x.fmt(f),
+            Self::DateTime(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<i64> for RepositoryPublicizedRepositoryCreatedAt {
     fn from(value: i64) -> Self {
-        Self::Variant0(value)
+        Self::Integer(value)
     }
 }
 impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
     for RepositoryPublicizedRepositoryCreatedAt
 {
     fn from(value: ::chrono::DateTime<::chrono::offset::Utc>) -> Self {
-        Self::Variant1(value)
+        Self::DateTime(value)
     }
 }
 #[doc = "`RepositoryPublicizedRepositoryPermissions`"]
@@ -82766,9 +82766,9 @@ impl ::std::convert::From<&RepositoryPublicizedRepositoryPermissions>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum RepositoryPublicizedRepositoryPushedAt {
-    Variant0(i64),
-    Variant1(::chrono::DateTime<::chrono::offset::Utc>),
-    Variant2,
+    Integer(i64),
+    DateTime(::chrono::DateTime<::chrono::offset::Utc>),
+    Null,
 }
 impl ::std::convert::From<&Self> for RepositoryPublicizedRepositoryPushedAt {
     fn from(value: &RepositoryPublicizedRepositoryPushedAt) -> Self {
@@ -82777,14 +82777,14 @@ impl ::std::convert::From<&Self> for RepositoryPublicizedRepositoryPushedAt {
 }
 impl ::std::convert::From<i64> for RepositoryPublicizedRepositoryPushedAt {
     fn from(value: i64) -> Self {
-        Self::Variant0(value)
+        Self::Integer(value)
     }
 }
 impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
     for RepositoryPublicizedRepositoryPushedAt
 {
     fn from(value: ::chrono::DateTime<::chrono::offset::Utc>) -> Self {
-        Self::Variant1(value)
+        Self::DateTime(value)
     }
 }
 #[doc = "`RepositoryPushedAt`"]
@@ -82811,9 +82811,9 @@ impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum RepositoryPushedAt {
-    Variant0(i64),
-    Variant1(::chrono::DateTime<::chrono::offset::Utc>),
-    Variant2,
+    Integer(i64),
+    DateTime(::chrono::DateTime<::chrono::offset::Utc>),
+    Null,
 }
 impl ::std::convert::From<&Self> for RepositoryPushedAt {
     fn from(value: &RepositoryPushedAt) -> Self {
@@ -82822,12 +82822,12 @@ impl ::std::convert::From<&Self> for RepositoryPushedAt {
 }
 impl ::std::convert::From<i64> for RepositoryPushedAt {
     fn from(value: i64) -> Self {
-        Self::Variant0(value)
+        Self::Integer(value)
     }
 }
 impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>> for RepositoryPushedAt {
     fn from(value: ::chrono::DateTime<::chrono::offset::Utc>) -> Self {
-        Self::Variant1(value)
+        Self::DateTime(value)
     }
 }
 #[doc = "`RepositoryRenamed`"]
@@ -83697,8 +83697,8 @@ impl ::std::convert::From<&RepositoryUnarchivedRepository> for RepositoryUnarchi
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum RepositoryUnarchivedRepositoryCreatedAt {
-    Variant0(i64),
-    Variant1(::chrono::DateTime<::chrono::offset::Utc>),
+    Integer(i64),
+    DateTime(::chrono::DateTime<::chrono::offset::Utc>),
 }
 impl ::std::convert::From<&Self> for RepositoryUnarchivedRepositoryCreatedAt {
     fn from(value: &RepositoryUnarchivedRepositoryCreatedAt) -> Self {
@@ -83709,9 +83709,9 @@ impl ::std::str::FromStr for RepositoryUnarchivedRepositoryCreatedAt {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Integer(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::DateTime(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -83742,21 +83742,21 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryUnarchivedRepo
 impl ::std::fmt::Display for RepositoryUnarchivedRepositoryCreatedAt {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Integer(x) => x.fmt(f),
+            Self::DateTime(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<i64> for RepositoryUnarchivedRepositoryCreatedAt {
     fn from(value: i64) -> Self {
-        Self::Variant0(value)
+        Self::Integer(value)
     }
 }
 impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
     for RepositoryUnarchivedRepositoryCreatedAt
 {
     fn from(value: ::chrono::DateTime<::chrono::offset::Utc>) -> Self {
-        Self::Variant1(value)
+        Self::DateTime(value)
     }
 }
 #[doc = "`RepositoryUnarchivedRepositoryPermissions`"]
@@ -83834,9 +83834,9 @@ impl ::std::convert::From<&RepositoryUnarchivedRepositoryPermissions>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum RepositoryUnarchivedRepositoryPushedAt {
-    Variant0(i64),
-    Variant1(::chrono::DateTime<::chrono::offset::Utc>),
-    Variant2,
+    Integer(i64),
+    DateTime(::chrono::DateTime<::chrono::offset::Utc>),
+    Null,
 }
 impl ::std::convert::From<&Self> for RepositoryUnarchivedRepositoryPushedAt {
     fn from(value: &RepositoryUnarchivedRepositoryPushedAt) -> Self {
@@ -83845,14 +83845,14 @@ impl ::std::convert::From<&Self> for RepositoryUnarchivedRepositoryPushedAt {
 }
 impl ::std::convert::From<i64> for RepositoryUnarchivedRepositoryPushedAt {
     fn from(value: i64) -> Self {
-        Self::Variant0(value)
+        Self::Integer(value)
     }
 }
 impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
     for RepositoryUnarchivedRepositoryPushedAt
 {
     fn from(value: ::chrono::DateTime<::chrono::offset::Utc>) -> Self {
-        Self::Variant1(value)
+        Self::DateTime(value)
     }
 }
 #[doc = "`RepositoryVulnerabilityAlertCreate`"]

--- a/typify-impl/tests/vega.out
+++ b/typify-impl/tests/vega.out
@@ -263,27 +263,25 @@ impl ::std::convert::From<&AggregateTransform> for AggregateTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum AggregateTransformAs {
-    Variant0(::std::vec::Vec<AggregateTransformAsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<AggregateTransformAsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for AggregateTransformAs {
     fn from(value: &AggregateTransformAs) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<AggregateTransformAsVariant0Item>>
-    for AggregateTransformAs
-{
-    fn from(value: ::std::vec::Vec<AggregateTransformAsVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<AggregateTransformAsArrayItem>> for AggregateTransformAs {
+    fn from(value: ::std::vec::Vec<AggregateTransformAsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for AggregateTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`AggregateTransformAsVariant0Item`"]
+#[doc = "`AggregateTransformAsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -305,19 +303,19 @@ impl ::std::convert::From<SignalRef> for AggregateTransformAs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum AggregateTransformAsVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
-    Variant2,
+pub enum AggregateTransformAsArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
+    Null,
 }
-impl ::std::convert::From<&Self> for AggregateTransformAsVariant0Item {
-    fn from(value: &AggregateTransformAsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for AggregateTransformAsArrayItem {
+    fn from(value: &AggregateTransformAsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for AggregateTransformAsVariant0Item {
+impl ::std::convert::From<SignalRef> for AggregateTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`AggregateTransformCross`"]
@@ -340,8 +338,8 @@ impl ::std::convert::From<SignalRef> for AggregateTransformAsVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum AggregateTransformCross {
-    Variant0(bool),
-    Variant1(SignalRef),
+    Boolean(bool),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for AggregateTransformCross {
     fn from(value: &AggregateTransformCross) -> Self {
@@ -350,12 +348,12 @@ impl ::std::convert::From<&Self> for AggregateTransformCross {
 }
 impl ::std::convert::From<bool> for AggregateTransformCross {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<SignalRef> for AggregateTransformCross {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`AggregateTransformDrop`"]
@@ -379,8 +377,8 @@ impl ::std::convert::From<SignalRef> for AggregateTransformCross {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum AggregateTransformDrop {
-    Variant0(bool),
-    Variant1(SignalRef),
+    Boolean(bool),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for AggregateTransformDrop {
     fn from(value: &AggregateTransformDrop) -> Self {
@@ -389,17 +387,17 @@ impl ::std::convert::From<&Self> for AggregateTransformDrop {
 }
 impl ::std::default::Default for AggregateTransformDrop {
     fn default() -> Self {
-        AggregateTransformDrop::Variant0(true)
+        AggregateTransformDrop::Boolean(true)
     }
 }
 impl ::std::convert::From<bool> for AggregateTransformDrop {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<SignalRef> for AggregateTransformDrop {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`AggregateTransformFields`"]
@@ -438,27 +436,27 @@ impl ::std::convert::From<SignalRef> for AggregateTransformDrop {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum AggregateTransformFields {
-    Variant0(::std::vec::Vec<AggregateTransformFieldsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<AggregateTransformFieldsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for AggregateTransformFields {
     fn from(value: &AggregateTransformFields) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<AggregateTransformFieldsVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<AggregateTransformFieldsArrayItem>>
     for AggregateTransformFields
 {
-    fn from(value: ::std::vec::Vec<AggregateTransformFieldsVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<AggregateTransformFieldsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for AggregateTransformFields {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`AggregateTransformFieldsVariant0Item`"]
+#[doc = "`AggregateTransformFieldsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -483,30 +481,30 @@ impl ::std::convert::From<SignalRef> for AggregateTransformFields {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum AggregateTransformFieldsVariant0Item {
-    Variant0(ScaleField),
-    Variant1(ParamField),
-    Variant2(Expr),
-    Variant3,
+pub enum AggregateTransformFieldsArrayItem {
+    ScaleField(ScaleField),
+    ParamField(ParamField),
+    Expr(Expr),
+    Null,
 }
-impl ::std::convert::From<&Self> for AggregateTransformFieldsVariant0Item {
-    fn from(value: &AggregateTransformFieldsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for AggregateTransformFieldsArrayItem {
+    fn from(value: &AggregateTransformFieldsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<ScaleField> for AggregateTransformFieldsVariant0Item {
+impl ::std::convert::From<ScaleField> for AggregateTransformFieldsArrayItem {
     fn from(value: ScaleField) -> Self {
-        Self::Variant0(value)
+        Self::ScaleField(value)
     }
 }
-impl ::std::convert::From<ParamField> for AggregateTransformFieldsVariant0Item {
+impl ::std::convert::From<ParamField> for AggregateTransformFieldsArrayItem {
     fn from(value: ParamField) -> Self {
-        Self::Variant1(value)
+        Self::ParamField(value)
     }
 }
-impl ::std::convert::From<Expr> for AggregateTransformFieldsVariant0Item {
+impl ::std::convert::From<Expr> for AggregateTransformFieldsArrayItem {
     fn from(value: Expr) -> Self {
-        Self::Variant2(value)
+        Self::Expr(value)
     }
 }
 #[doc = "`AggregateTransformGroupby`"]
@@ -542,27 +540,27 @@ impl ::std::convert::From<Expr> for AggregateTransformFieldsVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum AggregateTransformGroupby {
-    Variant0(::std::vec::Vec<AggregateTransformGroupbyVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<AggregateTransformGroupbyArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for AggregateTransformGroupby {
     fn from(value: &AggregateTransformGroupby) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<AggregateTransformGroupbyVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<AggregateTransformGroupbyArrayItem>>
     for AggregateTransformGroupby
 {
-    fn from(value: ::std::vec::Vec<AggregateTransformGroupbyVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<AggregateTransformGroupbyArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for AggregateTransformGroupby {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`AggregateTransformGroupbyVariant0Item`"]
+#[doc = "`AggregateTransformGroupbyArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -584,27 +582,27 @@ impl ::std::convert::From<SignalRef> for AggregateTransformGroupby {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum AggregateTransformGroupbyVariant0Item {
+pub enum AggregateTransformGroupbyArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for AggregateTransformGroupbyVariant0Item {
-    fn from(value: &AggregateTransformGroupbyVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for AggregateTransformGroupbyArrayItem {
+    fn from(value: &AggregateTransformGroupbyArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<ScaleField> for AggregateTransformGroupbyVariant0Item {
+impl ::std::convert::From<ScaleField> for AggregateTransformGroupbyArrayItem {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
     }
 }
-impl ::std::convert::From<ParamField> for AggregateTransformGroupbyVariant0Item {
+impl ::std::convert::From<ParamField> for AggregateTransformGroupbyArrayItem {
     fn from(value: ParamField) -> Self {
         Self::ParamField(value)
     }
 }
-impl ::std::convert::From<Expr> for AggregateTransformGroupbyVariant0Item {
+impl ::std::convert::From<Expr> for AggregateTransformGroupbyArrayItem {
     fn from(value: Expr) -> Self {
         Self::Expr(value)
     }
@@ -711,27 +709,27 @@ impl ::std::convert::From<Expr> for AggregateTransformKey {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum AggregateTransformOps {
-    Variant0(::std::vec::Vec<AggregateTransformOpsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<AggregateTransformOpsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for AggregateTransformOps {
     fn from(value: &AggregateTransformOps) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<AggregateTransformOpsVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<AggregateTransformOpsArrayItem>>
     for AggregateTransformOps
 {
-    fn from(value: ::std::vec::Vec<AggregateTransformOpsVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<AggregateTransformOpsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for AggregateTransformOps {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`AggregateTransformOpsVariant0Item`"]
+#[doc = "`AggregateTransformOpsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -775,28 +773,28 @@ impl ::std::convert::From<SignalRef> for AggregateTransformOps {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum AggregateTransformOpsVariant0Item {
-    Variant0(AggregateTransformOpsVariant0ItemVariant0),
+pub enum AggregateTransformOpsArrayItem {
+    Variant0(AggregateTransformOpsArrayItemVariant0),
     Variant1(SignalRef),
 }
-impl ::std::convert::From<&Self> for AggregateTransformOpsVariant0Item {
-    fn from(value: &AggregateTransformOpsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for AggregateTransformOpsArrayItem {
+    fn from(value: &AggregateTransformOpsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<AggregateTransformOpsVariant0ItemVariant0>
-    for AggregateTransformOpsVariant0Item
+impl ::std::convert::From<AggregateTransformOpsArrayItemVariant0>
+    for AggregateTransformOpsArrayItem
 {
-    fn from(value: AggregateTransformOpsVariant0ItemVariant0) -> Self {
+    fn from(value: AggregateTransformOpsArrayItemVariant0) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<SignalRef> for AggregateTransformOpsVariant0Item {
+impl ::std::convert::From<SignalRef> for AggregateTransformOpsArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`AggregateTransformOpsVariant0ItemVariant0`"]
+#[doc = "`AggregateTransformOpsArrayItemVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -843,7 +841,7 @@ impl ::std::convert::From<SignalRef> for AggregateTransformOpsVariant0Item {
     PartialEq,
     PartialOrd,
 )]
-pub enum AggregateTransformOpsVariant0ItemVariant0 {
+pub enum AggregateTransformOpsArrayItemVariant0 {
     #[serde(rename = "values")]
     Values,
     #[serde(rename = "count")]
@@ -893,12 +891,12 @@ pub enum AggregateTransformOpsVariant0ItemVariant0 {
     #[serde(rename = "argmax")]
     Argmax,
 }
-impl ::std::convert::From<&Self> for AggregateTransformOpsVariant0ItemVariant0 {
-    fn from(value: &AggregateTransformOpsVariant0ItemVariant0) -> Self {
+impl ::std::convert::From<&Self> for AggregateTransformOpsArrayItemVariant0 {
+    fn from(value: &AggregateTransformOpsArrayItemVariant0) -> Self {
         value.clone()
     }
 }
-impl ::std::fmt::Display for AggregateTransformOpsVariant0ItemVariant0 {
+impl ::std::fmt::Display for AggregateTransformOpsArrayItemVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
             Self::Values => f.write_str("values"),
@@ -928,7 +926,7 @@ impl ::std::fmt::Display for AggregateTransformOpsVariant0ItemVariant0 {
         }
     }
 }
-impl ::std::str::FromStr for AggregateTransformOpsVariant0ItemVariant0 {
+impl ::std::str::FromStr for AggregateTransformOpsArrayItemVariant0 {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         match value {
@@ -960,13 +958,13 @@ impl ::std::str::FromStr for AggregateTransformOpsVariant0ItemVariant0 {
         }
     }
 }
-impl ::std::convert::TryFrom<&str> for AggregateTransformOpsVariant0ItemVariant0 {
+impl ::std::convert::TryFrom<&str> for AggregateTransformOpsArrayItemVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AggregateTransformOpsVariant0ItemVariant0 {
+impl ::std::convert::TryFrom<&::std::string::String> for AggregateTransformOpsArrayItemVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: &::std::string::String,
@@ -974,7 +972,7 @@ impl ::std::convert::TryFrom<&::std::string::String> for AggregateTransformOpsVa
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<::std::string::String> for AggregateTransformOpsVariant0ItemVariant0 {
+impl ::std::convert::TryFrom<::std::string::String> for AggregateTransformOpsArrayItemVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: ::std::string::String,
@@ -1628,8 +1626,8 @@ impl ::std::convert::TryFrom<::std::string::String>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum AlignValueVariant0ItemVariant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for AlignValueVariant0ItemVariant0Variant3Range {
     fn from(value: &AlignValueVariant0ItemVariant0Variant3Range) -> Self {
@@ -1640,9 +1638,9 @@ impl ::std::str::FromStr for AlignValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -1677,19 +1675,19 @@ impl ::std::convert::TryFrom<::std::string::String>
 impl ::std::fmt::Display for AlignValueVariant0ItemVariant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for AlignValueVariant0ItemVariant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for AlignValueVariant0ItemVariant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`AlignValueVariant0ItemVariant1`"]
@@ -2271,8 +2269,8 @@ impl ::std::convert::TryFrom<::std::string::String> for AlignValueVariant1Varian
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum AlignValueVariant1Variant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for AlignValueVariant1Variant0Variant3Range {
     fn from(value: &AlignValueVariant1Variant0Variant3Range) -> Self {
@@ -2283,9 +2281,9 @@ impl ::std::str::FromStr for AlignValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -2316,19 +2314,19 @@ impl ::std::convert::TryFrom<::std::string::String> for AlignValueVariant1Varian
 impl ::std::fmt::Display for AlignValueVariant1Variant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for AlignValueVariant1Variant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for AlignValueVariant1Variant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`AlignValueVariant1Variant1`"]
@@ -3136,8 +3134,8 @@ impl ::std::convert::TryFrom<::std::string::String>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum AnchorValueVariant0ItemVariant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for AnchorValueVariant0ItemVariant0Variant3Range {
     fn from(value: &AnchorValueVariant0ItemVariant0Variant3Range) -> Self {
@@ -3148,9 +3146,9 @@ impl ::std::str::FromStr for AnchorValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -3185,19 +3183,19 @@ impl ::std::convert::TryFrom<::std::string::String>
 impl ::std::fmt::Display for AnchorValueVariant0ItemVariant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for AnchorValueVariant0ItemVariant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for AnchorValueVariant0ItemVariant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`AnchorValueVariant0ItemVariant1`"]
@@ -3779,8 +3777,8 @@ impl ::std::convert::TryFrom<::std::string::String> for AnchorValueVariant1Varia
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum AnchorValueVariant1Variant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for AnchorValueVariant1Variant0Variant3Range {
     fn from(value: &AnchorValueVariant1Variant0Variant3Range) -> Self {
@@ -3791,9 +3789,9 @@ impl ::std::str::FromStr for AnchorValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -3824,19 +3822,19 @@ impl ::std::convert::TryFrom<::std::string::String> for AnchorValueVariant1Varia
 impl ::std::fmt::Display for AnchorValueVariant1Variant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for AnchorValueVariant1Variant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for AnchorValueVariant1Variant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`AnchorValueVariant1Variant1`"]
@@ -4535,8 +4533,8 @@ impl ::std::convert::From<&Self> for AnyValueVariant0ItemVariant0 {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum AnyValueVariant0ItemVariant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for AnyValueVariant0ItemVariant0Variant3Range {
     fn from(value: &AnyValueVariant0ItemVariant0Variant3Range) -> Self {
@@ -4547,9 +4545,9 @@ impl ::std::str::FromStr for AnyValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -4580,19 +4578,19 @@ impl ::std::convert::TryFrom<::std::string::String> for AnyValueVariant0ItemVari
 impl ::std::fmt::Display for AnyValueVariant0ItemVariant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for AnyValueVariant0ItemVariant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for AnyValueVariant0ItemVariant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`AnyValueVariant0ItemVariant1`"]
@@ -5069,8 +5067,8 @@ impl ::std::convert::From<&Self> for AnyValueVariant1Variant0 {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum AnyValueVariant1Variant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for AnyValueVariant1Variant0Variant3Range {
     fn from(value: &AnyValueVariant1Variant0Variant3Range) -> Self {
@@ -5081,9 +5079,9 @@ impl ::std::str::FromStr for AnyValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -5114,19 +5112,19 @@ impl ::std::convert::TryFrom<::std::string::String> for AnyValueVariant1Variant0
 impl ::std::fmt::Display for AnyValueVariant1Variant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for AnyValueVariant1Variant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for AnyValueVariant1Variant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`AnyValueVariant1Variant1`"]
@@ -5367,8 +5365,8 @@ impl ::std::convert::From<&Self> for AnyValueVariant1Variant2 {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ArrayOrSignal {
-    Variant0(::std::vec::Vec<::serde_json::Value>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<::serde_json::Value>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ArrayOrSignal {
     fn from(value: &ArrayOrSignal) -> Self {
@@ -5377,12 +5375,12 @@ impl ::std::convert::From<&Self> for ArrayOrSignal {
 }
 impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ArrayOrSignal {
     fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ArrayOrSignal {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ArrayValue`"]
@@ -5859,8 +5857,8 @@ impl ::std::convert::From<&Self> for ArrayValueVariant0ItemVariant0 {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ArrayValueVariant0ItemVariant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for ArrayValueVariant0ItemVariant0Variant3Range {
     fn from(value: &ArrayValueVariant0ItemVariant0Variant3Range) -> Self {
@@ -5871,9 +5869,9 @@ impl ::std::str::FromStr for ArrayValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -5908,19 +5906,19 @@ impl ::std::convert::TryFrom<::std::string::String>
 impl ::std::fmt::Display for ArrayValueVariant0ItemVariant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for ArrayValueVariant0ItemVariant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for ArrayValueVariant0ItemVariant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`ArrayValueVariant0ItemVariant1`"]
@@ -6405,8 +6403,8 @@ impl ::std::convert::From<&Self> for ArrayValueVariant1Variant0 {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ArrayValueVariant1Variant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for ArrayValueVariant1Variant0Variant3Range {
     fn from(value: &ArrayValueVariant1Variant0Variant3Range) -> Self {
@@ -6417,9 +6415,9 @@ impl ::std::str::FromStr for ArrayValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -6450,19 +6448,19 @@ impl ::std::convert::TryFrom<::std::string::String> for ArrayValueVariant1Varian
 impl ::std::fmt::Display for ArrayValueVariant1Variant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for ArrayValueVariant1Variant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for ArrayValueVariant1Variant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`ArrayValueVariant1Variant1`"]
@@ -8389,9 +8387,9 @@ impl ::std::convert::From<StringValue> for AxisDomainCap {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum AxisDomainColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for AxisDomainColor {
     fn from(value: &AxisDomainColor) -> Self {
@@ -8400,7 +8398,7 @@ impl ::std::convert::From<&Self> for AxisDomainColor {
 }
 impl ::std::convert::From<ColorValue> for AxisDomainColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`AxisDomainDash`"]
@@ -8678,8 +8676,8 @@ impl ::std::default::Default for AxisEncode {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum AxisFormat {
-    Variant0(::std::string::String),
-    Variant1 {
+    String(::std::string::String),
+    Object {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         date: ::std::option::Option<::std::string::String>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -8701,7 +8699,7 @@ pub enum AxisFormat {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         year: ::std::option::Option<::std::string::String>,
     },
-    Variant2(SignalRef),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for AxisFormat {
     fn from(value: &AxisFormat) -> Self {
@@ -8710,7 +8708,7 @@ impl ::std::convert::From<&Self> for AxisFormat {
 }
 impl ::std::convert::From<SignalRef> for AxisFormat {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`AxisFormatType`"]
@@ -8892,9 +8890,9 @@ impl ::std::convert::From<StringValue> for AxisGridCap {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum AxisGridColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for AxisGridColor {
     fn from(value: &AxisGridColor) -> Self {
@@ -8903,7 +8901,7 @@ impl ::std::convert::From<&Self> for AxisGridColor {
 }
 impl ::std::convert::From<ColorValue> for AxisGridColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`AxisGridDash`"]
@@ -9386,9 +9384,9 @@ impl ::std::convert::TryFrom<::std::string::String> for AxisLabelBaselineVariant
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum AxisLabelBound {
-    Variant0(bool),
-    Variant1(f64),
-    Variant2(SignalRef),
+    Boolean(bool),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for AxisLabelBound {
     fn from(value: &AxisLabelBound) -> Self {
@@ -9397,17 +9395,17 @@ impl ::std::convert::From<&Self> for AxisLabelBound {
 }
 impl ::std::convert::From<bool> for AxisLabelBound {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<f64> for AxisLabelBound {
     fn from(value: f64) -> Self {
-        Self::Variant1(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for AxisLabelBound {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`AxisLabelColor`"]
@@ -9433,9 +9431,9 @@ impl ::std::convert::From<SignalRef> for AxisLabelBound {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum AxisLabelColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for AxisLabelColor {
     fn from(value: &AxisLabelColor) -> Self {
@@ -9444,7 +9442,7 @@ impl ::std::convert::From<&Self> for AxisLabelColor {
 }
 impl ::std::convert::From<ColorValue> for AxisLabelColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`AxisLabelFlush`"]
@@ -9470,9 +9468,9 @@ impl ::std::convert::From<ColorValue> for AxisLabelColor {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum AxisLabelFlush {
-    Variant0(bool),
-    Variant1(f64),
-    Variant2(SignalRef),
+    Boolean(bool),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for AxisLabelFlush {
     fn from(value: &AxisLabelFlush) -> Self {
@@ -9481,17 +9479,17 @@ impl ::std::convert::From<&Self> for AxisLabelFlush {
 }
 impl ::std::convert::From<bool> for AxisLabelFlush {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<f64> for AxisLabelFlush {
     fn from(value: f64) -> Self {
-        Self::Variant1(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for AxisLabelFlush {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`AxisLabelFont`"]
@@ -10187,9 +10185,9 @@ impl ::std::convert::From<StringValue> for AxisTickCap {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum AxisTickColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for AxisTickColor {
     fn from(value: &AxisTickColor) -> Self {
@@ -10198,7 +10196,7 @@ impl ::std::convert::From<&Self> for AxisTickColor {
 }
 impl ::std::convert::From<ColorValue> for AxisTickColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`AxisTickDash`"]
@@ -10920,9 +10918,9 @@ impl ::std::convert::TryFrom<::std::string::String> for AxisTitleBaselineVariant
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum AxisTitleColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for AxisTitleColor {
     fn from(value: &AxisTitleColor) -> Self {
@@ -10931,7 +10929,7 @@ impl ::std::convert::From<&Self> for AxisTitleColor {
 }
 impl ::std::convert::From<ColorValue> for AxisTitleColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`AxisTitleFont`"]
@@ -11877,8 +11875,8 @@ impl ::std::convert::From<&Self> for BaseColorValueVariant0Variant0 {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum BaseColorValueVariant0Variant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for BaseColorValueVariant0Variant0Variant3Range {
     fn from(value: &BaseColorValueVariant0Variant0Variant3Range) -> Self {
@@ -11889,9 +11887,9 @@ impl ::std::str::FromStr for BaseColorValueVariant0Variant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -11926,19 +11924,19 @@ impl ::std::convert::TryFrom<::std::string::String>
 impl ::std::fmt::Display for BaseColorValueVariant0Variant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for BaseColorValueVariant0Variant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for BaseColorValueVariant0Variant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`BaseColorValueVariant0Variant1`"]
@@ -12817,8 +12815,8 @@ impl ::std::convert::TryFrom<::std::string::String>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum BaselineValueVariant0ItemVariant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for BaselineValueVariant0ItemVariant0Variant3Range {
     fn from(value: &BaselineValueVariant0ItemVariant0Variant3Range) -> Self {
@@ -12829,9 +12827,9 @@ impl ::std::str::FromStr for BaselineValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -12866,19 +12864,19 @@ impl ::std::convert::TryFrom<::std::string::String>
 impl ::std::fmt::Display for BaselineValueVariant0ItemVariant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for BaselineValueVariant0ItemVariant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for BaselineValueVariant0ItemVariant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`BaselineValueVariant0ItemVariant1`"]
@@ -13471,8 +13469,8 @@ impl ::std::convert::TryFrom<::std::string::String> for BaselineValueVariant1Var
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum BaselineValueVariant1Variant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for BaselineValueVariant1Variant0Variant3Range {
     fn from(value: &BaselineValueVariant1Variant0Variant3Range) -> Self {
@@ -13483,9 +13481,9 @@ impl ::std::str::FromStr for BaselineValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -13518,19 +13516,19 @@ impl ::std::convert::TryFrom<::std::string::String> for BaselineValueVariant1Var
 impl ::std::fmt::Display for BaselineValueVariant1Variant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for BaselineValueVariant1Variant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for BaselineValueVariant1Variant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`BaselineValueVariant1Variant1`"]
@@ -14049,8 +14047,8 @@ impl ::std::convert::From<&BinTransform> for BinTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum BinTransformAnchor {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for BinTransformAnchor {
     fn from(value: &BinTransformAnchor) -> Self {
@@ -14059,12 +14057,12 @@ impl ::std::convert::From<&Self> for BinTransformAnchor {
 }
 impl ::std::convert::From<f64> for BinTransformAnchor {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for BinTransformAnchor {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`BinTransformAs`"]
@@ -14103,8 +14101,8 @@ impl ::std::convert::From<SignalRef> for BinTransformAnchor {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum BinTransformAs {
-    Variant0([BinTransformAsVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([BinTransformAsArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for BinTransformAs {
     fn from(value: &BinTransformAs) -> Self {
@@ -14113,23 +14111,23 @@ impl ::std::convert::From<&Self> for BinTransformAs {
 }
 impl ::std::default::Default for BinTransformAs {
     fn default() -> Self {
-        BinTransformAs::Variant0([
-            BinTransformAsVariant0Item::Variant0("bin0".to_string()),
-            BinTransformAsVariant0Item::Variant0("bin1".to_string()),
+        BinTransformAs::Array([
+            BinTransformAsArrayItem::String("bin0".to_string()),
+            BinTransformAsArrayItem::String("bin1".to_string()),
         ])
     }
 }
-impl ::std::convert::From<[BinTransformAsVariant0Item; 2usize]> for BinTransformAs {
-    fn from(value: [BinTransformAsVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[BinTransformAsArrayItem; 2usize]> for BinTransformAs {
+    fn from(value: [BinTransformAsArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for BinTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`BinTransformAsVariant0Item`"]
+#[doc = "`BinTransformAsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14148,18 +14146,18 @@ impl ::std::convert::From<SignalRef> for BinTransformAs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum BinTransformAsVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum BinTransformAsArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for BinTransformAsVariant0Item {
-    fn from(value: &BinTransformAsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for BinTransformAsArrayItem {
+    fn from(value: &BinTransformAsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for BinTransformAsVariant0Item {
+impl ::std::convert::From<SignalRef> for BinTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`BinTransformBase`"]
@@ -14183,8 +14181,8 @@ impl ::std::convert::From<SignalRef> for BinTransformAsVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum BinTransformBase {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for BinTransformBase {
     fn from(value: &BinTransformBase) -> Self {
@@ -14193,17 +14191,17 @@ impl ::std::convert::From<&Self> for BinTransformBase {
 }
 impl ::std::default::Default for BinTransformBase {
     fn default() -> Self {
-        BinTransformBase::Variant0(10_f64)
+        BinTransformBase::Number(10_f64)
     }
 }
 impl ::std::convert::From<f64> for BinTransformBase {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for BinTransformBase {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`BinTransformDivide`"]
@@ -14240,8 +14238,8 @@ impl ::std::convert::From<SignalRef> for BinTransformBase {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum BinTransformDivide {
-    Variant0(::std::vec::Vec<BinTransformDivideVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<BinTransformDivideArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for BinTransformDivide {
     fn from(value: &BinTransformDivide) -> Self {
@@ -14250,23 +14248,23 @@ impl ::std::convert::From<&Self> for BinTransformDivide {
 }
 impl ::std::default::Default for BinTransformDivide {
     fn default() -> Self {
-        BinTransformDivide::Variant0(vec![
-            BinTransformDivideVariant0Item::Variant0(5_f64),
-            BinTransformDivideVariant0Item::Variant0(2_f64),
+        BinTransformDivide::Array(vec![
+            BinTransformDivideArrayItem::Number(5_f64),
+            BinTransformDivideArrayItem::Number(2_f64),
         ])
     }
 }
-impl ::std::convert::From<::std::vec::Vec<BinTransformDivideVariant0Item>> for BinTransformDivide {
-    fn from(value: ::std::vec::Vec<BinTransformDivideVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<BinTransformDivideArrayItem>> for BinTransformDivide {
+    fn from(value: ::std::vec::Vec<BinTransformDivideArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for BinTransformDivide {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`BinTransformDivideVariant0Item`"]
+#[doc = "`BinTransformDivideArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14285,23 +14283,23 @@ impl ::std::convert::From<SignalRef> for BinTransformDivide {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum BinTransformDivideVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum BinTransformDivideArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for BinTransformDivideVariant0Item {
-    fn from(value: &BinTransformDivideVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for BinTransformDivideArrayItem {
+    fn from(value: &BinTransformDivideArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for BinTransformDivideVariant0Item {
+impl ::std::convert::From<f64> for BinTransformDivideArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for BinTransformDivideVariant0Item {
+impl ::std::convert::From<SignalRef> for BinTransformDivideArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`BinTransformExtent`"]
@@ -14336,25 +14334,25 @@ impl ::std::convert::From<SignalRef> for BinTransformDivideVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum BinTransformExtent {
-    Variant0([BinTransformExtentVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([BinTransformExtentArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for BinTransformExtent {
     fn from(value: &BinTransformExtent) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<[BinTransformExtentVariant0Item; 2usize]> for BinTransformExtent {
-    fn from(value: [BinTransformExtentVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[BinTransformExtentArrayItem; 2usize]> for BinTransformExtent {
+    fn from(value: [BinTransformExtentArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for BinTransformExtent {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`BinTransformExtentVariant0Item`"]
+#[doc = "`BinTransformExtentArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14373,23 +14371,23 @@ impl ::std::convert::From<SignalRef> for BinTransformExtent {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum BinTransformExtentVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum BinTransformExtentArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for BinTransformExtentVariant0Item {
-    fn from(value: &BinTransformExtentVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for BinTransformExtentArrayItem {
+    fn from(value: &BinTransformExtentArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for BinTransformExtentVariant0Item {
+impl ::std::convert::From<f64> for BinTransformExtentArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for BinTransformExtentVariant0Item {
+impl ::std::convert::From<SignalRef> for BinTransformExtentArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`BinTransformField`"]
@@ -14460,8 +14458,8 @@ impl ::std::convert::From<Expr> for BinTransformField {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum BinTransformInterval {
-    Variant0(bool),
-    Variant1(SignalRef),
+    Boolean(bool),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for BinTransformInterval {
     fn from(value: &BinTransformInterval) -> Self {
@@ -14470,17 +14468,17 @@ impl ::std::convert::From<&Self> for BinTransformInterval {
 }
 impl ::std::default::Default for BinTransformInterval {
     fn default() -> Self {
-        BinTransformInterval::Variant0(true)
+        BinTransformInterval::Boolean(true)
     }
 }
 impl ::std::convert::From<bool> for BinTransformInterval {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<SignalRef> for BinTransformInterval {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`BinTransformMaxbins`"]
@@ -14504,8 +14502,8 @@ impl ::std::convert::From<SignalRef> for BinTransformInterval {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum BinTransformMaxbins {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for BinTransformMaxbins {
     fn from(value: &BinTransformMaxbins) -> Self {
@@ -14514,17 +14512,17 @@ impl ::std::convert::From<&Self> for BinTransformMaxbins {
 }
 impl ::std::default::Default for BinTransformMaxbins {
     fn default() -> Self {
-        BinTransformMaxbins::Variant0(20_f64)
+        BinTransformMaxbins::Number(20_f64)
     }
 }
 impl ::std::convert::From<f64> for BinTransformMaxbins {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for BinTransformMaxbins {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`BinTransformMinstep`"]
@@ -14547,8 +14545,8 @@ impl ::std::convert::From<SignalRef> for BinTransformMaxbins {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum BinTransformMinstep {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for BinTransformMinstep {
     fn from(value: &BinTransformMinstep) -> Self {
@@ -14557,12 +14555,12 @@ impl ::std::convert::From<&Self> for BinTransformMinstep {
 }
 impl ::std::convert::From<f64> for BinTransformMinstep {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for BinTransformMinstep {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`BinTransformName`"]
@@ -14585,8 +14583,8 @@ impl ::std::convert::From<SignalRef> for BinTransformMinstep {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum BinTransformName {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for BinTransformName {
     fn from(value: &BinTransformName) -> Self {
@@ -14595,7 +14593,7 @@ impl ::std::convert::From<&Self> for BinTransformName {
 }
 impl ::std::convert::From<SignalRef> for BinTransformName {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`BinTransformNice`"]
@@ -14619,8 +14617,8 @@ impl ::std::convert::From<SignalRef> for BinTransformName {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum BinTransformNice {
-    Variant0(bool),
-    Variant1(SignalRef),
+    Boolean(bool),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for BinTransformNice {
     fn from(value: &BinTransformNice) -> Self {
@@ -14629,17 +14627,17 @@ impl ::std::convert::From<&Self> for BinTransformNice {
 }
 impl ::std::default::Default for BinTransformNice {
     fn default() -> Self {
-        BinTransformNice::Variant0(true)
+        BinTransformNice::Boolean(true)
     }
 }
 impl ::std::convert::From<bool> for BinTransformNice {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<SignalRef> for BinTransformNice {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`BinTransformSpan`"]
@@ -14662,8 +14660,8 @@ impl ::std::convert::From<SignalRef> for BinTransformNice {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum BinTransformSpan {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for BinTransformSpan {
     fn from(value: &BinTransformSpan) -> Self {
@@ -14672,12 +14670,12 @@ impl ::std::convert::From<&Self> for BinTransformSpan {
 }
 impl ::std::convert::From<f64> for BinTransformSpan {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for BinTransformSpan {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`BinTransformStep`"]
@@ -14700,8 +14698,8 @@ impl ::std::convert::From<SignalRef> for BinTransformSpan {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum BinTransformStep {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for BinTransformStep {
     fn from(value: &BinTransformStep) -> Self {
@@ -14710,12 +14708,12 @@ impl ::std::convert::From<&Self> for BinTransformStep {
 }
 impl ::std::convert::From<f64> for BinTransformStep {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for BinTransformStep {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`BinTransformSteps`"]
@@ -14748,25 +14746,25 @@ impl ::std::convert::From<SignalRef> for BinTransformStep {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum BinTransformSteps {
-    Variant0(::std::vec::Vec<BinTransformStepsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<BinTransformStepsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for BinTransformSteps {
     fn from(value: &BinTransformSteps) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<BinTransformStepsVariant0Item>> for BinTransformSteps {
-    fn from(value: ::std::vec::Vec<BinTransformStepsVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<BinTransformStepsArrayItem>> for BinTransformSteps {
+    fn from(value: ::std::vec::Vec<BinTransformStepsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for BinTransformSteps {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`BinTransformStepsVariant0Item`"]
+#[doc = "`BinTransformStepsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -14785,23 +14783,23 @@ impl ::std::convert::From<SignalRef> for BinTransformSteps {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum BinTransformStepsVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum BinTransformStepsArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for BinTransformStepsVariant0Item {
-    fn from(value: &BinTransformStepsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for BinTransformStepsArrayItem {
+    fn from(value: &BinTransformStepsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for BinTransformStepsVariant0Item {
+impl ::std::convert::From<f64> for BinTransformStepsArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for BinTransformStepsVariant0Item {
+impl ::std::convert::From<SignalRef> for BinTransformStepsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`BinTransformType`"]
@@ -16052,8 +16050,8 @@ impl ::std::convert::TryFrom<::std::string::String>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum BlendValueVariant0ItemVariant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for BlendValueVariant0ItemVariant0Variant3Range {
     fn from(value: &BlendValueVariant0ItemVariant0Variant3Range) -> Self {
@@ -16064,9 +16062,9 @@ impl ::std::str::FromStr for BlendValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -16101,19 +16099,19 @@ impl ::std::convert::TryFrom<::std::string::String>
 impl ::std::fmt::Display for BlendValueVariant0ItemVariant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for BlendValueVariant0ItemVariant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for BlendValueVariant0ItemVariant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`BlendValueVariant0ItemVariant1`"]
@@ -16808,8 +16806,8 @@ impl ::std::convert::TryFrom<::std::string::String> for BlendValueVariant1Varian
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum BlendValueVariant1Variant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for BlendValueVariant1Variant0Variant3Range {
     fn from(value: &BlendValueVariant1Variant0Variant3Range) -> Self {
@@ -16820,9 +16818,9 @@ impl ::std::str::FromStr for BlendValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -16853,19 +16851,19 @@ impl ::std::convert::TryFrom<::std::string::String> for BlendValueVariant1Varian
 impl ::std::fmt::Display for BlendValueVariant1Variant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for BlendValueVariant1Variant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for BlendValueVariant1Variant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`BlendValueVariant1Variant1`"]
@@ -17144,8 +17142,8 @@ impl ::std::convert::From<&Self> for BlendValueVariant1Variant2 {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum BooleanOrSignal {
-    Variant0(bool),
-    Variant1(SignalRef),
+    Boolean(bool),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for BooleanOrSignal {
     fn from(value: &BooleanOrSignal) -> Self {
@@ -17154,12 +17152,12 @@ impl ::std::convert::From<&Self> for BooleanOrSignal {
 }
 impl ::std::convert::From<bool> for BooleanOrSignal {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<SignalRef> for BooleanOrSignal {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`BooleanValue`"]
@@ -17636,8 +17634,8 @@ impl ::std::convert::From<&Self> for BooleanValueVariant0ItemVariant0 {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum BooleanValueVariant0ItemVariant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for BooleanValueVariant0ItemVariant0Variant3Range {
     fn from(value: &BooleanValueVariant0ItemVariant0Variant3Range) -> Self {
@@ -17648,9 +17646,9 @@ impl ::std::str::FromStr for BooleanValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -17685,19 +17683,19 @@ impl ::std::convert::TryFrom<::std::string::String>
 impl ::std::fmt::Display for BooleanValueVariant0ItemVariant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for BooleanValueVariant0ItemVariant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for BooleanValueVariant0ItemVariant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`BooleanValueVariant0ItemVariant1`"]
@@ -18182,8 +18180,8 @@ impl ::std::convert::From<&Self> for BooleanValueVariant1Variant0 {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum BooleanValueVariant1Variant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for BooleanValueVariant1Variant0Variant3Range {
     fn from(value: &BooleanValueVariant1Variant0Variant3Range) -> Self {
@@ -18194,9 +18192,9 @@ impl ::std::str::FromStr for BooleanValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -18227,19 +18225,19 @@ impl ::std::convert::TryFrom<::std::string::String> for BooleanValueVariant1Vari
 impl ::std::fmt::Display for BooleanValueVariant1Variant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for BooleanValueVariant1Variant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for BooleanValueVariant1Variant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`BooleanValueVariant1Variant1`"]
@@ -19112,8 +19110,8 @@ impl ::std::convert::From<&ContourTransform> for ContourTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ContourTransformBandwidth {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ContourTransformBandwidth {
     fn from(value: &ContourTransformBandwidth) -> Self {
@@ -19122,12 +19120,12 @@ impl ::std::convert::From<&Self> for ContourTransformBandwidth {
 }
 impl ::std::convert::From<f64> for ContourTransformBandwidth {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ContourTransformBandwidth {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ContourTransformCellSize`"]
@@ -19150,8 +19148,8 @@ impl ::std::convert::From<SignalRef> for ContourTransformBandwidth {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ContourTransformCellSize {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ContourTransformCellSize {
     fn from(value: &ContourTransformCellSize) -> Self {
@@ -19160,12 +19158,12 @@ impl ::std::convert::From<&Self> for ContourTransformCellSize {
 }
 impl ::std::convert::From<f64> for ContourTransformCellSize {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ContourTransformCellSize {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ContourTransformCount`"]
@@ -19188,8 +19186,8 @@ impl ::std::convert::From<SignalRef> for ContourTransformCellSize {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ContourTransformCount {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ContourTransformCount {
     fn from(value: &ContourTransformCount) -> Self {
@@ -19198,12 +19196,12 @@ impl ::std::convert::From<&Self> for ContourTransformCount {
 }
 impl ::std::convert::From<f64> for ContourTransformCount {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ContourTransformCount {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ContourTransformNice`"]
@@ -19226,8 +19224,8 @@ impl ::std::convert::From<SignalRef> for ContourTransformCount {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ContourTransformNice {
-    Variant0(bool),
-    Variant1(SignalRef),
+    Boolean(bool),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ContourTransformNice {
     fn from(value: &ContourTransformNice) -> Self {
@@ -19236,12 +19234,12 @@ impl ::std::convert::From<&Self> for ContourTransformNice {
 }
 impl ::std::convert::From<bool> for ContourTransformNice {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ContourTransformNice {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ContourTransformSize`"]
@@ -19276,25 +19274,25 @@ impl ::std::convert::From<SignalRef> for ContourTransformNice {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ContourTransformSize {
-    Variant0([ContourTransformSizeVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([ContourTransformSizeArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ContourTransformSize {
     fn from(value: &ContourTransformSize) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<[ContourTransformSizeVariant0Item; 2usize]> for ContourTransformSize {
-    fn from(value: [ContourTransformSizeVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[ContourTransformSizeArrayItem; 2usize]> for ContourTransformSize {
+    fn from(value: [ContourTransformSizeArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ContourTransformSize {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ContourTransformSizeVariant0Item`"]
+#[doc = "`ContourTransformSizeArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19313,23 +19311,23 @@ impl ::std::convert::From<SignalRef> for ContourTransformSize {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ContourTransformSizeVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum ContourTransformSizeArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ContourTransformSizeVariant0Item {
-    fn from(value: &ContourTransformSizeVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for ContourTransformSizeArrayItem {
+    fn from(value: &ContourTransformSizeArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for ContourTransformSizeVariant0Item {
+impl ::std::convert::From<f64> for ContourTransformSizeArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for ContourTransformSizeVariant0Item {
+impl ::std::convert::From<SignalRef> for ContourTransformSizeArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ContourTransformSmooth`"]
@@ -19353,8 +19351,8 @@ impl ::std::convert::From<SignalRef> for ContourTransformSizeVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ContourTransformSmooth {
-    Variant0(bool),
-    Variant1(SignalRef),
+    Boolean(bool),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ContourTransformSmooth {
     fn from(value: &ContourTransformSmooth) -> Self {
@@ -19363,17 +19361,17 @@ impl ::std::convert::From<&Self> for ContourTransformSmooth {
 }
 impl ::std::default::Default for ContourTransformSmooth {
     fn default() -> Self {
-        ContourTransformSmooth::Variant0(true)
+        ContourTransformSmooth::Boolean(true)
     }
 }
 impl ::std::convert::From<bool> for ContourTransformSmooth {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ContourTransformSmooth {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ContourTransformThresholds`"]
@@ -19406,27 +19404,27 @@ impl ::std::convert::From<SignalRef> for ContourTransformSmooth {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ContourTransformThresholds {
-    Variant0(::std::vec::Vec<ContourTransformThresholdsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<ContourTransformThresholdsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ContourTransformThresholds {
     fn from(value: &ContourTransformThresholds) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ContourTransformThresholdsVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<ContourTransformThresholdsArrayItem>>
     for ContourTransformThresholds
 {
-    fn from(value: ::std::vec::Vec<ContourTransformThresholdsVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<ContourTransformThresholdsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ContourTransformThresholds {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ContourTransformThresholdsVariant0Item`"]
+#[doc = "`ContourTransformThresholdsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19445,23 +19443,23 @@ impl ::std::convert::From<SignalRef> for ContourTransformThresholds {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ContourTransformThresholdsVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum ContourTransformThresholdsArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ContourTransformThresholdsVariant0Item {
-    fn from(value: &ContourTransformThresholdsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for ContourTransformThresholdsArrayItem {
+    fn from(value: &ContourTransformThresholdsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for ContourTransformThresholdsVariant0Item {
+impl ::std::convert::From<f64> for ContourTransformThresholdsArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for ContourTransformThresholdsVariant0Item {
+impl ::std::convert::From<SignalRef> for ContourTransformThresholdsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ContourTransformType`"]
@@ -19565,27 +19563,27 @@ impl ::std::convert::TryFrom<::std::string::String> for ContourTransformType {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ContourTransformValues {
-    Variant0(::std::vec::Vec<ContourTransformValuesVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<ContourTransformValuesArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ContourTransformValues {
     fn from(value: &ContourTransformValues) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ContourTransformValuesVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<ContourTransformValuesArrayItem>>
     for ContourTransformValues
 {
-    fn from(value: ::std::vec::Vec<ContourTransformValuesVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<ContourTransformValuesArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ContourTransformValues {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ContourTransformValuesVariant0Item`"]
+#[doc = "`ContourTransformValuesArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19604,23 +19602,23 @@ impl ::std::convert::From<SignalRef> for ContourTransformValues {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ContourTransformValuesVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum ContourTransformValuesArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ContourTransformValuesVariant0Item {
-    fn from(value: &ContourTransformValuesVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for ContourTransformValuesArrayItem {
+    fn from(value: &ContourTransformValuesArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for ContourTransformValuesVariant0Item {
+impl ::std::convert::From<f64> for ContourTransformValuesArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for ContourTransformValuesVariant0Item {
+impl ::std::convert::From<SignalRef> for ContourTransformValuesArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ContourTransformWeight`"]
@@ -19922,8 +19920,8 @@ impl ::std::convert::From<&CountpatternTransform> for CountpatternTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum CountpatternTransformAs {
-    Variant0([CountpatternTransformAsVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([CountpatternTransformAsArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for CountpatternTransformAs {
     fn from(value: &CountpatternTransformAs) -> Self {
@@ -19932,25 +19930,23 @@ impl ::std::convert::From<&Self> for CountpatternTransformAs {
 }
 impl ::std::default::Default for CountpatternTransformAs {
     fn default() -> Self {
-        CountpatternTransformAs::Variant0([
-            CountpatternTransformAsVariant0Item::Variant0("text".to_string()),
-            CountpatternTransformAsVariant0Item::Variant0("count".to_string()),
+        CountpatternTransformAs::Array([
+            CountpatternTransformAsArrayItem::String("text".to_string()),
+            CountpatternTransformAsArrayItem::String("count".to_string()),
         ])
     }
 }
-impl ::std::convert::From<[CountpatternTransformAsVariant0Item; 2usize]>
-    for CountpatternTransformAs
-{
-    fn from(value: [CountpatternTransformAsVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[CountpatternTransformAsArrayItem; 2usize]> for CountpatternTransformAs {
+    fn from(value: [CountpatternTransformAsArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for CountpatternTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`CountpatternTransformAsVariant0Item`"]
+#[doc = "`CountpatternTransformAsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -19969,18 +19965,18 @@ impl ::std::convert::From<SignalRef> for CountpatternTransformAs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum CountpatternTransformAsVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum CountpatternTransformAsArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for CountpatternTransformAsVariant0Item {
-    fn from(value: &CountpatternTransformAsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for CountpatternTransformAsArrayItem {
+    fn from(value: &CountpatternTransformAsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for CountpatternTransformAsVariant0Item {
+impl ::std::convert::From<SignalRef> for CountpatternTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`CountpatternTransformCase`"]
@@ -20180,8 +20176,8 @@ impl ::std::convert::From<Expr> for CountpatternTransformField {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum CountpatternTransformPattern {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for CountpatternTransformPattern {
     fn from(value: &CountpatternTransformPattern) -> Self {
@@ -20190,12 +20186,12 @@ impl ::std::convert::From<&Self> for CountpatternTransformPattern {
 }
 impl ::std::default::Default for CountpatternTransformPattern {
     fn default() -> Self {
-        CountpatternTransformPattern::Variant0("[\\w\"]+".to_string())
+        CountpatternTransformPattern::String("[\\w\"]+".to_string())
     }
 }
 impl ::std::convert::From<SignalRef> for CountpatternTransformPattern {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`CountpatternTransformStopwords`"]
@@ -20218,8 +20214,8 @@ impl ::std::convert::From<SignalRef> for CountpatternTransformPattern {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum CountpatternTransformStopwords {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for CountpatternTransformStopwords {
     fn from(value: &CountpatternTransformStopwords) -> Self {
@@ -20228,7 +20224,7 @@ impl ::std::convert::From<&Self> for CountpatternTransformStopwords {
 }
 impl ::std::convert::From<SignalRef> for CountpatternTransformStopwords {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`CountpatternTransformType`"]
@@ -20408,8 +20404,8 @@ impl ::std::convert::From<&CrossTransform> for CrossTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum CrossTransformAs {
-    Variant0([CrossTransformAsVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([CrossTransformAsArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for CrossTransformAs {
     fn from(value: &CrossTransformAs) -> Self {
@@ -20418,23 +20414,23 @@ impl ::std::convert::From<&Self> for CrossTransformAs {
 }
 impl ::std::default::Default for CrossTransformAs {
     fn default() -> Self {
-        CrossTransformAs::Variant0([
-            CrossTransformAsVariant0Item::Variant0("a".to_string()),
-            CrossTransformAsVariant0Item::Variant0("b".to_string()),
+        CrossTransformAs::Array([
+            CrossTransformAsArrayItem::String("a".to_string()),
+            CrossTransformAsArrayItem::String("b".to_string()),
         ])
     }
 }
-impl ::std::convert::From<[CrossTransformAsVariant0Item; 2usize]> for CrossTransformAs {
-    fn from(value: [CrossTransformAsVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[CrossTransformAsArrayItem; 2usize]> for CrossTransformAs {
+    fn from(value: [CrossTransformAsArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for CrossTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`CrossTransformAsVariant0Item`"]
+#[doc = "`CrossTransformAsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20453,18 +20449,18 @@ impl ::std::convert::From<SignalRef> for CrossTransformAs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum CrossTransformAsVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum CrossTransformAsArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for CrossTransformAsVariant0Item {
-    fn from(value: &CrossTransformAsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for CrossTransformAsArrayItem {
+    fn from(value: &CrossTransformAsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for CrossTransformAsVariant0Item {
+impl ::std::convert::From<SignalRef> for CrossTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`CrossTransformType`"]
@@ -20646,27 +20642,27 @@ impl ::std::convert::From<&CrossfilterTransform> for CrossfilterTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum CrossfilterTransformFields {
-    Variant0(::std::vec::Vec<CrossfilterTransformFieldsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<CrossfilterTransformFieldsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for CrossfilterTransformFields {
     fn from(value: &CrossfilterTransformFields) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<CrossfilterTransformFieldsVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<CrossfilterTransformFieldsArrayItem>>
     for CrossfilterTransformFields
 {
-    fn from(value: ::std::vec::Vec<CrossfilterTransformFieldsVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<CrossfilterTransformFieldsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for CrossfilterTransformFields {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`CrossfilterTransformFieldsVariant0Item`"]
+#[doc = "`CrossfilterTransformFieldsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -20688,27 +20684,27 @@ impl ::std::convert::From<SignalRef> for CrossfilterTransformFields {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum CrossfilterTransformFieldsVariant0Item {
+pub enum CrossfilterTransformFieldsArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for CrossfilterTransformFieldsVariant0Item {
-    fn from(value: &CrossfilterTransformFieldsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for CrossfilterTransformFieldsArrayItem {
+    fn from(value: &CrossfilterTransformFieldsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<ScaleField> for CrossfilterTransformFieldsVariant0Item {
+impl ::std::convert::From<ScaleField> for CrossfilterTransformFieldsArrayItem {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
     }
 }
-impl ::std::convert::From<ParamField> for CrossfilterTransformFieldsVariant0Item {
+impl ::std::convert::From<ParamField> for CrossfilterTransformFieldsArrayItem {
     fn from(value: ParamField) -> Self {
         Self::ParamField(value)
     }
 }
-impl ::std::convert::From<Expr> for CrossfilterTransformFieldsVariant0Item {
+impl ::std::convert::From<Expr> for CrossfilterTransformFieldsArrayItem {
     fn from(value: Expr) -> Self {
         Self::Expr(value)
     }
@@ -20734,8 +20730,8 @@ impl ::std::convert::From<Expr> for CrossfilterTransformFieldsVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum CrossfilterTransformQuery {
-    Variant0(::std::vec::Vec<::serde_json::Value>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<::serde_json::Value>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for CrossfilterTransformQuery {
     fn from(value: &CrossfilterTransformQuery) -> Self {
@@ -20744,12 +20740,12 @@ impl ::std::convert::From<&Self> for CrossfilterTransformQuery {
 }
 impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for CrossfilterTransformQuery {
     fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for CrossfilterTransformQuery {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`CrossfilterTransformType`"]
@@ -21548,8 +21544,8 @@ impl ::std::convert::From<&Self> for Data {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum DataVariant1Source {
-    Variant0(::std::string::String),
-    Variant1(::std::vec::Vec<::std::string::String>),
+    String(::std::string::String),
+    Array(::std::vec::Vec<::std::string::String>),
 }
 impl ::std::convert::From<&Self> for DataVariant1Source {
     fn from(value: &DataVariant1Source) -> Self {
@@ -21558,7 +21554,7 @@ impl ::std::convert::From<&Self> for DataVariant1Source {
 }
 impl ::std::convert::From<::std::vec::Vec<::std::string::String>> for DataVariant1Source {
     fn from(value: ::std::vec::Vec<::std::string::String>) -> Self {
-        Self::Variant1(value)
+        Self::Array(value)
     }
 }
 #[doc = "`DataVariant2Format`"]
@@ -27746,8 +27742,8 @@ impl ::std::convert::From<&DensityTransform> for DensityTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum DensityTransformAs {
-    Variant0(::std::vec::Vec<DensityTransformAsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<DensityTransformAsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for DensityTransformAs {
     fn from(value: &DensityTransformAs) -> Self {
@@ -27756,23 +27752,23 @@ impl ::std::convert::From<&Self> for DensityTransformAs {
 }
 impl ::std::default::Default for DensityTransformAs {
     fn default() -> Self {
-        DensityTransformAs::Variant0(vec![
-            DensityTransformAsVariant0Item::Variant0("value".to_string()),
-            DensityTransformAsVariant0Item::Variant0("density".to_string()),
+        DensityTransformAs::Array(vec![
+            DensityTransformAsArrayItem::String("value".to_string()),
+            DensityTransformAsArrayItem::String("density".to_string()),
         ])
     }
 }
-impl ::std::convert::From<::std::vec::Vec<DensityTransformAsVariant0Item>> for DensityTransformAs {
-    fn from(value: ::std::vec::Vec<DensityTransformAsVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<DensityTransformAsArrayItem>> for DensityTransformAs {
+    fn from(value: ::std::vec::Vec<DensityTransformAsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for DensityTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`DensityTransformAsVariant0Item`"]
+#[doc = "`DensityTransformAsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -27791,18 +27787,18 @@ impl ::std::convert::From<SignalRef> for DensityTransformAs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum DensityTransformAsVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum DensityTransformAsArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for DensityTransformAsVariant0Item {
-    fn from(value: &DensityTransformAsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for DensityTransformAsArrayItem {
+    fn from(value: &DensityTransformAsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for DensityTransformAsVariant0Item {
+impl ::std::convert::From<SignalRef> for DensityTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`DensityTransformDistribution`"]
@@ -28072,8 +28068,8 @@ impl ::std::convert::From<&Self> for DensityTransformDistribution {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionBandwidth {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for DensityTransformDistributionBandwidth {
     fn from(value: &DensityTransformDistributionBandwidth) -> Self {
@@ -28082,12 +28078,12 @@ impl ::std::convert::From<&Self> for DensityTransformDistributionBandwidth {
 }
 impl ::std::convert::From<f64> for DensityTransformDistributionBandwidth {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for DensityTransformDistributionBandwidth {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`DensityTransformDistributionDistributions`"]
@@ -28111,8 +28107,8 @@ impl ::std::convert::From<SignalRef> for DensityTransformDistributionBandwidth {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionDistributions {
-    Variant0(::std::vec::Vec<::serde_json::Value>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<::serde_json::Value>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for DensityTransformDistributionDistributions {
     fn from(value: &DensityTransformDistributionDistributions) -> Self {
@@ -28123,12 +28119,12 @@ impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>>
     for DensityTransformDistributionDistributions
 {
     fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for DensityTransformDistributionDistributions {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`DensityTransformDistributionField`"]
@@ -28199,8 +28195,8 @@ impl ::std::convert::From<Expr> for DensityTransformDistributionField {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionMax {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for DensityTransformDistributionMax {
     fn from(value: &DensityTransformDistributionMax) -> Self {
@@ -28209,17 +28205,17 @@ impl ::std::convert::From<&Self> for DensityTransformDistributionMax {
 }
 impl ::std::default::Default for DensityTransformDistributionMax {
     fn default() -> Self {
-        DensityTransformDistributionMax::Variant0(1_f64)
+        DensityTransformDistributionMax::Number(1_f64)
     }
 }
 impl ::std::convert::From<f64> for DensityTransformDistributionMax {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for DensityTransformDistributionMax {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`DensityTransformDistributionMean`"]
@@ -28242,8 +28238,8 @@ impl ::std::convert::From<SignalRef> for DensityTransformDistributionMax {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionMean {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for DensityTransformDistributionMean {
     fn from(value: &DensityTransformDistributionMean) -> Self {
@@ -28252,12 +28248,12 @@ impl ::std::convert::From<&Self> for DensityTransformDistributionMean {
 }
 impl ::std::convert::From<f64> for DensityTransformDistributionMean {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for DensityTransformDistributionMean {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`DensityTransformDistributionMin`"]
@@ -28280,8 +28276,8 @@ impl ::std::convert::From<SignalRef> for DensityTransformDistributionMean {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionMin {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for DensityTransformDistributionMin {
     fn from(value: &DensityTransformDistributionMin) -> Self {
@@ -28290,12 +28286,12 @@ impl ::std::convert::From<&Self> for DensityTransformDistributionMin {
 }
 impl ::std::convert::From<f64> for DensityTransformDistributionMin {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for DensityTransformDistributionMin {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`DensityTransformDistributionStdev`"]
@@ -28319,8 +28315,8 @@ impl ::std::convert::From<SignalRef> for DensityTransformDistributionMin {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionStdev {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for DensityTransformDistributionStdev {
     fn from(value: &DensityTransformDistributionStdev) -> Self {
@@ -28329,17 +28325,17 @@ impl ::std::convert::From<&Self> for DensityTransformDistributionStdev {
 }
 impl ::std::default::Default for DensityTransformDistributionStdev {
     fn default() -> Self {
-        DensityTransformDistributionStdev::Variant0(1_f64)
+        DensityTransformDistributionStdev::Number(1_f64)
     }
 }
 impl ::std::convert::From<f64> for DensityTransformDistributionStdev {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for DensityTransformDistributionStdev {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`DensityTransformDistributionWeights`"]
@@ -28372,27 +28368,27 @@ impl ::std::convert::From<SignalRef> for DensityTransformDistributionStdev {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum DensityTransformDistributionWeights {
-    Variant0(::std::vec::Vec<DensityTransformDistributionWeightsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<DensityTransformDistributionWeightsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for DensityTransformDistributionWeights {
     fn from(value: &DensityTransformDistributionWeights) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<DensityTransformDistributionWeightsVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<DensityTransformDistributionWeightsArrayItem>>
     for DensityTransformDistributionWeights
 {
-    fn from(value: ::std::vec::Vec<DensityTransformDistributionWeightsVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<DensityTransformDistributionWeightsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for DensityTransformDistributionWeights {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`DensityTransformDistributionWeightsVariant0Item`"]
+#[doc = "`DensityTransformDistributionWeightsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -28411,23 +28407,23 @@ impl ::std::convert::From<SignalRef> for DensityTransformDistributionWeights {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum DensityTransformDistributionWeightsVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum DensityTransformDistributionWeightsArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for DensityTransformDistributionWeightsVariant0Item {
-    fn from(value: &DensityTransformDistributionWeightsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for DensityTransformDistributionWeightsArrayItem {
+    fn from(value: &DensityTransformDistributionWeightsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for DensityTransformDistributionWeightsVariant0Item {
+impl ::std::convert::From<f64> for DensityTransformDistributionWeightsArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for DensityTransformDistributionWeightsVariant0Item {
+impl ::std::convert::From<SignalRef> for DensityTransformDistributionWeightsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`DensityTransformExtent`"]
@@ -28462,25 +28458,25 @@ impl ::std::convert::From<SignalRef> for DensityTransformDistributionWeightsVari
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum DensityTransformExtent {
-    Variant0([DensityTransformExtentVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([DensityTransformExtentArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for DensityTransformExtent {
     fn from(value: &DensityTransformExtent) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<[DensityTransformExtentVariant0Item; 2usize]> for DensityTransformExtent {
-    fn from(value: [DensityTransformExtentVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[DensityTransformExtentArrayItem; 2usize]> for DensityTransformExtent {
+    fn from(value: [DensityTransformExtentArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for DensityTransformExtent {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`DensityTransformExtentVariant0Item`"]
+#[doc = "`DensityTransformExtentArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -28499,23 +28495,23 @@ impl ::std::convert::From<SignalRef> for DensityTransformExtent {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum DensityTransformExtentVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum DensityTransformExtentArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for DensityTransformExtentVariant0Item {
-    fn from(value: &DensityTransformExtentVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for DensityTransformExtentArrayItem {
+    fn from(value: &DensityTransformExtentArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for DensityTransformExtentVariant0Item {
+impl ::std::convert::From<f64> for DensityTransformExtentArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for DensityTransformExtentVariant0Item {
+impl ::std::convert::From<SignalRef> for DensityTransformExtentArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`DensityTransformMaxsteps`"]
@@ -28539,8 +28535,8 @@ impl ::std::convert::From<SignalRef> for DensityTransformExtentVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum DensityTransformMaxsteps {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for DensityTransformMaxsteps {
     fn from(value: &DensityTransformMaxsteps) -> Self {
@@ -28549,17 +28545,17 @@ impl ::std::convert::From<&Self> for DensityTransformMaxsteps {
 }
 impl ::std::default::Default for DensityTransformMaxsteps {
     fn default() -> Self {
-        DensityTransformMaxsteps::Variant0(200_f64)
+        DensityTransformMaxsteps::Number(200_f64)
     }
 }
 impl ::std::convert::From<f64> for DensityTransformMaxsteps {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for DensityTransformMaxsteps {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`DensityTransformMethod`"]
@@ -28583,8 +28579,8 @@ impl ::std::convert::From<SignalRef> for DensityTransformMaxsteps {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum DensityTransformMethod {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for DensityTransformMethod {
     fn from(value: &DensityTransformMethod) -> Self {
@@ -28593,12 +28589,12 @@ impl ::std::convert::From<&Self> for DensityTransformMethod {
 }
 impl ::std::default::Default for DensityTransformMethod {
     fn default() -> Self {
-        DensityTransformMethod::Variant0("pdf".to_string())
+        DensityTransformMethod::String("pdf".to_string())
     }
 }
 impl ::std::convert::From<SignalRef> for DensityTransformMethod {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`DensityTransformMinsteps`"]
@@ -28622,8 +28618,8 @@ impl ::std::convert::From<SignalRef> for DensityTransformMethod {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum DensityTransformMinsteps {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for DensityTransformMinsteps {
     fn from(value: &DensityTransformMinsteps) -> Self {
@@ -28632,17 +28628,17 @@ impl ::std::convert::From<&Self> for DensityTransformMinsteps {
 }
 impl ::std::default::Default for DensityTransformMinsteps {
     fn default() -> Self {
-        DensityTransformMinsteps::Variant0(25_f64)
+        DensityTransformMinsteps::Number(25_f64)
     }
 }
 impl ::std::convert::From<f64> for DensityTransformMinsteps {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for DensityTransformMinsteps {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`DensityTransformSteps`"]
@@ -28665,8 +28661,8 @@ impl ::std::convert::From<SignalRef> for DensityTransformMinsteps {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum DensityTransformSteps {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for DensityTransformSteps {
     fn from(value: &DensityTransformSteps) -> Self {
@@ -28675,12 +28671,12 @@ impl ::std::convert::From<&Self> for DensityTransformSteps {
 }
 impl ::std::convert::From<f64> for DensityTransformSteps {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for DensityTransformSteps {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`DensityTransformType`"]
@@ -29320,8 +29316,8 @@ impl ::std::convert::TryFrom<::std::string::String>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum DirectionValueVariant0ItemVariant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for DirectionValueVariant0ItemVariant0Variant3Range {
     fn from(value: &DirectionValueVariant0ItemVariant0Variant3Range) -> Self {
@@ -29332,9 +29328,9 @@ impl ::std::str::FromStr for DirectionValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -29369,19 +29365,19 @@ impl ::std::convert::TryFrom<::std::string::String>
 impl ::std::fmt::Display for DirectionValueVariant0ItemVariant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for DirectionValueVariant0ItemVariant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for DirectionValueVariant0ItemVariant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`DirectionValueVariant0ItemVariant1`"]
@@ -29958,8 +29954,8 @@ impl ::std::convert::TryFrom<::std::string::String>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum DirectionValueVariant1Variant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for DirectionValueVariant1Variant0Variant3Range {
     fn from(value: &DirectionValueVariant1Variant0Variant3Range) -> Self {
@@ -29970,9 +29966,9 @@ impl ::std::str::FromStr for DirectionValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -30007,19 +30003,19 @@ impl ::std::convert::TryFrom<::std::string::String>
 impl ::std::fmt::Display for DirectionValueVariant1Variant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for DirectionValueVariant1Variant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for DirectionValueVariant1Variant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`DirectionValueVariant1Variant1`"]
@@ -30385,8 +30381,8 @@ impl ::std::convert::From<&DotbinTransform> for DotbinTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum DotbinTransformAs {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for DotbinTransformAs {
     fn from(value: &DotbinTransformAs) -> Self {
@@ -30395,12 +30391,12 @@ impl ::std::convert::From<&Self> for DotbinTransformAs {
 }
 impl ::std::default::Default for DotbinTransformAs {
     fn default() -> Self {
-        DotbinTransformAs::Variant0("bin".to_string())
+        DotbinTransformAs::String("bin".to_string())
     }
 }
 impl ::std::convert::From<SignalRef> for DotbinTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`DotbinTransformField`"]
@@ -30483,27 +30479,27 @@ impl ::std::convert::From<Expr> for DotbinTransformField {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum DotbinTransformGroupby {
-    Variant0(::std::vec::Vec<DotbinTransformGroupbyVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<DotbinTransformGroupbyArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for DotbinTransformGroupby {
     fn from(value: &DotbinTransformGroupby) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<DotbinTransformGroupbyVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<DotbinTransformGroupbyArrayItem>>
     for DotbinTransformGroupby
 {
-    fn from(value: ::std::vec::Vec<DotbinTransformGroupbyVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<DotbinTransformGroupbyArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for DotbinTransformGroupby {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`DotbinTransformGroupbyVariant0Item`"]
+#[doc = "`DotbinTransformGroupbyArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -30525,27 +30521,27 @@ impl ::std::convert::From<SignalRef> for DotbinTransformGroupby {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum DotbinTransformGroupbyVariant0Item {
+pub enum DotbinTransformGroupbyArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for DotbinTransformGroupbyVariant0Item {
-    fn from(value: &DotbinTransformGroupbyVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for DotbinTransformGroupbyArrayItem {
+    fn from(value: &DotbinTransformGroupbyArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<ScaleField> for DotbinTransformGroupbyVariant0Item {
+impl ::std::convert::From<ScaleField> for DotbinTransformGroupbyArrayItem {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
     }
 }
-impl ::std::convert::From<ParamField> for DotbinTransformGroupbyVariant0Item {
+impl ::std::convert::From<ParamField> for DotbinTransformGroupbyArrayItem {
     fn from(value: ParamField) -> Self {
         Self::ParamField(value)
     }
 }
-impl ::std::convert::From<Expr> for DotbinTransformGroupbyVariant0Item {
+impl ::std::convert::From<Expr> for DotbinTransformGroupbyArrayItem {
     fn from(value: Expr) -> Self {
         Self::Expr(value)
     }
@@ -30570,8 +30566,8 @@ impl ::std::convert::From<Expr> for DotbinTransformGroupbyVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum DotbinTransformSmooth {
-    Variant0(bool),
-    Variant1(SignalRef),
+    Boolean(bool),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for DotbinTransformSmooth {
     fn from(value: &DotbinTransformSmooth) -> Self {
@@ -30580,12 +30576,12 @@ impl ::std::convert::From<&Self> for DotbinTransformSmooth {
 }
 impl ::std::convert::From<bool> for DotbinTransformSmooth {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<SignalRef> for DotbinTransformSmooth {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`DotbinTransformStep`"]
@@ -30608,8 +30604,8 @@ impl ::std::convert::From<SignalRef> for DotbinTransformSmooth {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum DotbinTransformStep {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for DotbinTransformStep {
     fn from(value: &DotbinTransformStep) -> Self {
@@ -30618,12 +30614,12 @@ impl ::std::convert::From<&Self> for DotbinTransformStep {
 }
 impl ::std::convert::From<f64> for DotbinTransformStep {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for DotbinTransformStep {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`DotbinTransformType`"]
@@ -32158,8 +32154,8 @@ impl ::std::default::Default for FacetFacetVariant1Aggregate {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum FacetFacetVariant1Groupby {
-    Variant0(::std::string::String),
-    Variant1(::std::vec::Vec<::std::string::String>),
+    String(::std::string::String),
+    Array(::std::vec::Vec<::std::string::String>),
 }
 impl ::std::convert::From<&Self> for FacetFacetVariant1Groupby {
     fn from(value: &FacetFacetVariant1Groupby) -> Self {
@@ -32168,7 +32164,7 @@ impl ::std::convert::From<&Self> for FacetFacetVariant1Groupby {
 }
 impl ::std::convert::From<::std::vec::Vec<::std::string::String>> for FacetFacetVariant1Groupby {
     fn from(value: ::std::vec::Vec<::std::string::String>) -> Self {
-        Self::Variant1(value)
+        Self::Array(value)
     }
 }
 #[doc = "`Field`"]
@@ -32502,25 +32498,25 @@ impl ::std::convert::From<&FlattenTransform> for FlattenTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum FlattenTransformAs {
-    Variant0(::std::vec::Vec<FlattenTransformAsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<FlattenTransformAsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for FlattenTransformAs {
     fn from(value: &FlattenTransformAs) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<FlattenTransformAsVariant0Item>> for FlattenTransformAs {
-    fn from(value: ::std::vec::Vec<FlattenTransformAsVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<FlattenTransformAsArrayItem>> for FlattenTransformAs {
+    fn from(value: ::std::vec::Vec<FlattenTransformAsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for FlattenTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`FlattenTransformAsVariant0Item`"]
+#[doc = "`FlattenTransformAsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32539,18 +32535,18 @@ impl ::std::convert::From<SignalRef> for FlattenTransformAs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum FlattenTransformAsVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum FlattenTransformAsArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for FlattenTransformAsVariant0Item {
-    fn from(value: &FlattenTransformAsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for FlattenTransformAsArrayItem {
+    fn from(value: &FlattenTransformAsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for FlattenTransformAsVariant0Item {
+impl ::std::convert::From<SignalRef> for FlattenTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`FlattenTransformFields`"]
@@ -32586,27 +32582,27 @@ impl ::std::convert::From<SignalRef> for FlattenTransformAsVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum FlattenTransformFields {
-    Variant0(::std::vec::Vec<FlattenTransformFieldsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<FlattenTransformFieldsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for FlattenTransformFields {
     fn from(value: &FlattenTransformFields) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<FlattenTransformFieldsVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<FlattenTransformFieldsArrayItem>>
     for FlattenTransformFields
 {
-    fn from(value: ::std::vec::Vec<FlattenTransformFieldsVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<FlattenTransformFieldsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for FlattenTransformFields {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`FlattenTransformFieldsVariant0Item`"]
+#[doc = "`FlattenTransformFieldsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32628,27 +32624,27 @@ impl ::std::convert::From<SignalRef> for FlattenTransformFields {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum FlattenTransformFieldsVariant0Item {
+pub enum FlattenTransformFieldsArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for FlattenTransformFieldsVariant0Item {
-    fn from(value: &FlattenTransformFieldsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for FlattenTransformFieldsArrayItem {
+    fn from(value: &FlattenTransformFieldsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<ScaleField> for FlattenTransformFieldsVariant0Item {
+impl ::std::convert::From<ScaleField> for FlattenTransformFieldsArrayItem {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
     }
 }
-impl ::std::convert::From<ParamField> for FlattenTransformFieldsVariant0Item {
+impl ::std::convert::From<ParamField> for FlattenTransformFieldsArrayItem {
     fn from(value: ParamField) -> Self {
         Self::ParamField(value)
     }
 }
-impl ::std::convert::From<Expr> for FlattenTransformFieldsVariant0Item {
+impl ::std::convert::From<Expr> for FlattenTransformFieldsArrayItem {
     fn from(value: Expr) -> Self {
         Self::Expr(value)
     }
@@ -32673,8 +32669,8 @@ impl ::std::convert::From<Expr> for FlattenTransformFieldsVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum FlattenTransformIndex {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for FlattenTransformIndex {
     fn from(value: &FlattenTransformIndex) -> Self {
@@ -32683,7 +32679,7 @@ impl ::std::convert::From<&Self> for FlattenTransformIndex {
 }
 impl ::std::convert::From<SignalRef> for FlattenTransformIndex {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`FlattenTransformType`"]
@@ -32883,8 +32879,8 @@ impl ::std::convert::From<&FoldTransform> for FoldTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum FoldTransformAs {
-    Variant0([FoldTransformAsVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([FoldTransformAsArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for FoldTransformAs {
     fn from(value: &FoldTransformAs) -> Self {
@@ -32893,23 +32889,23 @@ impl ::std::convert::From<&Self> for FoldTransformAs {
 }
 impl ::std::default::Default for FoldTransformAs {
     fn default() -> Self {
-        FoldTransformAs::Variant0([
-            FoldTransformAsVariant0Item::Variant0("key".to_string()),
-            FoldTransformAsVariant0Item::Variant0("value".to_string()),
+        FoldTransformAs::Array([
+            FoldTransformAsArrayItem::String("key".to_string()),
+            FoldTransformAsArrayItem::String("value".to_string()),
         ])
     }
 }
-impl ::std::convert::From<[FoldTransformAsVariant0Item; 2usize]> for FoldTransformAs {
-    fn from(value: [FoldTransformAsVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[FoldTransformAsArrayItem; 2usize]> for FoldTransformAs {
+    fn from(value: [FoldTransformAsArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for FoldTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`FoldTransformAsVariant0Item`"]
+#[doc = "`FoldTransformAsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -32928,18 +32924,18 @@ impl ::std::convert::From<SignalRef> for FoldTransformAs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum FoldTransformAsVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum FoldTransformAsArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for FoldTransformAsVariant0Item {
-    fn from(value: &FoldTransformAsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for FoldTransformAsArrayItem {
+    fn from(value: &FoldTransformAsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for FoldTransformAsVariant0Item {
+impl ::std::convert::From<SignalRef> for FoldTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`FoldTransformFields`"]
@@ -32975,27 +32971,25 @@ impl ::std::convert::From<SignalRef> for FoldTransformAsVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum FoldTransformFields {
-    Variant0(::std::vec::Vec<FoldTransformFieldsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<FoldTransformFieldsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for FoldTransformFields {
     fn from(value: &FoldTransformFields) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<FoldTransformFieldsVariant0Item>>
-    for FoldTransformFields
-{
-    fn from(value: ::std::vec::Vec<FoldTransformFieldsVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<FoldTransformFieldsArrayItem>> for FoldTransformFields {
+    fn from(value: ::std::vec::Vec<FoldTransformFieldsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for FoldTransformFields {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`FoldTransformFieldsVariant0Item`"]
+#[doc = "`FoldTransformFieldsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -33017,27 +33011,27 @@ impl ::std::convert::From<SignalRef> for FoldTransformFields {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum FoldTransformFieldsVariant0Item {
+pub enum FoldTransformFieldsArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for FoldTransformFieldsVariant0Item {
-    fn from(value: &FoldTransformFieldsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for FoldTransformFieldsArrayItem {
+    fn from(value: &FoldTransformFieldsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<ScaleField> for FoldTransformFieldsVariant0Item {
+impl ::std::convert::From<ScaleField> for FoldTransformFieldsArrayItem {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
     }
 }
-impl ::std::convert::From<ParamField> for FoldTransformFieldsVariant0Item {
+impl ::std::convert::From<ParamField> for FoldTransformFieldsArrayItem {
     fn from(value: ParamField) -> Self {
         Self::ParamField(value)
     }
 }
-impl ::std::convert::From<Expr> for FoldTransformFieldsVariant0Item {
+impl ::std::convert::From<Expr> for FoldTransformFieldsArrayItem {
     fn from(value: Expr) -> Self {
         Self::Expr(value)
     }
@@ -33683,8 +33677,8 @@ impl ::std::convert::From<&Self> for FontWeightValueVariant0ItemVariant0 {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum FontWeightValueVariant0ItemVariant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for FontWeightValueVariant0ItemVariant0Variant3Range {
     fn from(value: &FontWeightValueVariant0ItemVariant0Variant3Range) -> Self {
@@ -33695,9 +33689,9 @@ impl ::std::str::FromStr for FontWeightValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -33732,19 +33726,19 @@ impl ::std::convert::TryFrom<::std::string::String>
 impl ::std::fmt::Display for FontWeightValueVariant0ItemVariant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for FontWeightValueVariant0ItemVariant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for FontWeightValueVariant0ItemVariant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`FontWeightValueVariant0ItemVariant1`"]
@@ -34325,8 +34319,8 @@ impl ::std::convert::From<&Self> for FontWeightValueVariant1Variant0 {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum FontWeightValueVariant1Variant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for FontWeightValueVariant1Variant0Variant3Range {
     fn from(value: &FontWeightValueVariant1Variant0Variant3Range) -> Self {
@@ -34337,9 +34331,9 @@ impl ::std::str::FromStr for FontWeightValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -34374,19 +34368,19 @@ impl ::std::convert::TryFrom<::std::string::String>
 impl ::std::fmt::Display for FontWeightValueVariant1Variant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for FontWeightValueVariant1Variant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for FontWeightValueVariant1Variant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`FontWeightValueVariant1Variant1`"]
@@ -35146,8 +35140,8 @@ impl ::std::convert::From<&ForceTransform> for ForceTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ForceTransformAlpha {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ForceTransformAlpha {
     fn from(value: &ForceTransformAlpha) -> Self {
@@ -35156,17 +35150,17 @@ impl ::std::convert::From<&Self> for ForceTransformAlpha {
 }
 impl ::std::default::Default for ForceTransformAlpha {
     fn default() -> Self {
-        ForceTransformAlpha::Variant0(1_f64)
+        ForceTransformAlpha::Number(1_f64)
     }
 }
 impl ::std::convert::From<f64> for ForceTransformAlpha {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ForceTransformAlpha {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ForceTransformAlphaMin`"]
@@ -35190,8 +35184,8 @@ impl ::std::convert::From<SignalRef> for ForceTransformAlpha {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ForceTransformAlphaMin {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ForceTransformAlphaMin {
     fn from(value: &ForceTransformAlphaMin) -> Self {
@@ -35200,17 +35194,17 @@ impl ::std::convert::From<&Self> for ForceTransformAlphaMin {
 }
 impl ::std::default::Default for ForceTransformAlphaMin {
     fn default() -> Self {
-        ForceTransformAlphaMin::Variant0(0.001_f64)
+        ForceTransformAlphaMin::Number(0.001_f64)
     }
 }
 impl ::std::convert::From<f64> for ForceTransformAlphaMin {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ForceTransformAlphaMin {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ForceTransformAlphaTarget`"]
@@ -35233,8 +35227,8 @@ impl ::std::convert::From<SignalRef> for ForceTransformAlphaMin {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ForceTransformAlphaTarget {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ForceTransformAlphaTarget {
     fn from(value: &ForceTransformAlphaTarget) -> Self {
@@ -35243,12 +35237,12 @@ impl ::std::convert::From<&Self> for ForceTransformAlphaTarget {
 }
 impl ::std::convert::From<f64> for ForceTransformAlphaTarget {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ForceTransformAlphaTarget {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ForceTransformAs`"]
@@ -35287,8 +35281,8 @@ impl ::std::convert::From<SignalRef> for ForceTransformAlphaTarget {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ForceTransformAs {
-    Variant0(::std::vec::Vec<ForceTransformAsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<ForceTransformAsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ForceTransformAs {
     fn from(value: &ForceTransformAs) -> Self {
@@ -35297,25 +35291,25 @@ impl ::std::convert::From<&Self> for ForceTransformAs {
 }
 impl ::std::default::Default for ForceTransformAs {
     fn default() -> Self {
-        ForceTransformAs::Variant0(vec![
-            ForceTransformAsVariant0Item::Variant0("x".to_string()),
-            ForceTransformAsVariant0Item::Variant0("y".to_string()),
-            ForceTransformAsVariant0Item::Variant0("vx".to_string()),
-            ForceTransformAsVariant0Item::Variant0("vy".to_string()),
+        ForceTransformAs::Array(vec![
+            ForceTransformAsArrayItem::String("x".to_string()),
+            ForceTransformAsArrayItem::String("y".to_string()),
+            ForceTransformAsArrayItem::String("vx".to_string()),
+            ForceTransformAsArrayItem::String("vy".to_string()),
         ])
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ForceTransformAsVariant0Item>> for ForceTransformAs {
-    fn from(value: ::std::vec::Vec<ForceTransformAsVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<ForceTransformAsArrayItem>> for ForceTransformAs {
+    fn from(value: ::std::vec::Vec<ForceTransformAsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ForceTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ForceTransformAsVariant0Item`"]
+#[doc = "`ForceTransformAsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -35334,18 +35328,18 @@ impl ::std::convert::From<SignalRef> for ForceTransformAs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ForceTransformAsVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum ForceTransformAsArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ForceTransformAsVariant0Item {
-    fn from(value: &ForceTransformAsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for ForceTransformAsArrayItem {
+    fn from(value: &ForceTransformAsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for ForceTransformAsVariant0Item {
+impl ::std::convert::From<SignalRef> for ForceTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ForceTransformForcesItem`"]
@@ -35749,10 +35743,10 @@ impl ::std::convert::From<&Self> for ForceTransformForcesItem {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemDistance {
-    Variant0(f64),
-    Variant1(SignalRef),
-    Variant2(Expr),
-    Variant3(ParamField),
+    Number(f64),
+    SignalRef(SignalRef),
+    Expr(Expr),
+    ParamField(ParamField),
 }
 impl ::std::convert::From<&Self> for ForceTransformForcesItemDistance {
     fn from(value: &ForceTransformForcesItemDistance) -> Self {
@@ -35761,27 +35755,27 @@ impl ::std::convert::From<&Self> for ForceTransformForcesItemDistance {
 }
 impl ::std::default::Default for ForceTransformForcesItemDistance {
     fn default() -> Self {
-        ForceTransformForcesItemDistance::Variant0(30_f64)
+        ForceTransformForcesItemDistance::Number(30_f64)
     }
 }
 impl ::std::convert::From<f64> for ForceTransformForcesItemDistance {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ForceTransformForcesItemDistance {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 impl ::std::convert::From<Expr> for ForceTransformForcesItemDistance {
     fn from(value: Expr) -> Self {
-        Self::Variant2(value)
+        Self::Expr(value)
     }
 }
 impl ::std::convert::From<ParamField> for ForceTransformForcesItemDistance {
     fn from(value: ParamField) -> Self {
-        Self::Variant3(value)
+        Self::ParamField(value)
     }
 }
 #[doc = "`ForceTransformForcesItemDistanceMax`"]
@@ -35804,8 +35798,8 @@ impl ::std::convert::From<ParamField> for ForceTransformForcesItemDistance {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemDistanceMax {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ForceTransformForcesItemDistanceMax {
     fn from(value: &ForceTransformForcesItemDistanceMax) -> Self {
@@ -35814,12 +35808,12 @@ impl ::std::convert::From<&Self> for ForceTransformForcesItemDistanceMax {
 }
 impl ::std::convert::From<f64> for ForceTransformForcesItemDistanceMax {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ForceTransformForcesItemDistanceMax {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ForceTransformForcesItemDistanceMin`"]
@@ -35843,8 +35837,8 @@ impl ::std::convert::From<SignalRef> for ForceTransformForcesItemDistanceMax {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemDistanceMin {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ForceTransformForcesItemDistanceMin {
     fn from(value: &ForceTransformForcesItemDistanceMin) -> Self {
@@ -35853,17 +35847,17 @@ impl ::std::convert::From<&Self> for ForceTransformForcesItemDistanceMin {
 }
 impl ::std::default::Default for ForceTransformForcesItemDistanceMin {
     fn default() -> Self {
-        ForceTransformForcesItemDistanceMin::Variant0(1_f64)
+        ForceTransformForcesItemDistanceMin::Number(1_f64)
     }
 }
 impl ::std::convert::From<f64> for ForceTransformForcesItemDistanceMin {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ForceTransformForcesItemDistanceMin {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ForceTransformForcesItemId`"]
@@ -35934,8 +35928,8 @@ impl ::std::convert::From<Expr> for ForceTransformForcesItemId {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemIterations {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ForceTransformForcesItemIterations {
     fn from(value: &ForceTransformForcesItemIterations) -> Self {
@@ -35944,17 +35938,17 @@ impl ::std::convert::From<&Self> for ForceTransformForcesItemIterations {
 }
 impl ::std::default::Default for ForceTransformForcesItemIterations {
     fn default() -> Self {
-        ForceTransformForcesItemIterations::Variant0(1_f64)
+        ForceTransformForcesItemIterations::Number(1_f64)
     }
 }
 impl ::std::convert::From<f64> for ForceTransformForcesItemIterations {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ForceTransformForcesItemIterations {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ForceTransformForcesItemRadius`"]
@@ -35983,10 +35977,10 @@ impl ::std::convert::From<SignalRef> for ForceTransformForcesItemIterations {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemRadius {
-    Variant0(f64),
-    Variant1(SignalRef),
-    Variant2(Expr),
-    Variant3(ParamField),
+    Number(f64),
+    SignalRef(SignalRef),
+    Expr(Expr),
+    ParamField(ParamField),
 }
 impl ::std::convert::From<&Self> for ForceTransformForcesItemRadius {
     fn from(value: &ForceTransformForcesItemRadius) -> Self {
@@ -35995,22 +35989,22 @@ impl ::std::convert::From<&Self> for ForceTransformForcesItemRadius {
 }
 impl ::std::convert::From<f64> for ForceTransformForcesItemRadius {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ForceTransformForcesItemRadius {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 impl ::std::convert::From<Expr> for ForceTransformForcesItemRadius {
     fn from(value: Expr) -> Self {
-        Self::Variant2(value)
+        Self::Expr(value)
     }
 }
 impl ::std::convert::From<ParamField> for ForceTransformForcesItemRadius {
     fn from(value: ParamField) -> Self {
-        Self::Variant3(value)
+        Self::ParamField(value)
     }
 }
 #[doc = "`ForceTransformForcesItemStrength`"]
@@ -36034,8 +36028,8 @@ impl ::std::convert::From<ParamField> for ForceTransformForcesItemRadius {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemStrength {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ForceTransformForcesItemStrength {
     fn from(value: &ForceTransformForcesItemStrength) -> Self {
@@ -36044,17 +36038,17 @@ impl ::std::convert::From<&Self> for ForceTransformForcesItemStrength {
 }
 impl ::std::default::Default for ForceTransformForcesItemStrength {
     fn default() -> Self {
-        ForceTransformForcesItemStrength::Variant0(0.7_f64)
+        ForceTransformForcesItemStrength::Number(0.7_f64)
     }
 }
 impl ::std::convert::From<f64> for ForceTransformForcesItemStrength {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ForceTransformForcesItemStrength {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ForceTransformForcesItemTheta`"]
@@ -36078,8 +36072,8 @@ impl ::std::convert::From<SignalRef> for ForceTransformForcesItemStrength {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemTheta {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ForceTransformForcesItemTheta {
     fn from(value: &ForceTransformForcesItemTheta) -> Self {
@@ -36088,17 +36082,17 @@ impl ::std::convert::From<&Self> for ForceTransformForcesItemTheta {
 }
 impl ::std::default::Default for ForceTransformForcesItemTheta {
     fn default() -> Self {
-        ForceTransformForcesItemTheta::Variant0(0.9_f64)
+        ForceTransformForcesItemTheta::Number(0.9_f64)
     }
 }
 impl ::std::convert::From<f64> for ForceTransformForcesItemTheta {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ForceTransformForcesItemTheta {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ForceTransformForcesItemX`"]
@@ -36121,8 +36115,8 @@ impl ::std::convert::From<SignalRef> for ForceTransformForcesItemTheta {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemX {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ForceTransformForcesItemX {
     fn from(value: &ForceTransformForcesItemX) -> Self {
@@ -36131,12 +36125,12 @@ impl ::std::convert::From<&Self> for ForceTransformForcesItemX {
 }
 impl ::std::convert::From<f64> for ForceTransformForcesItemX {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ForceTransformForcesItemX {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ForceTransformForcesItemY`"]
@@ -36159,8 +36153,8 @@ impl ::std::convert::From<SignalRef> for ForceTransformForcesItemX {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ForceTransformForcesItemY {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ForceTransformForcesItemY {
     fn from(value: &ForceTransformForcesItemY) -> Self {
@@ -36169,12 +36163,12 @@ impl ::std::convert::From<&Self> for ForceTransformForcesItemY {
 }
 impl ::std::convert::From<f64> for ForceTransformForcesItemY {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ForceTransformForcesItemY {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ForceTransformIterations`"]
@@ -36198,8 +36192,8 @@ impl ::std::convert::From<SignalRef> for ForceTransformForcesItemY {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ForceTransformIterations {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ForceTransformIterations {
     fn from(value: &ForceTransformIterations) -> Self {
@@ -36208,17 +36202,17 @@ impl ::std::convert::From<&Self> for ForceTransformIterations {
 }
 impl ::std::default::Default for ForceTransformIterations {
     fn default() -> Self {
-        ForceTransformIterations::Variant0(300_f64)
+        ForceTransformIterations::Number(300_f64)
     }
 }
 impl ::std::convert::From<f64> for ForceTransformIterations {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ForceTransformIterations {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ForceTransformRestart`"]
@@ -36241,8 +36235,8 @@ impl ::std::convert::From<SignalRef> for ForceTransformIterations {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ForceTransformRestart {
-    Variant0(bool),
-    Variant1(SignalRef),
+    Boolean(bool),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ForceTransformRestart {
     fn from(value: &ForceTransformRestart) -> Self {
@@ -36251,12 +36245,12 @@ impl ::std::convert::From<&Self> for ForceTransformRestart {
 }
 impl ::std::convert::From<bool> for ForceTransformRestart {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ForceTransformRestart {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ForceTransformStatic`"]
@@ -36279,8 +36273,8 @@ impl ::std::convert::From<SignalRef> for ForceTransformRestart {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ForceTransformStatic {
-    Variant0(bool),
-    Variant1(SignalRef),
+    Boolean(bool),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ForceTransformStatic {
     fn from(value: &ForceTransformStatic) -> Self {
@@ -36289,12 +36283,12 @@ impl ::std::convert::From<&Self> for ForceTransformStatic {
 }
 impl ::std::convert::From<bool> for ForceTransformStatic {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ForceTransformStatic {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ForceTransformType`"]
@@ -36389,8 +36383,8 @@ impl ::std::convert::TryFrom<::std::string::String> for ForceTransformType {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ForceTransformVelocityDecay {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ForceTransformVelocityDecay {
     fn from(value: &ForceTransformVelocityDecay) -> Self {
@@ -36399,17 +36393,17 @@ impl ::std::convert::From<&Self> for ForceTransformVelocityDecay {
 }
 impl ::std::default::Default for ForceTransformVelocityDecay {
     fn default() -> Self {
-        ForceTransformVelocityDecay::Variant0(0.4_f64)
+        ForceTransformVelocityDecay::Number(0.4_f64)
     }
 }
 impl ::std::convert::From<f64> for ForceTransformVelocityDecay {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ForceTransformVelocityDecay {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`FormulaTransform`"]
@@ -36499,8 +36493,8 @@ impl ::std::convert::From<&FormulaTransform> for FormulaTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum FormulaTransformAs {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for FormulaTransformAs {
     fn from(value: &FormulaTransformAs) -> Self {
@@ -36509,7 +36503,7 @@ impl ::std::convert::From<&Self> for FormulaTransformAs {
 }
 impl ::std::convert::From<SignalRef> for FormulaTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`FormulaTransformInitonly`"]
@@ -36532,8 +36526,8 @@ impl ::std::convert::From<SignalRef> for FormulaTransformAs {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum FormulaTransformInitonly {
-    Variant0(bool),
-    Variant1(SignalRef),
+    Boolean(bool),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for FormulaTransformInitonly {
     fn from(value: &FormulaTransformInitonly) -> Self {
@@ -36542,12 +36536,12 @@ impl ::std::convert::From<&Self> for FormulaTransformInitonly {
 }
 impl ::std::convert::From<bool> for FormulaTransformInitonly {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<SignalRef> for FormulaTransformInitonly {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`FormulaTransformType`"]
@@ -36769,25 +36763,25 @@ impl ::std::convert::From<&GeojsonTransform> for GeojsonTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum GeojsonTransformFields {
-    Variant0([GeojsonTransformFieldsVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([GeojsonTransformFieldsArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for GeojsonTransformFields {
     fn from(value: &GeojsonTransformFields) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<[GeojsonTransformFieldsVariant0Item; 2usize]> for GeojsonTransformFields {
-    fn from(value: [GeojsonTransformFieldsVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[GeojsonTransformFieldsArrayItem; 2usize]> for GeojsonTransformFields {
+    fn from(value: [GeojsonTransformFieldsArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for GeojsonTransformFields {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`GeojsonTransformFieldsVariant0Item`"]
+#[doc = "`GeojsonTransformFieldsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -36809,27 +36803,27 @@ impl ::std::convert::From<SignalRef> for GeojsonTransformFields {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum GeojsonTransformFieldsVariant0Item {
+pub enum GeojsonTransformFieldsArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for GeojsonTransformFieldsVariant0Item {
-    fn from(value: &GeojsonTransformFieldsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for GeojsonTransformFieldsArrayItem {
+    fn from(value: &GeojsonTransformFieldsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<ScaleField> for GeojsonTransformFieldsVariant0Item {
+impl ::std::convert::From<ScaleField> for GeojsonTransformFieldsArrayItem {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
     }
 }
-impl ::std::convert::From<ParamField> for GeojsonTransformFieldsVariant0Item {
+impl ::std::convert::From<ParamField> for GeojsonTransformFieldsArrayItem {
     fn from(value: ParamField) -> Self {
         Self::ParamField(value)
     }
 }
-impl ::std::convert::From<Expr> for GeojsonTransformFieldsVariant0Item {
+impl ::std::convert::From<Expr> for GeojsonTransformFieldsArrayItem {
     fn from(value: Expr) -> Self {
         Self::Expr(value)
     }
@@ -37065,8 +37059,8 @@ impl ::std::convert::From<&GeopathTransform> for GeopathTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum GeopathTransformAs {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for GeopathTransformAs {
     fn from(value: &GeopathTransformAs) -> Self {
@@ -37075,12 +37069,12 @@ impl ::std::convert::From<&Self> for GeopathTransformAs {
 }
 impl ::std::default::Default for GeopathTransformAs {
     fn default() -> Self {
-        GeopathTransformAs::Variant0("path".to_string())
+        GeopathTransformAs::String("path".to_string())
     }
 }
 impl ::std::convert::From<SignalRef> for GeopathTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`GeopathTransformField`"]
@@ -37156,10 +37150,10 @@ impl ::std::convert::From<Expr> for GeopathTransformField {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum GeopathTransformPointRadius {
-    Variant0(f64),
-    Variant1(SignalRef),
-    Variant2(Expr),
-    Variant3(ParamField),
+    Number(f64),
+    SignalRef(SignalRef),
+    Expr(Expr),
+    ParamField(ParamField),
 }
 impl ::std::convert::From<&Self> for GeopathTransformPointRadius {
     fn from(value: &GeopathTransformPointRadius) -> Self {
@@ -37168,22 +37162,22 @@ impl ::std::convert::From<&Self> for GeopathTransformPointRadius {
 }
 impl ::std::convert::From<f64> for GeopathTransformPointRadius {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for GeopathTransformPointRadius {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 impl ::std::convert::From<Expr> for GeopathTransformPointRadius {
     fn from(value: Expr) -> Self {
-        Self::Variant2(value)
+        Self::Expr(value)
     }
 }
 impl ::std::convert::From<ParamField> for GeopathTransformPointRadius {
     fn from(value: ParamField) -> Self {
-        Self::Variant3(value)
+        Self::ParamField(value)
     }
 }
 #[doc = "`GeopathTransformType`"]
@@ -37390,8 +37384,8 @@ impl ::std::convert::From<&GeopointTransform> for GeopointTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum GeopointTransformAs {
-    Variant0([GeopointTransformAsVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([GeopointTransformAsArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for GeopointTransformAs {
     fn from(value: &GeopointTransformAs) -> Self {
@@ -37400,23 +37394,23 @@ impl ::std::convert::From<&Self> for GeopointTransformAs {
 }
 impl ::std::default::Default for GeopointTransformAs {
     fn default() -> Self {
-        GeopointTransformAs::Variant0([
-            GeopointTransformAsVariant0Item::Variant0("x".to_string()),
-            GeopointTransformAsVariant0Item::Variant0("y".to_string()),
+        GeopointTransformAs::Array([
+            GeopointTransformAsArrayItem::String("x".to_string()),
+            GeopointTransformAsArrayItem::String("y".to_string()),
         ])
     }
 }
-impl ::std::convert::From<[GeopointTransformAsVariant0Item; 2usize]> for GeopointTransformAs {
-    fn from(value: [GeopointTransformAsVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[GeopointTransformAsArrayItem; 2usize]> for GeopointTransformAs {
+    fn from(value: [GeopointTransformAsArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for GeopointTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`GeopointTransformAsVariant0Item`"]
+#[doc = "`GeopointTransformAsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37435,18 +37429,18 @@ impl ::std::convert::From<SignalRef> for GeopointTransformAs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum GeopointTransformAsVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum GeopointTransformAsArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for GeopointTransformAsVariant0Item {
-    fn from(value: &GeopointTransformAsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for GeopointTransformAsArrayItem {
+    fn from(value: &GeopointTransformAsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for GeopointTransformAsVariant0Item {
+impl ::std::convert::From<SignalRef> for GeopointTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`GeopointTransformFields`"]
@@ -37484,27 +37478,25 @@ impl ::std::convert::From<SignalRef> for GeopointTransformAsVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum GeopointTransformFields {
-    Variant0([GeopointTransformFieldsVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([GeopointTransformFieldsArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for GeopointTransformFields {
     fn from(value: &GeopointTransformFields) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<[GeopointTransformFieldsVariant0Item; 2usize]>
-    for GeopointTransformFields
-{
-    fn from(value: [GeopointTransformFieldsVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[GeopointTransformFieldsArrayItem; 2usize]> for GeopointTransformFields {
+    fn from(value: [GeopointTransformFieldsArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for GeopointTransformFields {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`GeopointTransformFieldsVariant0Item`"]
+#[doc = "`GeopointTransformFieldsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -37526,27 +37518,27 @@ impl ::std::convert::From<SignalRef> for GeopointTransformFields {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum GeopointTransformFieldsVariant0Item {
+pub enum GeopointTransformFieldsArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for GeopointTransformFieldsVariant0Item {
-    fn from(value: &GeopointTransformFieldsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for GeopointTransformFieldsArrayItem {
+    fn from(value: &GeopointTransformFieldsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<ScaleField> for GeopointTransformFieldsVariant0Item {
+impl ::std::convert::From<ScaleField> for GeopointTransformFieldsArrayItem {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
     }
 }
-impl ::std::convert::From<ParamField> for GeopointTransformFieldsVariant0Item {
+impl ::std::convert::From<ParamField> for GeopointTransformFieldsArrayItem {
     fn from(value: ParamField) -> Self {
         Self::ParamField(value)
     }
 }
-impl ::std::convert::From<Expr> for GeopointTransformFieldsVariant0Item {
+impl ::std::convert::From<Expr> for GeopointTransformFieldsArrayItem {
     fn from(value: Expr) -> Self {
         Self::Expr(value)
     }
@@ -37736,8 +37728,8 @@ impl ::std::convert::From<&GeoshapeTransform> for GeoshapeTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum GeoshapeTransformAs {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for GeoshapeTransformAs {
     fn from(value: &GeoshapeTransformAs) -> Self {
@@ -37746,12 +37738,12 @@ impl ::std::convert::From<&Self> for GeoshapeTransformAs {
 }
 impl ::std::default::Default for GeoshapeTransformAs {
     fn default() -> Self {
-        GeoshapeTransformAs::Variant0("shape".to_string())
+        GeoshapeTransformAs::String("shape".to_string())
     }
 }
 impl ::std::convert::From<SignalRef> for GeoshapeTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`GeoshapeTransformField`"]
@@ -37789,9 +37781,7 @@ impl ::std::convert::From<&Self> for GeoshapeTransformField {
 }
 impl ::std::default::Default for GeoshapeTransformField {
     fn default() -> Self {
-        GeoshapeTransformField::ScaleField(ScaleField(StringOrSignal::Variant0(
-            "datum".to_string(),
-        )))
+        GeoshapeTransformField::ScaleField(ScaleField(StringOrSignal::String("datum".to_string())))
     }
 }
 impl ::std::convert::From<ScaleField> for GeoshapeTransformField {
@@ -37835,10 +37825,10 @@ impl ::std::convert::From<Expr> for GeoshapeTransformField {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum GeoshapeTransformPointRadius {
-    Variant0(f64),
-    Variant1(SignalRef),
-    Variant2(Expr),
-    Variant3(ParamField),
+    Number(f64),
+    SignalRef(SignalRef),
+    Expr(Expr),
+    ParamField(ParamField),
 }
 impl ::std::convert::From<&Self> for GeoshapeTransformPointRadius {
     fn from(value: &GeoshapeTransformPointRadius) -> Self {
@@ -37847,22 +37837,22 @@ impl ::std::convert::From<&Self> for GeoshapeTransformPointRadius {
 }
 impl ::std::convert::From<f64> for GeoshapeTransformPointRadius {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for GeoshapeTransformPointRadius {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 impl ::std::convert::From<Expr> for GeoshapeTransformPointRadius {
     fn from(value: Expr) -> Self {
-        Self::Variant2(value)
+        Self::Expr(value)
     }
 }
 impl ::std::convert::From<ParamField> for GeoshapeTransformPointRadius {
     fn from(value: ParamField) -> Self {
-        Self::Variant3(value)
+        Self::ParamField(value)
     }
 }
 #[doc = "`GeoshapeTransformType`"]
@@ -38232,8 +38222,8 @@ impl ::std::convert::From<&GraticuleTransform> for GraticuleTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum GraticuleTransformExtent {
-    Variant0([::serde_json::Value; 2usize]),
-    Variant1(SignalRef),
+    Array([::serde_json::Value; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for GraticuleTransformExtent {
     fn from(value: &GraticuleTransformExtent) -> Self {
@@ -38242,12 +38232,12 @@ impl ::std::convert::From<&Self> for GraticuleTransformExtent {
 }
 impl ::std::convert::From<[::serde_json::Value; 2usize]> for GraticuleTransformExtent {
     fn from(value: [::serde_json::Value; 2usize]) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for GraticuleTransformExtent {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`GraticuleTransformExtentMajor`"]
@@ -38273,8 +38263,8 @@ impl ::std::convert::From<SignalRef> for GraticuleTransformExtent {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum GraticuleTransformExtentMajor {
-    Variant0([::serde_json::Value; 2usize]),
-    Variant1(SignalRef),
+    Array([::serde_json::Value; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for GraticuleTransformExtentMajor {
     fn from(value: &GraticuleTransformExtentMajor) -> Self {
@@ -38283,12 +38273,12 @@ impl ::std::convert::From<&Self> for GraticuleTransformExtentMajor {
 }
 impl ::std::convert::From<[::serde_json::Value; 2usize]> for GraticuleTransformExtentMajor {
     fn from(value: [::serde_json::Value; 2usize]) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for GraticuleTransformExtentMajor {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`GraticuleTransformExtentMinor`"]
@@ -38314,8 +38304,8 @@ impl ::std::convert::From<SignalRef> for GraticuleTransformExtentMajor {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum GraticuleTransformExtentMinor {
-    Variant0([::serde_json::Value; 2usize]),
-    Variant1(SignalRef),
+    Array([::serde_json::Value; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for GraticuleTransformExtentMinor {
     fn from(value: &GraticuleTransformExtentMinor) -> Self {
@@ -38324,12 +38314,12 @@ impl ::std::convert::From<&Self> for GraticuleTransformExtentMinor {
 }
 impl ::std::convert::From<[::serde_json::Value; 2usize]> for GraticuleTransformExtentMinor {
     fn from(value: [::serde_json::Value; 2usize]) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for GraticuleTransformExtentMinor {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`GraticuleTransformPrecision`"]
@@ -38353,8 +38343,8 @@ impl ::std::convert::From<SignalRef> for GraticuleTransformExtentMinor {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum GraticuleTransformPrecision {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for GraticuleTransformPrecision {
     fn from(value: &GraticuleTransformPrecision) -> Self {
@@ -38363,17 +38353,17 @@ impl ::std::convert::From<&Self> for GraticuleTransformPrecision {
 }
 impl ::std::default::Default for GraticuleTransformPrecision {
     fn default() -> Self {
-        GraticuleTransformPrecision::Variant0(2.5_f64)
+        GraticuleTransformPrecision::Number(2.5_f64)
     }
 }
 impl ::std::convert::From<f64> for GraticuleTransformPrecision {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for GraticuleTransformPrecision {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`GraticuleTransformStep`"]
@@ -38408,22 +38398,60 @@ impl ::std::convert::From<SignalRef> for GraticuleTransformPrecision {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum GraticuleTransformStep {
-    Variant0([GraticuleTransformStepVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([GraticuleTransformStepArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for GraticuleTransformStep {
     fn from(value: &GraticuleTransformStep) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<[GraticuleTransformStepVariant0Item; 2usize]> for GraticuleTransformStep {
-    fn from(value: [GraticuleTransformStepVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[GraticuleTransformStepArrayItem; 2usize]> for GraticuleTransformStep {
+    fn from(value: [GraticuleTransformStepArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for GraticuleTransformStep {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
+    }
+}
+#[doc = "`GraticuleTransformStepArrayItem`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"anyOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"number\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"$ref\": \"#/definitions/signalRef\""]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum GraticuleTransformStepArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
+}
+impl ::std::convert::From<&Self> for GraticuleTransformStepArrayItem {
+    fn from(value: &GraticuleTransformStepArrayItem) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<f64> for GraticuleTransformStepArrayItem {
+    fn from(value: f64) -> Self {
+        Self::Number(value)
+    }
+}
+impl ::std::convert::From<SignalRef> for GraticuleTransformStepArrayItem {
+    fn from(value: SignalRef) -> Self {
+        Self::SignalRef(value)
     }
 }
 #[doc = "`GraticuleTransformStepMajor`"]
@@ -38462,8 +38490,8 @@ impl ::std::convert::From<SignalRef> for GraticuleTransformStep {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum GraticuleTransformStepMajor {
-    Variant0([GraticuleTransformStepMajorVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([GraticuleTransformStepMajorArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for GraticuleTransformStepMajor {
     fn from(value: &GraticuleTransformStepMajor) -> Self {
@@ -38472,25 +38500,25 @@ impl ::std::convert::From<&Self> for GraticuleTransformStepMajor {
 }
 impl ::std::default::Default for GraticuleTransformStepMajor {
     fn default() -> Self {
-        GraticuleTransformStepMajor::Variant0([
-            GraticuleTransformStepMajorVariant0Item::Variant0(90_f64),
-            GraticuleTransformStepMajorVariant0Item::Variant0(360_f64),
+        GraticuleTransformStepMajor::Array([
+            GraticuleTransformStepMajorArrayItem::Number(90_f64),
+            GraticuleTransformStepMajorArrayItem::Number(360_f64),
         ])
     }
 }
-impl ::std::convert::From<[GraticuleTransformStepMajorVariant0Item; 2usize]>
+impl ::std::convert::From<[GraticuleTransformStepMajorArrayItem; 2usize]>
     for GraticuleTransformStepMajor
 {
-    fn from(value: [GraticuleTransformStepMajorVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+    fn from(value: [GraticuleTransformStepMajorArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for GraticuleTransformStepMajor {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`GraticuleTransformStepMajorVariant0Item`"]
+#[doc = "`GraticuleTransformStepMajorArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38509,23 +38537,23 @@ impl ::std::convert::From<SignalRef> for GraticuleTransformStepMajor {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum GraticuleTransformStepMajorVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum GraticuleTransformStepMajorArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for GraticuleTransformStepMajorVariant0Item {
-    fn from(value: &GraticuleTransformStepMajorVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for GraticuleTransformStepMajorArrayItem {
+    fn from(value: &GraticuleTransformStepMajorArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for GraticuleTransformStepMajorVariant0Item {
+impl ::std::convert::From<f64> for GraticuleTransformStepMajorArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for GraticuleTransformStepMajorVariant0Item {
+impl ::std::convert::From<SignalRef> for GraticuleTransformStepMajorArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`GraticuleTransformStepMinor`"]
@@ -38564,8 +38592,8 @@ impl ::std::convert::From<SignalRef> for GraticuleTransformStepMajorVariant0Item
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum GraticuleTransformStepMinor {
-    Variant0([GraticuleTransformStepMinorVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([GraticuleTransformStepMinorArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for GraticuleTransformStepMinor {
     fn from(value: &GraticuleTransformStepMinor) -> Self {
@@ -38574,25 +38602,25 @@ impl ::std::convert::From<&Self> for GraticuleTransformStepMinor {
 }
 impl ::std::default::Default for GraticuleTransformStepMinor {
     fn default() -> Self {
-        GraticuleTransformStepMinor::Variant0([
-            GraticuleTransformStepMinorVariant0Item::Variant0(10_f64),
-            GraticuleTransformStepMinorVariant0Item::Variant0(10_f64),
+        GraticuleTransformStepMinor::Array([
+            GraticuleTransformStepMinorArrayItem::Number(10_f64),
+            GraticuleTransformStepMinorArrayItem::Number(10_f64),
         ])
     }
 }
-impl ::std::convert::From<[GraticuleTransformStepMinorVariant0Item; 2usize]>
+impl ::std::convert::From<[GraticuleTransformStepMinorArrayItem; 2usize]>
     for GraticuleTransformStepMinor
 {
-    fn from(value: [GraticuleTransformStepMinorVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+    fn from(value: [GraticuleTransformStepMinorArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for GraticuleTransformStepMinor {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`GraticuleTransformStepMinorVariant0Item`"]
+#[doc = "`GraticuleTransformStepMinorArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -38611,61 +38639,23 @@ impl ::std::convert::From<SignalRef> for GraticuleTransformStepMinor {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum GraticuleTransformStepMinorVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum GraticuleTransformStepMinorArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for GraticuleTransformStepMinorVariant0Item {
-    fn from(value: &GraticuleTransformStepMinorVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for GraticuleTransformStepMinorArrayItem {
+    fn from(value: &GraticuleTransformStepMinorArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for GraticuleTransformStepMinorVariant0Item {
+impl ::std::convert::From<f64> for GraticuleTransformStepMinorArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for GraticuleTransformStepMinorVariant0Item {
+impl ::std::convert::From<SignalRef> for GraticuleTransformStepMinorArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
-    }
-}
-#[doc = "`GraticuleTransformStepVariant0Item`"]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"anyOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"type\": \"number\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/signalRef\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum GraticuleTransformStepVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for GraticuleTransformStepVariant0Item {
-    fn from(value: &GraticuleTransformStepVariant0Item) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<f64> for GraticuleTransformStepVariant0Item {
-    fn from(value: f64) -> Self {
-        Self::Variant0(value)
-    }
-}
-impl ::std::convert::From<SignalRef> for GraticuleTransformStepVariant0Item {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`GraticuleTransformType`"]
@@ -38929,8 +38919,8 @@ impl ::std::convert::From<&HeatmapTransform> for HeatmapTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum HeatmapTransformAs {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for HeatmapTransformAs {
     fn from(value: &HeatmapTransformAs) -> Self {
@@ -38939,12 +38929,12 @@ impl ::std::convert::From<&Self> for HeatmapTransformAs {
 }
 impl ::std::default::Default for HeatmapTransformAs {
     fn default() -> Self {
-        HeatmapTransformAs::Variant0("image".to_string())
+        HeatmapTransformAs::String("image".to_string())
     }
 }
 impl ::std::convert::From<SignalRef> for HeatmapTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`HeatmapTransformColor`"]
@@ -38973,10 +38963,10 @@ impl ::std::convert::From<SignalRef> for HeatmapTransformAs {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum HeatmapTransformColor {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
-    Variant2(Expr),
-    Variant3(ParamField),
+    String(::std::string::String),
+    SignalRef(SignalRef),
+    Expr(Expr),
+    ParamField(ParamField),
 }
 impl ::std::convert::From<&Self> for HeatmapTransformColor {
     fn from(value: &HeatmapTransformColor) -> Self {
@@ -38985,17 +38975,17 @@ impl ::std::convert::From<&Self> for HeatmapTransformColor {
 }
 impl ::std::convert::From<SignalRef> for HeatmapTransformColor {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 impl ::std::convert::From<Expr> for HeatmapTransformColor {
     fn from(value: Expr) -> Self {
-        Self::Variant2(value)
+        Self::Expr(value)
     }
 }
 impl ::std::convert::From<ParamField> for HeatmapTransformColor {
     fn from(value: ParamField) -> Self {
-        Self::Variant3(value)
+        Self::ParamField(value)
     }
 }
 #[doc = "`HeatmapTransformField`"]
@@ -39071,10 +39061,10 @@ impl ::std::convert::From<Expr> for HeatmapTransformField {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum HeatmapTransformOpacity {
-    Variant0(f64),
-    Variant1(SignalRef),
-    Variant2(Expr),
-    Variant3(ParamField),
+    Number(f64),
+    SignalRef(SignalRef),
+    Expr(Expr),
+    ParamField(ParamField),
 }
 impl ::std::convert::From<&Self> for HeatmapTransformOpacity {
     fn from(value: &HeatmapTransformOpacity) -> Self {
@@ -39083,22 +39073,22 @@ impl ::std::convert::From<&Self> for HeatmapTransformOpacity {
 }
 impl ::std::convert::From<f64> for HeatmapTransformOpacity {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for HeatmapTransformOpacity {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 impl ::std::convert::From<Expr> for HeatmapTransformOpacity {
     fn from(value: Expr) -> Self {
-        Self::Variant2(value)
+        Self::Expr(value)
     }
 }
 impl ::std::convert::From<ParamField> for HeatmapTransformOpacity {
     fn from(value: ParamField) -> Self {
-        Self::Variant3(value)
+        Self::ParamField(value)
     }
 }
 #[doc = "`HeatmapTransformResolve`"]
@@ -39365,8 +39355,8 @@ impl ::std::convert::From<&IdentifierTransform> for IdentifierTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum IdentifierTransformAs {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for IdentifierTransformAs {
     fn from(value: &IdentifierTransformAs) -> Self {
@@ -39375,7 +39365,7 @@ impl ::std::convert::From<&Self> for IdentifierTransformAs {
 }
 impl ::std::convert::From<SignalRef> for IdentifierTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`IdentifierTransformType`"]
@@ -39656,27 +39646,27 @@ impl ::std::convert::From<Expr> for ImputeTransformField {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ImputeTransformGroupby {
-    Variant0(::std::vec::Vec<ImputeTransformGroupbyVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<ImputeTransformGroupbyArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ImputeTransformGroupby {
     fn from(value: &ImputeTransformGroupby) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ImputeTransformGroupbyVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<ImputeTransformGroupbyArrayItem>>
     for ImputeTransformGroupby
 {
-    fn from(value: ::std::vec::Vec<ImputeTransformGroupbyVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<ImputeTransformGroupbyArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ImputeTransformGroupby {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ImputeTransformGroupbyVariant0Item`"]
+#[doc = "`ImputeTransformGroupbyArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -39698,27 +39688,27 @@ impl ::std::convert::From<SignalRef> for ImputeTransformGroupby {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ImputeTransformGroupbyVariant0Item {
+pub enum ImputeTransformGroupbyArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for ImputeTransformGroupbyVariant0Item {
-    fn from(value: &ImputeTransformGroupbyVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for ImputeTransformGroupbyArrayItem {
+    fn from(value: &ImputeTransformGroupbyArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<ScaleField> for ImputeTransformGroupbyVariant0Item {
+impl ::std::convert::From<ScaleField> for ImputeTransformGroupbyArrayItem {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
     }
 }
-impl ::std::convert::From<ParamField> for ImputeTransformGroupbyVariant0Item {
+impl ::std::convert::From<ParamField> for ImputeTransformGroupbyArrayItem {
     fn from(value: ParamField) -> Self {
         Self::ParamField(value)
     }
 }
-impl ::std::convert::From<Expr> for ImputeTransformGroupbyVariant0Item {
+impl ::std::convert::From<Expr> for ImputeTransformGroupbyArrayItem {
     fn from(value: Expr) -> Self {
         Self::Expr(value)
     }
@@ -39791,8 +39781,8 @@ impl ::std::convert::From<Expr> for ImputeTransformKey {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ImputeTransformKeyvals {
-    Variant0(::std::vec::Vec<::serde_json::Value>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<::serde_json::Value>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ImputeTransformKeyvals {
     fn from(value: &ImputeTransformKeyvals) -> Self {
@@ -39801,12 +39791,12 @@ impl ::std::convert::From<&Self> for ImputeTransformKeyvals {
 }
 impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ImputeTransformKeyvals {
     fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ImputeTransformKeyvals {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ImputeTransformMethod`"]
@@ -40247,9 +40237,9 @@ impl ::std::convert::From<&IsocontourTransform> for IsocontourTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum IsocontourTransformAs {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
-    Variant2,
+    String(::std::string::String),
+    SignalRef(SignalRef),
+    Null,
 }
 impl ::std::convert::From<&Self> for IsocontourTransformAs {
     fn from(value: &IsocontourTransformAs) -> Self {
@@ -40258,12 +40248,12 @@ impl ::std::convert::From<&Self> for IsocontourTransformAs {
 }
 impl ::std::default::Default for IsocontourTransformAs {
     fn default() -> Self {
-        IsocontourTransformAs::Variant0("contour".to_string())
+        IsocontourTransformAs::String("contour".to_string())
     }
 }
 impl ::std::convert::From<SignalRef> for IsocontourTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`IsocontourTransformField`"]
@@ -40333,8 +40323,8 @@ impl ::std::convert::From<Expr> for IsocontourTransformField {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum IsocontourTransformLevels {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for IsocontourTransformLevels {
     fn from(value: &IsocontourTransformLevels) -> Self {
@@ -40343,12 +40333,12 @@ impl ::std::convert::From<&Self> for IsocontourTransformLevels {
 }
 impl ::std::convert::From<f64> for IsocontourTransformLevels {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for IsocontourTransformLevels {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`IsocontourTransformNice`"]
@@ -40371,8 +40361,8 @@ impl ::std::convert::From<SignalRef> for IsocontourTransformLevels {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum IsocontourTransformNice {
-    Variant0(bool),
-    Variant1(SignalRef),
+    Boolean(bool),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for IsocontourTransformNice {
     fn from(value: &IsocontourTransformNice) -> Self {
@@ -40381,12 +40371,12 @@ impl ::std::convert::From<&Self> for IsocontourTransformNice {
 }
 impl ::std::convert::From<bool> for IsocontourTransformNice {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<SignalRef> for IsocontourTransformNice {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`IsocontourTransformResolve`"]
@@ -40538,10 +40528,10 @@ impl ::std::convert::TryFrom<::std::string::String> for IsocontourTransformResol
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum IsocontourTransformScale {
-    Variant0(f64),
-    Variant1(SignalRef),
-    Variant2(Expr),
-    Variant3(ParamField),
+    Number(f64),
+    SignalRef(SignalRef),
+    Expr(Expr),
+    ParamField(ParamField),
 }
 impl ::std::convert::From<&Self> for IsocontourTransformScale {
     fn from(value: &IsocontourTransformScale) -> Self {
@@ -40550,22 +40540,22 @@ impl ::std::convert::From<&Self> for IsocontourTransformScale {
 }
 impl ::std::convert::From<f64> for IsocontourTransformScale {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for IsocontourTransformScale {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 impl ::std::convert::From<Expr> for IsocontourTransformScale {
     fn from(value: Expr) -> Self {
-        Self::Variant2(value)
+        Self::Expr(value)
     }
 }
 impl ::std::convert::From<ParamField> for IsocontourTransformScale {
     fn from(value: ParamField) -> Self {
-        Self::Variant3(value)
+        Self::ParamField(value)
     }
 }
 #[doc = "`IsocontourTransformSmooth`"]
@@ -40589,8 +40579,8 @@ impl ::std::convert::From<ParamField> for IsocontourTransformScale {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum IsocontourTransformSmooth {
-    Variant0(bool),
-    Variant1(SignalRef),
+    Boolean(bool),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for IsocontourTransformSmooth {
     fn from(value: &IsocontourTransformSmooth) -> Self {
@@ -40599,17 +40589,17 @@ impl ::std::convert::From<&Self> for IsocontourTransformSmooth {
 }
 impl ::std::default::Default for IsocontourTransformSmooth {
     fn default() -> Self {
-        IsocontourTransformSmooth::Variant0(true)
+        IsocontourTransformSmooth::Boolean(true)
     }
 }
 impl ::std::convert::From<bool> for IsocontourTransformSmooth {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<SignalRef> for IsocontourTransformSmooth {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`IsocontourTransformThresholds`"]
@@ -40642,27 +40632,27 @@ impl ::std::convert::From<SignalRef> for IsocontourTransformSmooth {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum IsocontourTransformThresholds {
-    Variant0(::std::vec::Vec<IsocontourTransformThresholdsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<IsocontourTransformThresholdsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for IsocontourTransformThresholds {
     fn from(value: &IsocontourTransformThresholds) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<IsocontourTransformThresholdsVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<IsocontourTransformThresholdsArrayItem>>
     for IsocontourTransformThresholds
 {
-    fn from(value: ::std::vec::Vec<IsocontourTransformThresholdsVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<IsocontourTransformThresholdsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for IsocontourTransformThresholds {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`IsocontourTransformThresholdsVariant0Item`"]
+#[doc = "`IsocontourTransformThresholdsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40681,23 +40671,23 @@ impl ::std::convert::From<SignalRef> for IsocontourTransformThresholds {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum IsocontourTransformThresholdsVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum IsocontourTransformThresholdsArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for IsocontourTransformThresholdsVariant0Item {
-    fn from(value: &IsocontourTransformThresholdsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for IsocontourTransformThresholdsArrayItem {
+    fn from(value: &IsocontourTransformThresholdsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for IsocontourTransformThresholdsVariant0Item {
+impl ::std::convert::From<f64> for IsocontourTransformThresholdsArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for IsocontourTransformThresholdsVariant0Item {
+impl ::std::convert::From<SignalRef> for IsocontourTransformThresholdsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`IsocontourTransformTranslate`"]
@@ -40736,27 +40726,27 @@ impl ::std::convert::From<SignalRef> for IsocontourTransformThresholdsVariant0It
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum IsocontourTransformTranslate {
-    Variant0(::std::vec::Vec<IsocontourTransformTranslateVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<IsocontourTransformTranslateArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for IsocontourTransformTranslate {
     fn from(value: &IsocontourTransformTranslate) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<IsocontourTransformTranslateVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<IsocontourTransformTranslateArrayItem>>
     for IsocontourTransformTranslate
 {
-    fn from(value: ::std::vec::Vec<IsocontourTransformTranslateVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<IsocontourTransformTranslateArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for IsocontourTransformTranslate {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`IsocontourTransformTranslateVariant0Item`"]
+#[doc = "`IsocontourTransformTranslateArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -40781,35 +40771,35 @@ impl ::std::convert::From<SignalRef> for IsocontourTransformTranslate {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum IsocontourTransformTranslateVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
-    Variant2(Expr),
-    Variant3(ParamField),
+pub enum IsocontourTransformTranslateArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
+    Expr(Expr),
+    ParamField(ParamField),
 }
-impl ::std::convert::From<&Self> for IsocontourTransformTranslateVariant0Item {
-    fn from(value: &IsocontourTransformTranslateVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for IsocontourTransformTranslateArrayItem {
+    fn from(value: &IsocontourTransformTranslateArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for IsocontourTransformTranslateVariant0Item {
+impl ::std::convert::From<f64> for IsocontourTransformTranslateArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for IsocontourTransformTranslateVariant0Item {
+impl ::std::convert::From<SignalRef> for IsocontourTransformTranslateArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-impl ::std::convert::From<Expr> for IsocontourTransformTranslateVariant0Item {
+impl ::std::convert::From<Expr> for IsocontourTransformTranslateArrayItem {
     fn from(value: Expr) -> Self {
-        Self::Variant2(value)
+        Self::Expr(value)
     }
 }
-impl ::std::convert::From<ParamField> for IsocontourTransformTranslateVariant0Item {
+impl ::std::convert::From<ParamField> for IsocontourTransformTranslateArrayItem {
     fn from(value: ParamField) -> Self {
-        Self::Variant3(value)
+        Self::ParamField(value)
     }
 }
 #[doc = "`IsocontourTransformType`"]
@@ -40904,8 +40894,8 @@ impl ::std::convert::TryFrom<::std::string::String> for IsocontourTransformType 
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum IsocontourTransformZero {
-    Variant0(bool),
-    Variant1(SignalRef),
+    Boolean(bool),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for IsocontourTransformZero {
     fn from(value: &IsocontourTransformZero) -> Self {
@@ -40914,17 +40904,17 @@ impl ::std::convert::From<&Self> for IsocontourTransformZero {
 }
 impl ::std::default::Default for IsocontourTransformZero {
     fn default() -> Self {
-        IsocontourTransformZero::Variant0(true)
+        IsocontourTransformZero::Boolean(true)
     }
 }
 impl ::std::convert::From<bool> for IsocontourTransformZero {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<SignalRef> for IsocontourTransformZero {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`JoinaggregateTransform`"]
@@ -41141,27 +41131,27 @@ impl ::std::convert::From<&JoinaggregateTransform> for JoinaggregateTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformAs {
-    Variant0(::std::vec::Vec<JoinaggregateTransformAsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<JoinaggregateTransformAsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for JoinaggregateTransformAs {
     fn from(value: &JoinaggregateTransformAs) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<JoinaggregateTransformAsVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<JoinaggregateTransformAsArrayItem>>
     for JoinaggregateTransformAs
 {
-    fn from(value: ::std::vec::Vec<JoinaggregateTransformAsVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<JoinaggregateTransformAsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for JoinaggregateTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`JoinaggregateTransformAsVariant0Item`"]
+#[doc = "`JoinaggregateTransformAsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41183,19 +41173,19 @@ impl ::std::convert::From<SignalRef> for JoinaggregateTransformAs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum JoinaggregateTransformAsVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
-    Variant2,
+pub enum JoinaggregateTransformAsArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
+    Null,
 }
-impl ::std::convert::From<&Self> for JoinaggregateTransformAsVariant0Item {
-    fn from(value: &JoinaggregateTransformAsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for JoinaggregateTransformAsArrayItem {
+    fn from(value: &JoinaggregateTransformAsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for JoinaggregateTransformAsVariant0Item {
+impl ::std::convert::From<SignalRef> for JoinaggregateTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`JoinaggregateTransformFields`"]
@@ -41234,27 +41224,27 @@ impl ::std::convert::From<SignalRef> for JoinaggregateTransformAsVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformFields {
-    Variant0(::std::vec::Vec<JoinaggregateTransformFieldsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<JoinaggregateTransformFieldsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for JoinaggregateTransformFields {
     fn from(value: &JoinaggregateTransformFields) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<JoinaggregateTransformFieldsVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<JoinaggregateTransformFieldsArrayItem>>
     for JoinaggregateTransformFields
 {
-    fn from(value: ::std::vec::Vec<JoinaggregateTransformFieldsVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<JoinaggregateTransformFieldsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for JoinaggregateTransformFields {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`JoinaggregateTransformFieldsVariant0Item`"]
+#[doc = "`JoinaggregateTransformFieldsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41279,30 +41269,30 @@ impl ::std::convert::From<SignalRef> for JoinaggregateTransformFields {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum JoinaggregateTransformFieldsVariant0Item {
-    Variant0(ScaleField),
-    Variant1(ParamField),
-    Variant2(Expr),
-    Variant3,
+pub enum JoinaggregateTransformFieldsArrayItem {
+    ScaleField(ScaleField),
+    ParamField(ParamField),
+    Expr(Expr),
+    Null,
 }
-impl ::std::convert::From<&Self> for JoinaggregateTransformFieldsVariant0Item {
-    fn from(value: &JoinaggregateTransformFieldsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for JoinaggregateTransformFieldsArrayItem {
+    fn from(value: &JoinaggregateTransformFieldsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<ScaleField> for JoinaggregateTransformFieldsVariant0Item {
+impl ::std::convert::From<ScaleField> for JoinaggregateTransformFieldsArrayItem {
     fn from(value: ScaleField) -> Self {
-        Self::Variant0(value)
+        Self::ScaleField(value)
     }
 }
-impl ::std::convert::From<ParamField> for JoinaggregateTransformFieldsVariant0Item {
+impl ::std::convert::From<ParamField> for JoinaggregateTransformFieldsArrayItem {
     fn from(value: ParamField) -> Self {
-        Self::Variant1(value)
+        Self::ParamField(value)
     }
 }
-impl ::std::convert::From<Expr> for JoinaggregateTransformFieldsVariant0Item {
+impl ::std::convert::From<Expr> for JoinaggregateTransformFieldsArrayItem {
     fn from(value: Expr) -> Self {
-        Self::Variant2(value)
+        Self::Expr(value)
     }
 }
 #[doc = "`JoinaggregateTransformGroupby`"]
@@ -41338,27 +41328,27 @@ impl ::std::convert::From<Expr> for JoinaggregateTransformFieldsVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformGroupby {
-    Variant0(::std::vec::Vec<JoinaggregateTransformGroupbyVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<JoinaggregateTransformGroupbyArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for JoinaggregateTransformGroupby {
     fn from(value: &JoinaggregateTransformGroupby) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<JoinaggregateTransformGroupbyVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<JoinaggregateTransformGroupbyArrayItem>>
     for JoinaggregateTransformGroupby
 {
-    fn from(value: ::std::vec::Vec<JoinaggregateTransformGroupbyVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<JoinaggregateTransformGroupbyArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for JoinaggregateTransformGroupby {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`JoinaggregateTransformGroupbyVariant0Item`"]
+#[doc = "`JoinaggregateTransformGroupbyArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41380,27 +41370,27 @@ impl ::std::convert::From<SignalRef> for JoinaggregateTransformGroupby {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum JoinaggregateTransformGroupbyVariant0Item {
+pub enum JoinaggregateTransformGroupbyArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for JoinaggregateTransformGroupbyVariant0Item {
-    fn from(value: &JoinaggregateTransformGroupbyVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for JoinaggregateTransformGroupbyArrayItem {
+    fn from(value: &JoinaggregateTransformGroupbyArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<ScaleField> for JoinaggregateTransformGroupbyVariant0Item {
+impl ::std::convert::From<ScaleField> for JoinaggregateTransformGroupbyArrayItem {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
     }
 }
-impl ::std::convert::From<ParamField> for JoinaggregateTransformGroupbyVariant0Item {
+impl ::std::convert::From<ParamField> for JoinaggregateTransformGroupbyArrayItem {
     fn from(value: ParamField) -> Self {
         Self::ParamField(value)
     }
 }
-impl ::std::convert::From<Expr> for JoinaggregateTransformGroupbyVariant0Item {
+impl ::std::convert::From<Expr> for JoinaggregateTransformGroupbyArrayItem {
     fn from(value: Expr) -> Self {
         Self::Expr(value)
     }
@@ -41507,27 +41497,27 @@ impl ::std::convert::From<Expr> for JoinaggregateTransformKey {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum JoinaggregateTransformOps {
-    Variant0(::std::vec::Vec<JoinaggregateTransformOpsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<JoinaggregateTransformOpsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for JoinaggregateTransformOps {
     fn from(value: &JoinaggregateTransformOps) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<JoinaggregateTransformOpsVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<JoinaggregateTransformOpsArrayItem>>
     for JoinaggregateTransformOps
 {
-    fn from(value: ::std::vec::Vec<JoinaggregateTransformOpsVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<JoinaggregateTransformOpsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for JoinaggregateTransformOps {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`JoinaggregateTransformOpsVariant0Item`"]
+#[doc = "`JoinaggregateTransformOpsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41571,28 +41561,28 @@ impl ::std::convert::From<SignalRef> for JoinaggregateTransformOps {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum JoinaggregateTransformOpsVariant0Item {
-    Variant0(JoinaggregateTransformOpsVariant0ItemVariant0),
+pub enum JoinaggregateTransformOpsArrayItem {
+    Variant0(JoinaggregateTransformOpsArrayItemVariant0),
     Variant1(SignalRef),
 }
-impl ::std::convert::From<&Self> for JoinaggregateTransformOpsVariant0Item {
-    fn from(value: &JoinaggregateTransformOpsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for JoinaggregateTransformOpsArrayItem {
+    fn from(value: &JoinaggregateTransformOpsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<JoinaggregateTransformOpsVariant0ItemVariant0>
-    for JoinaggregateTransformOpsVariant0Item
+impl ::std::convert::From<JoinaggregateTransformOpsArrayItemVariant0>
+    for JoinaggregateTransformOpsArrayItem
 {
-    fn from(value: JoinaggregateTransformOpsVariant0ItemVariant0) -> Self {
+    fn from(value: JoinaggregateTransformOpsArrayItemVariant0) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<SignalRef> for JoinaggregateTransformOpsVariant0Item {
+impl ::std::convert::From<SignalRef> for JoinaggregateTransformOpsArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`JoinaggregateTransformOpsVariant0ItemVariant0`"]
+#[doc = "`JoinaggregateTransformOpsArrayItemVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -41639,7 +41629,7 @@ impl ::std::convert::From<SignalRef> for JoinaggregateTransformOpsVariant0Item {
     PartialEq,
     PartialOrd,
 )]
-pub enum JoinaggregateTransformOpsVariant0ItemVariant0 {
+pub enum JoinaggregateTransformOpsArrayItemVariant0 {
     #[serde(rename = "values")]
     Values,
     #[serde(rename = "count")]
@@ -41689,12 +41679,12 @@ pub enum JoinaggregateTransformOpsVariant0ItemVariant0 {
     #[serde(rename = "argmax")]
     Argmax,
 }
-impl ::std::convert::From<&Self> for JoinaggregateTransformOpsVariant0ItemVariant0 {
-    fn from(value: &JoinaggregateTransformOpsVariant0ItemVariant0) -> Self {
+impl ::std::convert::From<&Self> for JoinaggregateTransformOpsArrayItemVariant0 {
+    fn from(value: &JoinaggregateTransformOpsArrayItemVariant0) -> Self {
         value.clone()
     }
 }
-impl ::std::fmt::Display for JoinaggregateTransformOpsVariant0ItemVariant0 {
+impl ::std::fmt::Display for JoinaggregateTransformOpsArrayItemVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
             Self::Values => f.write_str("values"),
@@ -41724,7 +41714,7 @@ impl ::std::fmt::Display for JoinaggregateTransformOpsVariant0ItemVariant0 {
         }
     }
 }
-impl ::std::str::FromStr for JoinaggregateTransformOpsVariant0ItemVariant0 {
+impl ::std::str::FromStr for JoinaggregateTransformOpsArrayItemVariant0 {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         match value {
@@ -41756,14 +41746,14 @@ impl ::std::str::FromStr for JoinaggregateTransformOpsVariant0ItemVariant0 {
         }
     }
 }
-impl ::std::convert::TryFrom<&str> for JoinaggregateTransformOpsVariant0ItemVariant0 {
+impl ::std::convert::TryFrom<&str> for JoinaggregateTransformOpsArrayItemVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl ::std::convert::TryFrom<&::std::string::String>
-    for JoinaggregateTransformOpsVariant0ItemVariant0
+    for JoinaggregateTransformOpsArrayItemVariant0
 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -41772,9 +41762,7 @@ impl ::std::convert::TryFrom<&::std::string::String>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<::std::string::String>
-    for JoinaggregateTransformOpsVariant0ItemVariant0
-{
+impl ::std::convert::TryFrom<::std::string::String> for JoinaggregateTransformOpsArrayItemVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: ::std::string::String,
@@ -42070,8 +42058,8 @@ impl ::std::convert::From<&Kde2dTransform> for Kde2dTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum Kde2dTransformAs {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for Kde2dTransformAs {
     fn from(value: &Kde2dTransformAs) -> Self {
@@ -42080,12 +42068,12 @@ impl ::std::convert::From<&Self> for Kde2dTransformAs {
 }
 impl ::std::default::Default for Kde2dTransformAs {
     fn default() -> Self {
-        Kde2dTransformAs::Variant0("grid".to_string())
+        Kde2dTransformAs::String("grid".to_string())
     }
 }
 impl ::std::convert::From<SignalRef> for Kde2dTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`Kde2dTransformBandwidth`"]
@@ -42120,27 +42108,25 @@ impl ::std::convert::From<SignalRef> for Kde2dTransformAs {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum Kde2dTransformBandwidth {
-    Variant0([Kde2dTransformBandwidthVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([Kde2dTransformBandwidthArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for Kde2dTransformBandwidth {
     fn from(value: &Kde2dTransformBandwidth) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<[Kde2dTransformBandwidthVariant0Item; 2usize]>
-    for Kde2dTransformBandwidth
-{
-    fn from(value: [Kde2dTransformBandwidthVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[Kde2dTransformBandwidthArrayItem; 2usize]> for Kde2dTransformBandwidth {
+    fn from(value: [Kde2dTransformBandwidthArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for Kde2dTransformBandwidth {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`Kde2dTransformBandwidthVariant0Item`"]
+#[doc = "`Kde2dTransformBandwidthArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42159,23 +42145,23 @@ impl ::std::convert::From<SignalRef> for Kde2dTransformBandwidth {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum Kde2dTransformBandwidthVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum Kde2dTransformBandwidthArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for Kde2dTransformBandwidthVariant0Item {
-    fn from(value: &Kde2dTransformBandwidthVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for Kde2dTransformBandwidthArrayItem {
+    fn from(value: &Kde2dTransformBandwidthArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for Kde2dTransformBandwidthVariant0Item {
+impl ::std::convert::From<f64> for Kde2dTransformBandwidthArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for Kde2dTransformBandwidthVariant0Item {
+impl ::std::convert::From<SignalRef> for Kde2dTransformBandwidthArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`Kde2dTransformCellSize`"]
@@ -42198,8 +42184,8 @@ impl ::std::convert::From<SignalRef> for Kde2dTransformBandwidthVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum Kde2dTransformCellSize {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for Kde2dTransformCellSize {
     fn from(value: &Kde2dTransformCellSize) -> Self {
@@ -42208,12 +42194,12 @@ impl ::std::convert::From<&Self> for Kde2dTransformCellSize {
 }
 impl ::std::convert::From<f64> for Kde2dTransformCellSize {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for Kde2dTransformCellSize {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`Kde2dTransformCounts`"]
@@ -42236,8 +42222,8 @@ impl ::std::convert::From<SignalRef> for Kde2dTransformCellSize {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum Kde2dTransformCounts {
-    Variant0(bool),
-    Variant1(SignalRef),
+    Boolean(bool),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for Kde2dTransformCounts {
     fn from(value: &Kde2dTransformCounts) -> Self {
@@ -42246,12 +42232,12 @@ impl ::std::convert::From<&Self> for Kde2dTransformCounts {
 }
 impl ::std::convert::From<bool> for Kde2dTransformCounts {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<SignalRef> for Kde2dTransformCounts {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`Kde2dTransformGroupby`"]
@@ -42287,27 +42273,27 @@ impl ::std::convert::From<SignalRef> for Kde2dTransformCounts {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum Kde2dTransformGroupby {
-    Variant0(::std::vec::Vec<Kde2dTransformGroupbyVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<Kde2dTransformGroupbyArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for Kde2dTransformGroupby {
     fn from(value: &Kde2dTransformGroupby) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<Kde2dTransformGroupbyVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<Kde2dTransformGroupbyArrayItem>>
     for Kde2dTransformGroupby
 {
-    fn from(value: ::std::vec::Vec<Kde2dTransformGroupbyVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<Kde2dTransformGroupbyArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for Kde2dTransformGroupby {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`Kde2dTransformGroupbyVariant0Item`"]
+#[doc = "`Kde2dTransformGroupbyArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42329,27 +42315,27 @@ impl ::std::convert::From<SignalRef> for Kde2dTransformGroupby {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum Kde2dTransformGroupbyVariant0Item {
+pub enum Kde2dTransformGroupbyArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for Kde2dTransformGroupbyVariant0Item {
-    fn from(value: &Kde2dTransformGroupbyVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for Kde2dTransformGroupbyArrayItem {
+    fn from(value: &Kde2dTransformGroupbyArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<ScaleField> for Kde2dTransformGroupbyVariant0Item {
+impl ::std::convert::From<ScaleField> for Kde2dTransformGroupbyArrayItem {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
     }
 }
-impl ::std::convert::From<ParamField> for Kde2dTransformGroupbyVariant0Item {
+impl ::std::convert::From<ParamField> for Kde2dTransformGroupbyArrayItem {
     fn from(value: ParamField) -> Self {
         Self::ParamField(value)
     }
 }
-impl ::std::convert::From<Expr> for Kde2dTransformGroupbyVariant0Item {
+impl ::std::convert::From<Expr> for Kde2dTransformGroupbyArrayItem {
     fn from(value: Expr) -> Self {
         Self::Expr(value)
     }
@@ -42386,25 +42372,25 @@ impl ::std::convert::From<Expr> for Kde2dTransformGroupbyVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum Kde2dTransformSize {
-    Variant0([Kde2dTransformSizeVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([Kde2dTransformSizeArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for Kde2dTransformSize {
     fn from(value: &Kde2dTransformSize) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<[Kde2dTransformSizeVariant0Item; 2usize]> for Kde2dTransformSize {
-    fn from(value: [Kde2dTransformSizeVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[Kde2dTransformSizeArrayItem; 2usize]> for Kde2dTransformSize {
+    fn from(value: [Kde2dTransformSizeArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for Kde2dTransformSize {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`Kde2dTransformSizeVariant0Item`"]
+#[doc = "`Kde2dTransformSizeArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42423,23 +42409,23 @@ impl ::std::convert::From<SignalRef> for Kde2dTransformSize {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum Kde2dTransformSizeVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum Kde2dTransformSizeArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for Kde2dTransformSizeVariant0Item {
-    fn from(value: &Kde2dTransformSizeVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for Kde2dTransformSizeArrayItem {
+    fn from(value: &Kde2dTransformSizeArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for Kde2dTransformSizeVariant0Item {
+impl ::std::convert::From<f64> for Kde2dTransformSizeArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for Kde2dTransformSizeVariant0Item {
+impl ::std::convert::From<SignalRef> for Kde2dTransformSizeArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`Kde2dTransformType`"]
@@ -42905,8 +42891,8 @@ impl ::std::convert::From<&KdeTransform> for KdeTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum KdeTransformAs {
-    Variant0(::std::vec::Vec<KdeTransformAsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<KdeTransformAsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for KdeTransformAs {
     fn from(value: &KdeTransformAs) -> Self {
@@ -42915,23 +42901,23 @@ impl ::std::convert::From<&Self> for KdeTransformAs {
 }
 impl ::std::default::Default for KdeTransformAs {
     fn default() -> Self {
-        KdeTransformAs::Variant0(vec![
-            KdeTransformAsVariant0Item::Variant0("value".to_string()),
-            KdeTransformAsVariant0Item::Variant0("density".to_string()),
+        KdeTransformAs::Array(vec![
+            KdeTransformAsArrayItem::String("value".to_string()),
+            KdeTransformAsArrayItem::String("density".to_string()),
         ])
     }
 }
-impl ::std::convert::From<::std::vec::Vec<KdeTransformAsVariant0Item>> for KdeTransformAs {
-    fn from(value: ::std::vec::Vec<KdeTransformAsVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<KdeTransformAsArrayItem>> for KdeTransformAs {
+    fn from(value: ::std::vec::Vec<KdeTransformAsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for KdeTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`KdeTransformAsVariant0Item`"]
+#[doc = "`KdeTransformAsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -42950,18 +42936,18 @@ impl ::std::convert::From<SignalRef> for KdeTransformAs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum KdeTransformAsVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum KdeTransformAsArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for KdeTransformAsVariant0Item {
-    fn from(value: &KdeTransformAsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for KdeTransformAsArrayItem {
+    fn from(value: &KdeTransformAsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for KdeTransformAsVariant0Item {
+impl ::std::convert::From<SignalRef> for KdeTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`KdeTransformBandwidth`"]
@@ -42984,8 +42970,8 @@ impl ::std::convert::From<SignalRef> for KdeTransformAsVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum KdeTransformBandwidth {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for KdeTransformBandwidth {
     fn from(value: &KdeTransformBandwidth) -> Self {
@@ -42994,12 +42980,12 @@ impl ::std::convert::From<&Self> for KdeTransformBandwidth {
 }
 impl ::std::convert::From<f64> for KdeTransformBandwidth {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for KdeTransformBandwidth {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`KdeTransformCounts`"]
@@ -43022,8 +43008,8 @@ impl ::std::convert::From<SignalRef> for KdeTransformBandwidth {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum KdeTransformCounts {
-    Variant0(bool),
-    Variant1(SignalRef),
+    Boolean(bool),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for KdeTransformCounts {
     fn from(value: &KdeTransformCounts) -> Self {
@@ -43032,12 +43018,12 @@ impl ::std::convert::From<&Self> for KdeTransformCounts {
 }
 impl ::std::convert::From<bool> for KdeTransformCounts {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<SignalRef> for KdeTransformCounts {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`KdeTransformCumulative`"]
@@ -43060,8 +43046,8 @@ impl ::std::convert::From<SignalRef> for KdeTransformCounts {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum KdeTransformCumulative {
-    Variant0(bool),
-    Variant1(SignalRef),
+    Boolean(bool),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for KdeTransformCumulative {
     fn from(value: &KdeTransformCumulative) -> Self {
@@ -43070,12 +43056,12 @@ impl ::std::convert::From<&Self> for KdeTransformCumulative {
 }
 impl ::std::convert::From<bool> for KdeTransformCumulative {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<SignalRef> for KdeTransformCumulative {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`KdeTransformExtent`"]
@@ -43110,25 +43096,25 @@ impl ::std::convert::From<SignalRef> for KdeTransformCumulative {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum KdeTransformExtent {
-    Variant0([KdeTransformExtentVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([KdeTransformExtentArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for KdeTransformExtent {
     fn from(value: &KdeTransformExtent) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<[KdeTransformExtentVariant0Item; 2usize]> for KdeTransformExtent {
-    fn from(value: [KdeTransformExtentVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[KdeTransformExtentArrayItem; 2usize]> for KdeTransformExtent {
+    fn from(value: [KdeTransformExtentArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for KdeTransformExtent {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`KdeTransformExtentVariant0Item`"]
+#[doc = "`KdeTransformExtentArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -43147,23 +43133,23 @@ impl ::std::convert::From<SignalRef> for KdeTransformExtent {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum KdeTransformExtentVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum KdeTransformExtentArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for KdeTransformExtentVariant0Item {
-    fn from(value: &KdeTransformExtentVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for KdeTransformExtentArrayItem {
+    fn from(value: &KdeTransformExtentArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for KdeTransformExtentVariant0Item {
+impl ::std::convert::From<f64> for KdeTransformExtentArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for KdeTransformExtentVariant0Item {
+impl ::std::convert::From<SignalRef> for KdeTransformExtentArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`KdeTransformField`"]
@@ -43246,27 +43232,25 @@ impl ::std::convert::From<Expr> for KdeTransformField {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum KdeTransformGroupby {
-    Variant0(::std::vec::Vec<KdeTransformGroupbyVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<KdeTransformGroupbyArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for KdeTransformGroupby {
     fn from(value: &KdeTransformGroupby) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<KdeTransformGroupbyVariant0Item>>
-    for KdeTransformGroupby
-{
-    fn from(value: ::std::vec::Vec<KdeTransformGroupbyVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<KdeTransformGroupbyArrayItem>> for KdeTransformGroupby {
+    fn from(value: ::std::vec::Vec<KdeTransformGroupbyArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for KdeTransformGroupby {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`KdeTransformGroupbyVariant0Item`"]
+#[doc = "`KdeTransformGroupbyArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -43288,27 +43272,27 @@ impl ::std::convert::From<SignalRef> for KdeTransformGroupby {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum KdeTransformGroupbyVariant0Item {
+pub enum KdeTransformGroupbyArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for KdeTransformGroupbyVariant0Item {
-    fn from(value: &KdeTransformGroupbyVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for KdeTransformGroupbyArrayItem {
+    fn from(value: &KdeTransformGroupbyArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<ScaleField> for KdeTransformGroupbyVariant0Item {
+impl ::std::convert::From<ScaleField> for KdeTransformGroupbyArrayItem {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
     }
 }
-impl ::std::convert::From<ParamField> for KdeTransformGroupbyVariant0Item {
+impl ::std::convert::From<ParamField> for KdeTransformGroupbyArrayItem {
     fn from(value: ParamField) -> Self {
         Self::ParamField(value)
     }
 }
-impl ::std::convert::From<Expr> for KdeTransformGroupbyVariant0Item {
+impl ::std::convert::From<Expr> for KdeTransformGroupbyArrayItem {
     fn from(value: Expr) -> Self {
         Self::Expr(value)
     }
@@ -43334,8 +43318,8 @@ impl ::std::convert::From<Expr> for KdeTransformGroupbyVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum KdeTransformMaxsteps {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for KdeTransformMaxsteps {
     fn from(value: &KdeTransformMaxsteps) -> Self {
@@ -43344,17 +43328,17 @@ impl ::std::convert::From<&Self> for KdeTransformMaxsteps {
 }
 impl ::std::default::Default for KdeTransformMaxsteps {
     fn default() -> Self {
-        KdeTransformMaxsteps::Variant0(200_f64)
+        KdeTransformMaxsteps::Number(200_f64)
     }
 }
 impl ::std::convert::From<f64> for KdeTransformMaxsteps {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for KdeTransformMaxsteps {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`KdeTransformMinsteps`"]
@@ -43378,8 +43362,8 @@ impl ::std::convert::From<SignalRef> for KdeTransformMaxsteps {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum KdeTransformMinsteps {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for KdeTransformMinsteps {
     fn from(value: &KdeTransformMinsteps) -> Self {
@@ -43388,17 +43372,17 @@ impl ::std::convert::From<&Self> for KdeTransformMinsteps {
 }
 impl ::std::default::Default for KdeTransformMinsteps {
     fn default() -> Self {
-        KdeTransformMinsteps::Variant0(25_f64)
+        KdeTransformMinsteps::Number(25_f64)
     }
 }
 impl ::std::convert::From<f64> for KdeTransformMinsteps {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for KdeTransformMinsteps {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`KdeTransformResolve`"]
@@ -43544,8 +43528,8 @@ impl ::std::convert::TryFrom<::std::string::String> for KdeTransformResolveVaria
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum KdeTransformSteps {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for KdeTransformSteps {
     fn from(value: &KdeTransformSteps) -> Self {
@@ -43554,12 +43538,12 @@ impl ::std::convert::From<&Self> for KdeTransformSteps {
 }
 impl ::std::convert::From<f64> for KdeTransformSteps {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for KdeTransformSteps {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`KdeTransformType`"]
@@ -44048,8 +44032,8 @@ impl ::std::convert::From<&LabelTransform> for LabelTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LabelTransformAnchor {
-    Variant0(::std::vec::Vec<LabelTransformAnchorVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<LabelTransformAnchorArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for LabelTransformAnchor {
     fn from(value: &LabelTransformAnchor) -> Self {
@@ -44058,31 +44042,29 @@ impl ::std::convert::From<&Self> for LabelTransformAnchor {
 }
 impl ::std::default::Default for LabelTransformAnchor {
     fn default() -> Self {
-        LabelTransformAnchor::Variant0(vec![
-            LabelTransformAnchorVariant0Item::Variant0("top-left".to_string()),
-            LabelTransformAnchorVariant0Item::Variant0("left".to_string()),
-            LabelTransformAnchorVariant0Item::Variant0("bottom-left".to_string()),
-            LabelTransformAnchorVariant0Item::Variant0("top".to_string()),
-            LabelTransformAnchorVariant0Item::Variant0("bottom".to_string()),
-            LabelTransformAnchorVariant0Item::Variant0("top-right".to_string()),
-            LabelTransformAnchorVariant0Item::Variant0("right".to_string()),
-            LabelTransformAnchorVariant0Item::Variant0("bottom-right".to_string()),
+        LabelTransformAnchor::Array(vec![
+            LabelTransformAnchorArrayItem::String("top-left".to_string()),
+            LabelTransformAnchorArrayItem::String("left".to_string()),
+            LabelTransformAnchorArrayItem::String("bottom-left".to_string()),
+            LabelTransformAnchorArrayItem::String("top".to_string()),
+            LabelTransformAnchorArrayItem::String("bottom".to_string()),
+            LabelTransformAnchorArrayItem::String("top-right".to_string()),
+            LabelTransformAnchorArrayItem::String("right".to_string()),
+            LabelTransformAnchorArrayItem::String("bottom-right".to_string()),
         ])
     }
 }
-impl ::std::convert::From<::std::vec::Vec<LabelTransformAnchorVariant0Item>>
-    for LabelTransformAnchor
-{
-    fn from(value: ::std::vec::Vec<LabelTransformAnchorVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<LabelTransformAnchorArrayItem>> for LabelTransformAnchor {
+    fn from(value: ::std::vec::Vec<LabelTransformAnchorArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for LabelTransformAnchor {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`LabelTransformAnchorVariant0Item`"]
+#[doc = "`LabelTransformAnchorArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44101,18 +44083,18 @@ impl ::std::convert::From<SignalRef> for LabelTransformAnchor {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum LabelTransformAnchorVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum LabelTransformAnchorArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for LabelTransformAnchorVariant0Item {
-    fn from(value: &LabelTransformAnchorVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for LabelTransformAnchorArrayItem {
+    fn from(value: &LabelTransformAnchorArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for LabelTransformAnchorVariant0Item {
+impl ::std::convert::From<SignalRef> for LabelTransformAnchorArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`LabelTransformAs`"]
@@ -44154,8 +44136,8 @@ impl ::std::convert::From<SignalRef> for LabelTransformAnchorVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LabelTransformAs {
-    Variant0([LabelTransformAsVariant0Item; 5usize]),
-    Variant1(SignalRef),
+    Array([LabelTransformAsArrayItem; 5usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for LabelTransformAs {
     fn from(value: &LabelTransformAs) -> Self {
@@ -44164,26 +44146,26 @@ impl ::std::convert::From<&Self> for LabelTransformAs {
 }
 impl ::std::default::Default for LabelTransformAs {
     fn default() -> Self {
-        LabelTransformAs::Variant0([
-            LabelTransformAsVariant0Item::Variant0("x".to_string()),
-            LabelTransformAsVariant0Item::Variant0("y".to_string()),
-            LabelTransformAsVariant0Item::Variant0("opacity".to_string()),
-            LabelTransformAsVariant0Item::Variant0("align".to_string()),
-            LabelTransformAsVariant0Item::Variant0("baseline".to_string()),
+        LabelTransformAs::Array([
+            LabelTransformAsArrayItem::String("x".to_string()),
+            LabelTransformAsArrayItem::String("y".to_string()),
+            LabelTransformAsArrayItem::String("opacity".to_string()),
+            LabelTransformAsArrayItem::String("align".to_string()),
+            LabelTransformAsArrayItem::String("baseline".to_string()),
         ])
     }
 }
-impl ::std::convert::From<[LabelTransformAsVariant0Item; 5usize]> for LabelTransformAs {
-    fn from(value: [LabelTransformAsVariant0Item; 5usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[LabelTransformAsArrayItem; 5usize]> for LabelTransformAs {
+    fn from(value: [LabelTransformAsArrayItem; 5usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for LabelTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`LabelTransformAsVariant0Item`"]
+#[doc = "`LabelTransformAsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44202,18 +44184,18 @@ impl ::std::convert::From<SignalRef> for LabelTransformAs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum LabelTransformAsVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum LabelTransformAsArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for LabelTransformAsVariant0Item {
-    fn from(value: &LabelTransformAsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for LabelTransformAsArrayItem {
+    fn from(value: &LabelTransformAsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for LabelTransformAsVariant0Item {
+impl ::std::convert::From<SignalRef> for LabelTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`LabelTransformAvoidBaseMark`"]
@@ -44237,8 +44219,8 @@ impl ::std::convert::From<SignalRef> for LabelTransformAsVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LabelTransformAvoidBaseMark {
-    Variant0(bool),
-    Variant1(SignalRef),
+    Boolean(bool),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for LabelTransformAvoidBaseMark {
     fn from(value: &LabelTransformAvoidBaseMark) -> Self {
@@ -44247,17 +44229,17 @@ impl ::std::convert::From<&Self> for LabelTransformAvoidBaseMark {
 }
 impl ::std::default::Default for LabelTransformAvoidBaseMark {
     fn default() -> Self {
-        LabelTransformAvoidBaseMark::Variant0(true)
+        LabelTransformAvoidBaseMark::Boolean(true)
     }
 }
 impl ::std::convert::From<bool> for LabelTransformAvoidBaseMark {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<SignalRef> for LabelTransformAvoidBaseMark {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`LabelTransformAvoidMarks`"]
@@ -44283,8 +44265,8 @@ impl ::std::convert::From<SignalRef> for LabelTransformAvoidBaseMark {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LabelTransformAvoidMarks {
-    Variant0(::std::vec::Vec<::std::string::String>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<::std::string::String>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for LabelTransformAvoidMarks {
     fn from(value: &LabelTransformAvoidMarks) -> Self {
@@ -44293,12 +44275,12 @@ impl ::std::convert::From<&Self> for LabelTransformAvoidMarks {
 }
 impl ::std::convert::From<::std::vec::Vec<::std::string::String>> for LabelTransformAvoidMarks {
     fn from(value: ::std::vec::Vec<::std::string::String>) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for LabelTransformAvoidMarks {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`LabelTransformLineAnchor`"]
@@ -44322,8 +44304,8 @@ impl ::std::convert::From<SignalRef> for LabelTransformAvoidMarks {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LabelTransformLineAnchor {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for LabelTransformLineAnchor {
     fn from(value: &LabelTransformLineAnchor) -> Self {
@@ -44332,12 +44314,12 @@ impl ::std::convert::From<&Self> for LabelTransformLineAnchor {
 }
 impl ::std::default::Default for LabelTransformLineAnchor {
     fn default() -> Self {
-        LabelTransformLineAnchor::Variant0("end".to_string())
+        LabelTransformLineAnchor::String("end".to_string())
     }
 }
 impl ::std::convert::From<SignalRef> for LabelTransformLineAnchor {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`LabelTransformMarkIndex`"]
@@ -44360,8 +44342,8 @@ impl ::std::convert::From<SignalRef> for LabelTransformLineAnchor {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LabelTransformMarkIndex {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for LabelTransformMarkIndex {
     fn from(value: &LabelTransformMarkIndex) -> Self {
@@ -44370,12 +44352,12 @@ impl ::std::convert::From<&Self> for LabelTransformMarkIndex {
 }
 impl ::std::convert::From<f64> for LabelTransformMarkIndex {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for LabelTransformMarkIndex {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`LabelTransformMethod`"]
@@ -44399,8 +44381,8 @@ impl ::std::convert::From<SignalRef> for LabelTransformMarkIndex {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LabelTransformMethod {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for LabelTransformMethod {
     fn from(value: &LabelTransformMethod) -> Self {
@@ -44409,12 +44391,12 @@ impl ::std::convert::From<&Self> for LabelTransformMethod {
 }
 impl ::std::default::Default for LabelTransformMethod {
     fn default() -> Self {
-        LabelTransformMethod::Variant0("naive".to_string())
+        LabelTransformMethod::String("naive".to_string())
     }
 }
 impl ::std::convert::From<SignalRef> for LabelTransformMethod {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`LabelTransformOffset`"]
@@ -44450,8 +44432,8 @@ impl ::std::convert::From<SignalRef> for LabelTransformMethod {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LabelTransformOffset {
-    Variant0(::std::vec::Vec<LabelTransformOffsetVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<LabelTransformOffsetArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for LabelTransformOffset {
     fn from(value: &LabelTransformOffset) -> Self {
@@ -44460,22 +44442,20 @@ impl ::std::convert::From<&Self> for LabelTransformOffset {
 }
 impl ::std::default::Default for LabelTransformOffset {
     fn default() -> Self {
-        LabelTransformOffset::Variant0(vec![LabelTransformOffsetVariant0Item::Variant0(1_f64)])
+        LabelTransformOffset::Array(vec![LabelTransformOffsetArrayItem::Number(1_f64)])
     }
 }
-impl ::std::convert::From<::std::vec::Vec<LabelTransformOffsetVariant0Item>>
-    for LabelTransformOffset
-{
-    fn from(value: ::std::vec::Vec<LabelTransformOffsetVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<LabelTransformOffsetArrayItem>> for LabelTransformOffset {
+    fn from(value: ::std::vec::Vec<LabelTransformOffsetArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for LabelTransformOffset {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`LabelTransformOffsetVariant0Item`"]
+#[doc = "`LabelTransformOffsetArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44494,23 +44474,23 @@ impl ::std::convert::From<SignalRef> for LabelTransformOffset {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum LabelTransformOffsetVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum LabelTransformOffsetArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for LabelTransformOffsetVariant0Item {
-    fn from(value: &LabelTransformOffsetVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for LabelTransformOffsetArrayItem {
+    fn from(value: &LabelTransformOffsetArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for LabelTransformOffsetVariant0Item {
+impl ::std::convert::From<f64> for LabelTransformOffsetArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for LabelTransformOffsetVariant0Item {
+impl ::std::convert::From<SignalRef> for LabelTransformOffsetArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`LabelTransformPadding`"]
@@ -44536,9 +44516,9 @@ impl ::std::convert::From<SignalRef> for LabelTransformOffsetVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LabelTransformPadding {
-    Variant0(f64),
-    Variant1(SignalRef),
-    Variant2,
+    Number(f64),
+    SignalRef(SignalRef),
+    Null,
 }
 impl ::std::convert::From<&Self> for LabelTransformPadding {
     fn from(value: &LabelTransformPadding) -> Self {
@@ -44547,12 +44527,12 @@ impl ::std::convert::From<&Self> for LabelTransformPadding {
 }
 impl ::std::convert::From<f64> for LabelTransformPadding {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for LabelTransformPadding {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`LabelTransformSize`"]
@@ -44587,25 +44567,25 @@ impl ::std::convert::From<SignalRef> for LabelTransformPadding {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LabelTransformSize {
-    Variant0([LabelTransformSizeVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([LabelTransformSizeArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for LabelTransformSize {
     fn from(value: &LabelTransformSize) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<[LabelTransformSizeVariant0Item; 2usize]> for LabelTransformSize {
-    fn from(value: [LabelTransformSizeVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[LabelTransformSizeArrayItem; 2usize]> for LabelTransformSize {
+    fn from(value: [LabelTransformSizeArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for LabelTransformSize {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`LabelTransformSizeVariant0Item`"]
+#[doc = "`LabelTransformSizeArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -44624,23 +44604,23 @@ impl ::std::convert::From<SignalRef> for LabelTransformSize {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum LabelTransformSizeVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum LabelTransformSizeArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for LabelTransformSizeVariant0Item {
-    fn from(value: &LabelTransformSizeVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for LabelTransformSizeArrayItem {
+    fn from(value: &LabelTransformSizeArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for LabelTransformSizeVariant0Item {
+impl ::std::convert::From<f64> for LabelTransformSizeArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for LabelTransformSizeVariant0Item {
+impl ::std::convert::From<SignalRef> for LabelTransformSizeArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`LabelTransformType`"]
@@ -44998,13 +44978,13 @@ impl ::std::convert::TryFrom<::std::string::String> for LabelTransformType {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Layout {
-    Variant0 {
+    Object {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        align: ::std::option::Option<LayoutVariant0Align>,
+        align: ::std::option::Option<LayoutObjectAlign>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        bounds: ::std::option::Option<LayoutVariant0Bounds>,
+        bounds: ::std::option::Option<LayoutObjectBounds>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        center: ::std::option::Option<LayoutVariant0Center>,
+        center: ::std::option::Option<LayoutObjectCenter>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         columns: ::std::option::Option<NumberOrSignal>,
         #[serde(
@@ -45012,31 +44992,31 @@ pub enum Layout {
             default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
-        footer_band: ::std::option::Option<LayoutVariant0FooterBand>,
+        footer_band: ::std::option::Option<LayoutObjectFooterBand>,
         #[serde(
             rename = "headerBand",
             default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
-        header_band: ::std::option::Option<LayoutVariant0HeaderBand>,
+        header_band: ::std::option::Option<LayoutObjectHeaderBand>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        offset: ::std::option::Option<LayoutVariant0Offset>,
+        offset: ::std::option::Option<LayoutObjectOffset>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        padding: ::std::option::Option<LayoutVariant0Padding>,
+        padding: ::std::option::Option<LayoutObjectPadding>,
         #[serde(
             rename = "titleAnchor",
             default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
-        title_anchor: ::std::option::Option<LayoutVariant0TitleAnchor>,
+        title_anchor: ::std::option::Option<LayoutObjectTitleAnchor>,
         #[serde(
             rename = "titleBand",
             default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
-        title_band: ::std::option::Option<LayoutVariant0TitleBand>,
+        title_band: ::std::option::Option<LayoutObjectTitleBand>,
     },
-    Variant1(SignalRef),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for Layout {
     fn from(value: &Layout) -> Self {
@@ -45045,10 +45025,10 @@ impl ::std::convert::From<&Self> for Layout {
 }
 impl ::std::convert::From<SignalRef> for Layout {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`LayoutVariant0Align`"]
+#[doc = "`LayoutObjectAlign`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45109,26 +45089,26 @@ impl ::std::convert::From<SignalRef> for Layout {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged, deny_unknown_fields)]
-pub enum LayoutVariant0Align {
-    Variant0(LayoutVariant0AlignVariant0),
+pub enum LayoutObjectAlign {
+    Variant0(LayoutObjectAlignVariant0),
     Variant1 {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        column: ::std::option::Option<LayoutVariant0AlignVariant1Column>,
+        column: ::std::option::Option<LayoutObjectAlignVariant1Column>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        row: ::std::option::Option<LayoutVariant0AlignVariant1Row>,
+        row: ::std::option::Option<LayoutObjectAlignVariant1Row>,
     },
 }
-impl ::std::convert::From<&Self> for LayoutVariant0Align {
-    fn from(value: &LayoutVariant0Align) -> Self {
+impl ::std::convert::From<&Self> for LayoutObjectAlign {
+    fn from(value: &LayoutObjectAlign) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<LayoutVariant0AlignVariant0> for LayoutVariant0Align {
-    fn from(value: LayoutVariant0AlignVariant0) -> Self {
+impl ::std::convert::From<LayoutObjectAlignVariant0> for LayoutObjectAlign {
+    fn from(value: LayoutObjectAlignVariant0) -> Self {
         Self::Variant0(value)
     }
 }
-#[doc = "`LayoutVariant0AlignVariant0`"]
+#[doc = "`LayoutObjectAlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45151,26 +45131,26 @@ impl ::std::convert::From<LayoutVariant0AlignVariant0> for LayoutVariant0Align {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum LayoutVariant0AlignVariant0 {
-    Variant0(LayoutVariant0AlignVariant0Variant0),
+pub enum LayoutObjectAlignVariant0 {
+    Variant0(LayoutObjectAlignVariant0Variant0),
     Variant1(SignalRef),
 }
-impl ::std::convert::From<&Self> for LayoutVariant0AlignVariant0 {
-    fn from(value: &LayoutVariant0AlignVariant0) -> Self {
+impl ::std::convert::From<&Self> for LayoutObjectAlignVariant0 {
+    fn from(value: &LayoutObjectAlignVariant0) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<LayoutVariant0AlignVariant0Variant0> for LayoutVariant0AlignVariant0 {
-    fn from(value: LayoutVariant0AlignVariant0Variant0) -> Self {
+impl ::std::convert::From<LayoutObjectAlignVariant0Variant0> for LayoutObjectAlignVariant0 {
+    fn from(value: LayoutObjectAlignVariant0Variant0) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<SignalRef> for LayoutVariant0AlignVariant0 {
+impl ::std::convert::From<SignalRef> for LayoutObjectAlignVariant0 {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`LayoutVariant0AlignVariant0Variant0`"]
+#[doc = "`LayoutObjectAlignVariant0Variant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45196,7 +45176,7 @@ impl ::std::convert::From<SignalRef> for LayoutVariant0AlignVariant0 {
     PartialEq,
     PartialOrd,
 )]
-pub enum LayoutVariant0AlignVariant0Variant0 {
+pub enum LayoutObjectAlignVariant0Variant0 {
     #[serde(rename = "all")]
     All,
     #[serde(rename = "each")]
@@ -45204,12 +45184,12 @@ pub enum LayoutVariant0AlignVariant0Variant0 {
     #[serde(rename = "none")]
     None,
 }
-impl ::std::convert::From<&Self> for LayoutVariant0AlignVariant0Variant0 {
-    fn from(value: &LayoutVariant0AlignVariant0Variant0) -> Self {
+impl ::std::convert::From<&Self> for LayoutObjectAlignVariant0Variant0 {
+    fn from(value: &LayoutObjectAlignVariant0Variant0) -> Self {
         value.clone()
     }
 }
-impl ::std::fmt::Display for LayoutVariant0AlignVariant0Variant0 {
+impl ::std::fmt::Display for LayoutObjectAlignVariant0Variant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
             Self::All => f.write_str("all"),
@@ -45218,7 +45198,7 @@ impl ::std::fmt::Display for LayoutVariant0AlignVariant0Variant0 {
         }
     }
 }
-impl ::std::str::FromStr for LayoutVariant0AlignVariant0Variant0 {
+impl ::std::str::FromStr for LayoutObjectAlignVariant0Variant0 {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         match value {
@@ -45229,13 +45209,13 @@ impl ::std::str::FromStr for LayoutVariant0AlignVariant0Variant0 {
         }
     }
 }
-impl ::std::convert::TryFrom<&str> for LayoutVariant0AlignVariant0Variant0 {
+impl ::std::convert::TryFrom<&str> for LayoutObjectAlignVariant0Variant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LayoutVariant0AlignVariant0Variant0 {
+impl ::std::convert::TryFrom<&::std::string::String> for LayoutObjectAlignVariant0Variant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: &::std::string::String,
@@ -45243,7 +45223,7 @@ impl ::std::convert::TryFrom<&::std::string::String> for LayoutVariant0AlignVari
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<::std::string::String> for LayoutVariant0AlignVariant0Variant0 {
+impl ::std::convert::TryFrom<::std::string::String> for LayoutObjectAlignVariant0Variant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: ::std::string::String,
@@ -45251,7 +45231,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LayoutVariant0AlignVaria
         value.parse()
     }
 }
-#[doc = "`LayoutVariant0AlignVariant1Column`"]
+#[doc = "`LayoutObjectAlignVariant1Column`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45274,28 +45254,28 @@ impl ::std::convert::TryFrom<::std::string::String> for LayoutVariant0AlignVaria
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum LayoutVariant0AlignVariant1Column {
-    Variant0(LayoutVariant0AlignVariant1ColumnVariant0),
+pub enum LayoutObjectAlignVariant1Column {
+    Variant0(LayoutObjectAlignVariant1ColumnVariant0),
     Variant1(SignalRef),
 }
-impl ::std::convert::From<&Self> for LayoutVariant0AlignVariant1Column {
-    fn from(value: &LayoutVariant0AlignVariant1Column) -> Self {
+impl ::std::convert::From<&Self> for LayoutObjectAlignVariant1Column {
+    fn from(value: &LayoutObjectAlignVariant1Column) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<LayoutVariant0AlignVariant1ColumnVariant0>
-    for LayoutVariant0AlignVariant1Column
+impl ::std::convert::From<LayoutObjectAlignVariant1ColumnVariant0>
+    for LayoutObjectAlignVariant1Column
 {
-    fn from(value: LayoutVariant0AlignVariant1ColumnVariant0) -> Self {
+    fn from(value: LayoutObjectAlignVariant1ColumnVariant0) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<SignalRef> for LayoutVariant0AlignVariant1Column {
+impl ::std::convert::From<SignalRef> for LayoutObjectAlignVariant1Column {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`LayoutVariant0AlignVariant1ColumnVariant0`"]
+#[doc = "`LayoutObjectAlignVariant1ColumnVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45321,7 +45301,7 @@ impl ::std::convert::From<SignalRef> for LayoutVariant0AlignVariant1Column {
     PartialEq,
     PartialOrd,
 )]
-pub enum LayoutVariant0AlignVariant1ColumnVariant0 {
+pub enum LayoutObjectAlignVariant1ColumnVariant0 {
     #[serde(rename = "all")]
     All,
     #[serde(rename = "each")]
@@ -45329,12 +45309,12 @@ pub enum LayoutVariant0AlignVariant1ColumnVariant0 {
     #[serde(rename = "none")]
     None,
 }
-impl ::std::convert::From<&Self> for LayoutVariant0AlignVariant1ColumnVariant0 {
-    fn from(value: &LayoutVariant0AlignVariant1ColumnVariant0) -> Self {
+impl ::std::convert::From<&Self> for LayoutObjectAlignVariant1ColumnVariant0 {
+    fn from(value: &LayoutObjectAlignVariant1ColumnVariant0) -> Self {
         value.clone()
     }
 }
-impl ::std::fmt::Display for LayoutVariant0AlignVariant1ColumnVariant0 {
+impl ::std::fmt::Display for LayoutObjectAlignVariant1ColumnVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
             Self::All => f.write_str("all"),
@@ -45343,7 +45323,7 @@ impl ::std::fmt::Display for LayoutVariant0AlignVariant1ColumnVariant0 {
         }
     }
 }
-impl ::std::str::FromStr for LayoutVariant0AlignVariant1ColumnVariant0 {
+impl ::std::str::FromStr for LayoutObjectAlignVariant1ColumnVariant0 {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         match value {
@@ -45354,13 +45334,13 @@ impl ::std::str::FromStr for LayoutVariant0AlignVariant1ColumnVariant0 {
         }
     }
 }
-impl ::std::convert::TryFrom<&str> for LayoutVariant0AlignVariant1ColumnVariant0 {
+impl ::std::convert::TryFrom<&str> for LayoutObjectAlignVariant1ColumnVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LayoutVariant0AlignVariant1ColumnVariant0 {
+impl ::std::convert::TryFrom<&::std::string::String> for LayoutObjectAlignVariant1ColumnVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: &::std::string::String,
@@ -45368,7 +45348,7 @@ impl ::std::convert::TryFrom<&::std::string::String> for LayoutVariant0AlignVari
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<::std::string::String> for LayoutVariant0AlignVariant1ColumnVariant0 {
+impl ::std::convert::TryFrom<::std::string::String> for LayoutObjectAlignVariant1ColumnVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: ::std::string::String,
@@ -45376,7 +45356,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LayoutVariant0AlignVaria
         value.parse()
     }
 }
-#[doc = "`LayoutVariant0AlignVariant1Row`"]
+#[doc = "`LayoutObjectAlignVariant1Row`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45399,28 +45379,26 @@ impl ::std::convert::TryFrom<::std::string::String> for LayoutVariant0AlignVaria
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum LayoutVariant0AlignVariant1Row {
-    Variant0(LayoutVariant0AlignVariant1RowVariant0),
+pub enum LayoutObjectAlignVariant1Row {
+    Variant0(LayoutObjectAlignVariant1RowVariant0),
     Variant1(SignalRef),
 }
-impl ::std::convert::From<&Self> for LayoutVariant0AlignVariant1Row {
-    fn from(value: &LayoutVariant0AlignVariant1Row) -> Self {
+impl ::std::convert::From<&Self> for LayoutObjectAlignVariant1Row {
+    fn from(value: &LayoutObjectAlignVariant1Row) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<LayoutVariant0AlignVariant1RowVariant0>
-    for LayoutVariant0AlignVariant1Row
-{
-    fn from(value: LayoutVariant0AlignVariant1RowVariant0) -> Self {
+impl ::std::convert::From<LayoutObjectAlignVariant1RowVariant0> for LayoutObjectAlignVariant1Row {
+    fn from(value: LayoutObjectAlignVariant1RowVariant0) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<SignalRef> for LayoutVariant0AlignVariant1Row {
+impl ::std::convert::From<SignalRef> for LayoutObjectAlignVariant1Row {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`LayoutVariant0AlignVariant1RowVariant0`"]
+#[doc = "`LayoutObjectAlignVariant1RowVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45446,7 +45424,7 @@ impl ::std::convert::From<SignalRef> for LayoutVariant0AlignVariant1Row {
     PartialEq,
     PartialOrd,
 )]
-pub enum LayoutVariant0AlignVariant1RowVariant0 {
+pub enum LayoutObjectAlignVariant1RowVariant0 {
     #[serde(rename = "all")]
     All,
     #[serde(rename = "each")]
@@ -45454,12 +45432,12 @@ pub enum LayoutVariant0AlignVariant1RowVariant0 {
     #[serde(rename = "none")]
     None,
 }
-impl ::std::convert::From<&Self> for LayoutVariant0AlignVariant1RowVariant0 {
-    fn from(value: &LayoutVariant0AlignVariant1RowVariant0) -> Self {
+impl ::std::convert::From<&Self> for LayoutObjectAlignVariant1RowVariant0 {
+    fn from(value: &LayoutObjectAlignVariant1RowVariant0) -> Self {
         value.clone()
     }
 }
-impl ::std::fmt::Display for LayoutVariant0AlignVariant1RowVariant0 {
+impl ::std::fmt::Display for LayoutObjectAlignVariant1RowVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
             Self::All => f.write_str("all"),
@@ -45468,7 +45446,7 @@ impl ::std::fmt::Display for LayoutVariant0AlignVariant1RowVariant0 {
         }
     }
 }
-impl ::std::str::FromStr for LayoutVariant0AlignVariant1RowVariant0 {
+impl ::std::str::FromStr for LayoutObjectAlignVariant1RowVariant0 {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         match value {
@@ -45479,13 +45457,13 @@ impl ::std::str::FromStr for LayoutVariant0AlignVariant1RowVariant0 {
         }
     }
 }
-impl ::std::convert::TryFrom<&str> for LayoutVariant0AlignVariant1RowVariant0 {
+impl ::std::convert::TryFrom<&str> for LayoutObjectAlignVariant1RowVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LayoutVariant0AlignVariant1RowVariant0 {
+impl ::std::convert::TryFrom<&::std::string::String> for LayoutObjectAlignVariant1RowVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: &::std::string::String,
@@ -45493,7 +45471,7 @@ impl ::std::convert::TryFrom<&::std::string::String> for LayoutVariant0AlignVari
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<::std::string::String> for LayoutVariant0AlignVariant1RowVariant0 {
+impl ::std::convert::TryFrom<::std::string::String> for LayoutObjectAlignVariant1RowVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: ::std::string::String,
@@ -45501,7 +45479,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LayoutVariant0AlignVaria
         value.parse()
     }
 }
-#[doc = "`LayoutVariant0Bounds`"]
+#[doc = "`LayoutObjectBounds`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45523,26 +45501,26 @@ impl ::std::convert::TryFrom<::std::string::String> for LayoutVariant0AlignVaria
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum LayoutVariant0Bounds {
-    Variant0(LayoutVariant0BoundsVariant0),
+pub enum LayoutObjectBounds {
+    Variant0(LayoutObjectBoundsVariant0),
     Variant1(SignalRef),
 }
-impl ::std::convert::From<&Self> for LayoutVariant0Bounds {
-    fn from(value: &LayoutVariant0Bounds) -> Self {
+impl ::std::convert::From<&Self> for LayoutObjectBounds {
+    fn from(value: &LayoutObjectBounds) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<LayoutVariant0BoundsVariant0> for LayoutVariant0Bounds {
-    fn from(value: LayoutVariant0BoundsVariant0) -> Self {
+impl ::std::convert::From<LayoutObjectBoundsVariant0> for LayoutObjectBounds {
+    fn from(value: LayoutObjectBoundsVariant0) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<SignalRef> for LayoutVariant0Bounds {
+impl ::std::convert::From<SignalRef> for LayoutObjectBounds {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`LayoutVariant0BoundsVariant0`"]
+#[doc = "`LayoutObjectBoundsVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45567,18 +45545,18 @@ impl ::std::convert::From<SignalRef> for LayoutVariant0Bounds {
     PartialEq,
     PartialOrd,
 )]
-pub enum LayoutVariant0BoundsVariant0 {
+pub enum LayoutObjectBoundsVariant0 {
     #[serde(rename = "full")]
     Full,
     #[serde(rename = "flush")]
     Flush,
 }
-impl ::std::convert::From<&Self> for LayoutVariant0BoundsVariant0 {
-    fn from(value: &LayoutVariant0BoundsVariant0) -> Self {
+impl ::std::convert::From<&Self> for LayoutObjectBoundsVariant0 {
+    fn from(value: &LayoutObjectBoundsVariant0) -> Self {
         value.clone()
     }
 }
-impl ::std::fmt::Display for LayoutVariant0BoundsVariant0 {
+impl ::std::fmt::Display for LayoutObjectBoundsVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
             Self::Full => f.write_str("full"),
@@ -45586,7 +45564,7 @@ impl ::std::fmt::Display for LayoutVariant0BoundsVariant0 {
         }
     }
 }
-impl ::std::str::FromStr for LayoutVariant0BoundsVariant0 {
+impl ::std::str::FromStr for LayoutObjectBoundsVariant0 {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         match value {
@@ -45596,13 +45574,13 @@ impl ::std::str::FromStr for LayoutVariant0BoundsVariant0 {
         }
     }
 }
-impl ::std::convert::TryFrom<&str> for LayoutVariant0BoundsVariant0 {
+impl ::std::convert::TryFrom<&str> for LayoutObjectBoundsVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LayoutVariant0BoundsVariant0 {
+impl ::std::convert::TryFrom<&::std::string::String> for LayoutObjectBoundsVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: &::std::string::String,
@@ -45610,7 +45588,7 @@ impl ::std::convert::TryFrom<&::std::string::String> for LayoutVariant0BoundsVar
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<::std::string::String> for LayoutVariant0BoundsVariant0 {
+impl ::std::convert::TryFrom<::std::string::String> for LayoutObjectBoundsVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: ::std::string::String,
@@ -45618,7 +45596,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LayoutVariant0BoundsVari
         value.parse()
     }
 }
-#[doc = "`LayoutVariant0Center`"]
+#[doc = "`LayoutObjectCenter`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45649,32 +45627,32 @@ impl ::std::convert::TryFrom<::std::string::String> for LayoutVariant0BoundsVari
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged, deny_unknown_fields)]
-pub enum LayoutVariant0Center {
-    Variant0(bool),
-    Variant1(SignalRef),
-    Variant2 {
+pub enum LayoutObjectCenter {
+    Boolean(bool),
+    SignalRef(SignalRef),
+    Object {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         column: ::std::option::Option<BooleanOrSignal>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         row: ::std::option::Option<BooleanOrSignal>,
     },
 }
-impl ::std::convert::From<&Self> for LayoutVariant0Center {
-    fn from(value: &LayoutVariant0Center) -> Self {
+impl ::std::convert::From<&Self> for LayoutObjectCenter {
+    fn from(value: &LayoutObjectCenter) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<bool> for LayoutVariant0Center {
+impl ::std::convert::From<bool> for LayoutObjectCenter {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
-impl ::std::convert::From<SignalRef> for LayoutVariant0Center {
+impl ::std::convert::From<SignalRef> for LayoutObjectCenter {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`LayoutVariant0FooterBand`"]
+#[doc = "`LayoutObjectFooterBand`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45705,27 +45683,27 @@ impl ::std::convert::From<SignalRef> for LayoutVariant0Center {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged, deny_unknown_fields)]
-pub enum LayoutVariant0FooterBand {
-    Variant0(NumberOrSignal),
-    Variant1,
-    Variant2 {
+pub enum LayoutObjectFooterBand {
+    NumberOrSignal(NumberOrSignal),
+    Null,
+    Object {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         column: ::std::option::Option<NumberOrSignal>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         row: ::std::option::Option<NumberOrSignal>,
     },
 }
-impl ::std::convert::From<&Self> for LayoutVariant0FooterBand {
-    fn from(value: &LayoutVariant0FooterBand) -> Self {
+impl ::std::convert::From<&Self> for LayoutObjectFooterBand {
+    fn from(value: &LayoutObjectFooterBand) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<NumberOrSignal> for LayoutVariant0FooterBand {
+impl ::std::convert::From<NumberOrSignal> for LayoutObjectFooterBand {
     fn from(value: NumberOrSignal) -> Self {
-        Self::Variant0(value)
+        Self::NumberOrSignal(value)
     }
 }
-#[doc = "`LayoutVariant0HeaderBand`"]
+#[doc = "`LayoutObjectHeaderBand`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45756,27 +45734,27 @@ impl ::std::convert::From<NumberOrSignal> for LayoutVariant0FooterBand {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged, deny_unknown_fields)]
-pub enum LayoutVariant0HeaderBand {
-    Variant0(NumberOrSignal),
-    Variant1,
-    Variant2 {
+pub enum LayoutObjectHeaderBand {
+    NumberOrSignal(NumberOrSignal),
+    Null,
+    Object {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         column: ::std::option::Option<NumberOrSignal>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         row: ::std::option::Option<NumberOrSignal>,
     },
 }
-impl ::std::convert::From<&Self> for LayoutVariant0HeaderBand {
-    fn from(value: &LayoutVariant0HeaderBand) -> Self {
+impl ::std::convert::From<&Self> for LayoutObjectHeaderBand {
+    fn from(value: &LayoutObjectHeaderBand) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<NumberOrSignal> for LayoutVariant0HeaderBand {
+impl ::std::convert::From<NumberOrSignal> for LayoutObjectHeaderBand {
     fn from(value: NumberOrSignal) -> Self {
-        Self::Variant0(value)
+        Self::NumberOrSignal(value)
     }
 }
-#[doc = "`LayoutVariant0Offset`"]
+#[doc = "`LayoutObjectOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45819,10 +45797,10 @@ impl ::std::convert::From<NumberOrSignal> for LayoutVariant0HeaderBand {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged, deny_unknown_fields)]
-pub enum LayoutVariant0Offset {
-    Variant0(f64),
-    Variant1(SignalRef),
-    Variant2 {
+pub enum LayoutObjectOffset {
+    Number(f64),
+    SignalRef(SignalRef),
+    Object {
         #[serde(
             rename = "columnFooter",
             default,
@@ -45861,22 +45839,22 @@ pub enum LayoutVariant0Offset {
         row_title: ::std::option::Option<NumberOrSignal>,
     },
 }
-impl ::std::convert::From<&Self> for LayoutVariant0Offset {
-    fn from(value: &LayoutVariant0Offset) -> Self {
+impl ::std::convert::From<&Self> for LayoutObjectOffset {
+    fn from(value: &LayoutObjectOffset) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for LayoutVariant0Offset {
+impl ::std::convert::From<f64> for LayoutObjectOffset {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for LayoutVariant0Offset {
+impl ::std::convert::From<SignalRef> for LayoutObjectOffset {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`LayoutVariant0Padding`"]
+#[doc = "`LayoutObjectPadding`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45907,32 +45885,32 @@ impl ::std::convert::From<SignalRef> for LayoutVariant0Offset {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged, deny_unknown_fields)]
-pub enum LayoutVariant0Padding {
-    Variant0(f64),
-    Variant1(SignalRef),
-    Variant2 {
+pub enum LayoutObjectPadding {
+    Number(f64),
+    SignalRef(SignalRef),
+    Object {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         column: ::std::option::Option<NumberOrSignal>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         row: ::std::option::Option<NumberOrSignal>,
     },
 }
-impl ::std::convert::From<&Self> for LayoutVariant0Padding {
-    fn from(value: &LayoutVariant0Padding) -> Self {
+impl ::std::convert::From<&Self> for LayoutObjectPadding {
+    fn from(value: &LayoutObjectPadding) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for LayoutVariant0Padding {
+impl ::std::convert::From<f64> for LayoutObjectPadding {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for LayoutVariant0Padding {
+impl ::std::convert::From<SignalRef> for LayoutObjectPadding {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`LayoutVariant0TitleAnchor`"]
+#[doc = "`LayoutObjectTitleAnchor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -45990,26 +45968,26 @@ impl ::std::convert::From<SignalRef> for LayoutVariant0Padding {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged, deny_unknown_fields)]
-pub enum LayoutVariant0TitleAnchor {
-    Variant0(LayoutVariant0TitleAnchorVariant0),
+pub enum LayoutObjectTitleAnchor {
+    Variant0(LayoutObjectTitleAnchorVariant0),
     Variant1 {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        column: ::std::option::Option<LayoutVariant0TitleAnchorVariant1Column>,
+        column: ::std::option::Option<LayoutObjectTitleAnchorVariant1Column>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        row: ::std::option::Option<LayoutVariant0TitleAnchorVariant1Row>,
+        row: ::std::option::Option<LayoutObjectTitleAnchorVariant1Row>,
     },
 }
-impl ::std::convert::From<&Self> for LayoutVariant0TitleAnchor {
-    fn from(value: &LayoutVariant0TitleAnchor) -> Self {
+impl ::std::convert::From<&Self> for LayoutObjectTitleAnchor {
+    fn from(value: &LayoutObjectTitleAnchor) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<LayoutVariant0TitleAnchorVariant0> for LayoutVariant0TitleAnchor {
-    fn from(value: LayoutVariant0TitleAnchorVariant0) -> Self {
+impl ::std::convert::From<LayoutObjectTitleAnchorVariant0> for LayoutObjectTitleAnchor {
+    fn from(value: LayoutObjectTitleAnchorVariant0) -> Self {
         Self::Variant0(value)
     }
 }
-#[doc = "`LayoutVariant0TitleAnchorVariant0`"]
+#[doc = "`LayoutObjectTitleAnchorVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46031,28 +46009,28 @@ impl ::std::convert::From<LayoutVariant0TitleAnchorVariant0> for LayoutVariant0T
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum LayoutVariant0TitleAnchorVariant0 {
-    Variant0(LayoutVariant0TitleAnchorVariant0Variant0),
+pub enum LayoutObjectTitleAnchorVariant0 {
+    Variant0(LayoutObjectTitleAnchorVariant0Variant0),
     Variant1(SignalRef),
 }
-impl ::std::convert::From<&Self> for LayoutVariant0TitleAnchorVariant0 {
-    fn from(value: &LayoutVariant0TitleAnchorVariant0) -> Self {
+impl ::std::convert::From<&Self> for LayoutObjectTitleAnchorVariant0 {
+    fn from(value: &LayoutObjectTitleAnchorVariant0) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<LayoutVariant0TitleAnchorVariant0Variant0>
-    for LayoutVariant0TitleAnchorVariant0
+impl ::std::convert::From<LayoutObjectTitleAnchorVariant0Variant0>
+    for LayoutObjectTitleAnchorVariant0
 {
-    fn from(value: LayoutVariant0TitleAnchorVariant0Variant0) -> Self {
+    fn from(value: LayoutObjectTitleAnchorVariant0Variant0) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<SignalRef> for LayoutVariant0TitleAnchorVariant0 {
+impl ::std::convert::From<SignalRef> for LayoutObjectTitleAnchorVariant0 {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`LayoutVariant0TitleAnchorVariant0Variant0`"]
+#[doc = "`LayoutObjectTitleAnchorVariant0Variant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46077,18 +46055,18 @@ impl ::std::convert::From<SignalRef> for LayoutVariant0TitleAnchorVariant0 {
     PartialEq,
     PartialOrd,
 )]
-pub enum LayoutVariant0TitleAnchorVariant0Variant0 {
+pub enum LayoutObjectTitleAnchorVariant0Variant0 {
     #[serde(rename = "start")]
     Start,
     #[serde(rename = "end")]
     End,
 }
-impl ::std::convert::From<&Self> for LayoutVariant0TitleAnchorVariant0Variant0 {
-    fn from(value: &LayoutVariant0TitleAnchorVariant0Variant0) -> Self {
+impl ::std::convert::From<&Self> for LayoutObjectTitleAnchorVariant0Variant0 {
+    fn from(value: &LayoutObjectTitleAnchorVariant0Variant0) -> Self {
         value.clone()
     }
 }
-impl ::std::fmt::Display for LayoutVariant0TitleAnchorVariant0Variant0 {
+impl ::std::fmt::Display for LayoutObjectTitleAnchorVariant0Variant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
             Self::Start => f.write_str("start"),
@@ -46096,7 +46074,7 @@ impl ::std::fmt::Display for LayoutVariant0TitleAnchorVariant0Variant0 {
         }
     }
 }
-impl ::std::str::FromStr for LayoutVariant0TitleAnchorVariant0Variant0 {
+impl ::std::str::FromStr for LayoutObjectTitleAnchorVariant0Variant0 {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         match value {
@@ -46106,13 +46084,13 @@ impl ::std::str::FromStr for LayoutVariant0TitleAnchorVariant0Variant0 {
         }
     }
 }
-impl ::std::convert::TryFrom<&str> for LayoutVariant0TitleAnchorVariant0Variant0 {
+impl ::std::convert::TryFrom<&str> for LayoutObjectTitleAnchorVariant0Variant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LayoutVariant0TitleAnchorVariant0Variant0 {
+impl ::std::convert::TryFrom<&::std::string::String> for LayoutObjectTitleAnchorVariant0Variant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: &::std::string::String,
@@ -46120,7 +46098,7 @@ impl ::std::convert::TryFrom<&::std::string::String> for LayoutVariant0TitleAnch
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<::std::string::String> for LayoutVariant0TitleAnchorVariant0Variant0 {
+impl ::std::convert::TryFrom<::std::string::String> for LayoutObjectTitleAnchorVariant0Variant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: ::std::string::String,
@@ -46128,7 +46106,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LayoutVariant0TitleAncho
         value.parse()
     }
 }
-#[doc = "`LayoutVariant0TitleAnchorVariant1Column`"]
+#[doc = "`LayoutObjectTitleAnchorVariant1Column`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46150,28 +46128,28 @@ impl ::std::convert::TryFrom<::std::string::String> for LayoutVariant0TitleAncho
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum LayoutVariant0TitleAnchorVariant1Column {
-    Variant0(LayoutVariant0TitleAnchorVariant1ColumnVariant0),
+pub enum LayoutObjectTitleAnchorVariant1Column {
+    Variant0(LayoutObjectTitleAnchorVariant1ColumnVariant0),
     Variant1(SignalRef),
 }
-impl ::std::convert::From<&Self> for LayoutVariant0TitleAnchorVariant1Column {
-    fn from(value: &LayoutVariant0TitleAnchorVariant1Column) -> Self {
+impl ::std::convert::From<&Self> for LayoutObjectTitleAnchorVariant1Column {
+    fn from(value: &LayoutObjectTitleAnchorVariant1Column) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<LayoutVariant0TitleAnchorVariant1ColumnVariant0>
-    for LayoutVariant0TitleAnchorVariant1Column
+impl ::std::convert::From<LayoutObjectTitleAnchorVariant1ColumnVariant0>
+    for LayoutObjectTitleAnchorVariant1Column
 {
-    fn from(value: LayoutVariant0TitleAnchorVariant1ColumnVariant0) -> Self {
+    fn from(value: LayoutObjectTitleAnchorVariant1ColumnVariant0) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<SignalRef> for LayoutVariant0TitleAnchorVariant1Column {
+impl ::std::convert::From<SignalRef> for LayoutObjectTitleAnchorVariant1Column {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`LayoutVariant0TitleAnchorVariant1ColumnVariant0`"]
+#[doc = "`LayoutObjectTitleAnchorVariant1ColumnVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46196,18 +46174,18 @@ impl ::std::convert::From<SignalRef> for LayoutVariant0TitleAnchorVariant1Column
     PartialEq,
     PartialOrd,
 )]
-pub enum LayoutVariant0TitleAnchorVariant1ColumnVariant0 {
+pub enum LayoutObjectTitleAnchorVariant1ColumnVariant0 {
     #[serde(rename = "start")]
     Start,
     #[serde(rename = "end")]
     End,
 }
-impl ::std::convert::From<&Self> for LayoutVariant0TitleAnchorVariant1ColumnVariant0 {
-    fn from(value: &LayoutVariant0TitleAnchorVariant1ColumnVariant0) -> Self {
+impl ::std::convert::From<&Self> for LayoutObjectTitleAnchorVariant1ColumnVariant0 {
+    fn from(value: &LayoutObjectTitleAnchorVariant1ColumnVariant0) -> Self {
         value.clone()
     }
 }
-impl ::std::fmt::Display for LayoutVariant0TitleAnchorVariant1ColumnVariant0 {
+impl ::std::fmt::Display for LayoutObjectTitleAnchorVariant1ColumnVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
             Self::Start => f.write_str("start"),
@@ -46215,7 +46193,7 @@ impl ::std::fmt::Display for LayoutVariant0TitleAnchorVariant1ColumnVariant0 {
         }
     }
 }
-impl ::std::str::FromStr for LayoutVariant0TitleAnchorVariant1ColumnVariant0 {
+impl ::std::str::FromStr for LayoutObjectTitleAnchorVariant1ColumnVariant0 {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         match value {
@@ -46225,14 +46203,14 @@ impl ::std::str::FromStr for LayoutVariant0TitleAnchorVariant1ColumnVariant0 {
         }
     }
 }
-impl ::std::convert::TryFrom<&str> for LayoutVariant0TitleAnchorVariant1ColumnVariant0 {
+impl ::std::convert::TryFrom<&str> for LayoutObjectTitleAnchorVariant1ColumnVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl ::std::convert::TryFrom<&::std::string::String>
-    for LayoutVariant0TitleAnchorVariant1ColumnVariant0
+    for LayoutObjectTitleAnchorVariant1ColumnVariant0
 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -46242,7 +46220,7 @@ impl ::std::convert::TryFrom<&::std::string::String>
     }
 }
 impl ::std::convert::TryFrom<::std::string::String>
-    for LayoutVariant0TitleAnchorVariant1ColumnVariant0
+    for LayoutObjectTitleAnchorVariant1ColumnVariant0
 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -46251,7 +46229,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "`LayoutVariant0TitleAnchorVariant1Row`"]
+#[doc = "`LayoutObjectTitleAnchorVariant1Row`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46273,28 +46251,28 @@ impl ::std::convert::TryFrom<::std::string::String>
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum LayoutVariant0TitleAnchorVariant1Row {
-    Variant0(LayoutVariant0TitleAnchorVariant1RowVariant0),
+pub enum LayoutObjectTitleAnchorVariant1Row {
+    Variant0(LayoutObjectTitleAnchorVariant1RowVariant0),
     Variant1(SignalRef),
 }
-impl ::std::convert::From<&Self> for LayoutVariant0TitleAnchorVariant1Row {
-    fn from(value: &LayoutVariant0TitleAnchorVariant1Row) -> Self {
+impl ::std::convert::From<&Self> for LayoutObjectTitleAnchorVariant1Row {
+    fn from(value: &LayoutObjectTitleAnchorVariant1Row) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<LayoutVariant0TitleAnchorVariant1RowVariant0>
-    for LayoutVariant0TitleAnchorVariant1Row
+impl ::std::convert::From<LayoutObjectTitleAnchorVariant1RowVariant0>
+    for LayoutObjectTitleAnchorVariant1Row
 {
-    fn from(value: LayoutVariant0TitleAnchorVariant1RowVariant0) -> Self {
+    fn from(value: LayoutObjectTitleAnchorVariant1RowVariant0) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<SignalRef> for LayoutVariant0TitleAnchorVariant1Row {
+impl ::std::convert::From<SignalRef> for LayoutObjectTitleAnchorVariant1Row {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`LayoutVariant0TitleAnchorVariant1RowVariant0`"]
+#[doc = "`LayoutObjectTitleAnchorVariant1RowVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46319,18 +46297,18 @@ impl ::std::convert::From<SignalRef> for LayoutVariant0TitleAnchorVariant1Row {
     PartialEq,
     PartialOrd,
 )]
-pub enum LayoutVariant0TitleAnchorVariant1RowVariant0 {
+pub enum LayoutObjectTitleAnchorVariant1RowVariant0 {
     #[serde(rename = "start")]
     Start,
     #[serde(rename = "end")]
     End,
 }
-impl ::std::convert::From<&Self> for LayoutVariant0TitleAnchorVariant1RowVariant0 {
-    fn from(value: &LayoutVariant0TitleAnchorVariant1RowVariant0) -> Self {
+impl ::std::convert::From<&Self> for LayoutObjectTitleAnchorVariant1RowVariant0 {
+    fn from(value: &LayoutObjectTitleAnchorVariant1RowVariant0) -> Self {
         value.clone()
     }
 }
-impl ::std::fmt::Display for LayoutVariant0TitleAnchorVariant1RowVariant0 {
+impl ::std::fmt::Display for LayoutObjectTitleAnchorVariant1RowVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
             Self::Start => f.write_str("start"),
@@ -46338,7 +46316,7 @@ impl ::std::fmt::Display for LayoutVariant0TitleAnchorVariant1RowVariant0 {
         }
     }
 }
-impl ::std::str::FromStr for LayoutVariant0TitleAnchorVariant1RowVariant0 {
+impl ::std::str::FromStr for LayoutObjectTitleAnchorVariant1RowVariant0 {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         match value {
@@ -46348,14 +46326,14 @@ impl ::std::str::FromStr for LayoutVariant0TitleAnchorVariant1RowVariant0 {
         }
     }
 }
-impl ::std::convert::TryFrom<&str> for LayoutVariant0TitleAnchorVariant1RowVariant0 {
+impl ::std::convert::TryFrom<&str> for LayoutObjectTitleAnchorVariant1RowVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
 impl ::std::convert::TryFrom<&::std::string::String>
-    for LayoutVariant0TitleAnchorVariant1RowVariant0
+    for LayoutObjectTitleAnchorVariant1RowVariant0
 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -46364,9 +46342,7 @@ impl ::std::convert::TryFrom<&::std::string::String>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<::std::string::String>
-    for LayoutVariant0TitleAnchorVariant1RowVariant0
-{
+impl ::std::convert::TryFrom<::std::string::String> for LayoutObjectTitleAnchorVariant1RowVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: ::std::string::String,
@@ -46374,7 +46350,7 @@ impl ::std::convert::TryFrom<::std::string::String>
         value.parse()
     }
 }
-#[doc = "`LayoutVariant0TitleBand`"]
+#[doc = "`LayoutObjectTitleBand`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -46405,24 +46381,24 @@ impl ::std::convert::TryFrom<::std::string::String>
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged, deny_unknown_fields)]
-pub enum LayoutVariant0TitleBand {
-    Variant0(NumberOrSignal),
-    Variant1,
-    Variant2 {
+pub enum LayoutObjectTitleBand {
+    NumberOrSignal(NumberOrSignal),
+    Null,
+    Object {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         column: ::std::option::Option<NumberOrSignal>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         row: ::std::option::Option<NumberOrSignal>,
     },
 }
-impl ::std::convert::From<&Self> for LayoutVariant0TitleBand {
-    fn from(value: &LayoutVariant0TitleBand) -> Self {
+impl ::std::convert::From<&Self> for LayoutObjectTitleBand {
+    fn from(value: &LayoutObjectTitleBand) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<NumberOrSignal> for LayoutVariant0TitleBand {
+impl ::std::convert::From<NumberOrSignal> for LayoutObjectTitleBand {
     fn from(value: NumberOrSignal) -> Self {
-        Self::Variant0(value)
+        Self::NumberOrSignal(value)
     }
 }
 #[doc = "`Legend`"]
@@ -49839,9 +49815,9 @@ impl ::std::default::Default for LegendVariant0Encode {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant0FillColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant0FillColor {
     fn from(value: &LegendVariant0FillColor) -> Self {
@@ -49850,7 +49826,7 @@ impl ::std::convert::From<&Self> for LegendVariant0FillColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant0FillColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant0Format`"]
@@ -49909,8 +49885,8 @@ impl ::std::convert::From<ColorValue> for LegendVariant0FillColor {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LegendVariant0Format {
-    Variant0(::std::string::String),
-    Variant1 {
+    String(::std::string::String),
+    Object {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         date: ::std::option::Option<::std::string::String>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -49932,7 +49908,7 @@ pub enum LegendVariant0Format {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         year: ::std::option::Option<::std::string::String>,
     },
-    Variant2(SignalRef),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for LegendVariant0Format {
     fn from(value: &LegendVariant0Format) -> Self {
@@ -49941,7 +49917,7 @@ impl ::std::convert::From<&Self> for LegendVariant0Format {
 }
 impl ::std::convert::From<SignalRef> for LegendVariant0Format {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`LegendVariant0FormatType`"]
@@ -50128,9 +50104,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant0GradientOpacity {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant0GradientStrokeColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant0GradientStrokeColor {
     fn from(value: &LegendVariant0GradientStrokeColor) -> Self {
@@ -50139,7 +50115,7 @@ impl ::std::convert::From<&Self> for LegendVariant0GradientStrokeColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant0GradientStrokeColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant0GradientStrokeWidth`"]
@@ -50590,9 +50566,9 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant0LabelBasel
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant0LabelColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant0LabelColor {
     fn from(value: &LegendVariant0LabelColor) -> Self {
@@ -50601,7 +50577,7 @@ impl ::std::convert::From<&Self> for LegendVariant0LabelColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant0LabelColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant0LabelFont`"]
@@ -51220,9 +51196,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant0Padding {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant0StrokeColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant0StrokeColor {
     fn from(value: &LegendVariant0StrokeColor) -> Self {
@@ -51231,7 +51207,7 @@ impl ::std::convert::From<&Self> for LegendVariant0StrokeColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant0StrokeColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant0SymbolDash`"]
@@ -51336,9 +51312,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant0SymbolDashOffset {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant0SymbolFillColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant0SymbolFillColor {
     fn from(value: &LegendVariant0SymbolFillColor) -> Self {
@@ -51347,7 +51323,7 @@ impl ::std::convert::From<&Self> for LegendVariant0SymbolFillColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant0SymbolFillColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant0SymbolOffset`"]
@@ -51487,9 +51463,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant0SymbolSize {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant0SymbolStrokeColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant0SymbolStrokeColor {
     fn from(value: &LegendVariant0SymbolStrokeColor) -> Self {
@@ -51498,7 +51474,7 @@ impl ::std::convert::From<&Self> for LegendVariant0SymbolStrokeColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant0SymbolStrokeColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant0SymbolStrokeWidth`"]
@@ -51986,9 +51962,9 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant0TitleBasel
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant0TitleColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant0TitleColor {
     fn from(value: &LegendVariant0TitleColor) -> Self {
@@ -51997,7 +51973,7 @@ impl ::std::convert::From<&Self> for LegendVariant0TitleColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant0TitleColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant0TitleFont`"]
@@ -52724,9 +52700,9 @@ impl ::std::default::Default for LegendVariant1Encode {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant1FillColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant1FillColor {
     fn from(value: &LegendVariant1FillColor) -> Self {
@@ -52735,7 +52711,7 @@ impl ::std::convert::From<&Self> for LegendVariant1FillColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant1FillColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant1Format`"]
@@ -52794,8 +52770,8 @@ impl ::std::convert::From<ColorValue> for LegendVariant1FillColor {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LegendVariant1Format {
-    Variant0(::std::string::String),
-    Variant1 {
+    String(::std::string::String),
+    Object {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         date: ::std::option::Option<::std::string::String>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -52817,7 +52793,7 @@ pub enum LegendVariant1Format {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         year: ::std::option::Option<::std::string::String>,
     },
-    Variant2(SignalRef),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for LegendVariant1Format {
     fn from(value: &LegendVariant1Format) -> Self {
@@ -52826,7 +52802,7 @@ impl ::std::convert::From<&Self> for LegendVariant1Format {
 }
 impl ::std::convert::From<SignalRef> for LegendVariant1Format {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`LegendVariant1FormatType`"]
@@ -53013,9 +52989,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant1GradientOpacity {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant1GradientStrokeColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant1GradientStrokeColor {
     fn from(value: &LegendVariant1GradientStrokeColor) -> Self {
@@ -53024,7 +53000,7 @@ impl ::std::convert::From<&Self> for LegendVariant1GradientStrokeColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant1GradientStrokeColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant1GradientStrokeWidth`"]
@@ -53475,9 +53451,9 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant1LabelBasel
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant1LabelColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant1LabelColor {
     fn from(value: &LegendVariant1LabelColor) -> Self {
@@ -53486,7 +53462,7 @@ impl ::std::convert::From<&Self> for LegendVariant1LabelColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant1LabelColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant1LabelFont`"]
@@ -54105,9 +54081,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant1Padding {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant1StrokeColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant1StrokeColor {
     fn from(value: &LegendVariant1StrokeColor) -> Self {
@@ -54116,7 +54092,7 @@ impl ::std::convert::From<&Self> for LegendVariant1StrokeColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant1StrokeColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant1SymbolDash`"]
@@ -54221,9 +54197,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant1SymbolDashOffset {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant1SymbolFillColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant1SymbolFillColor {
     fn from(value: &LegendVariant1SymbolFillColor) -> Self {
@@ -54232,7 +54208,7 @@ impl ::std::convert::From<&Self> for LegendVariant1SymbolFillColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant1SymbolFillColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant1SymbolOffset`"]
@@ -54372,9 +54348,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant1SymbolSize {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant1SymbolStrokeColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant1SymbolStrokeColor {
     fn from(value: &LegendVariant1SymbolStrokeColor) -> Self {
@@ -54383,7 +54359,7 @@ impl ::std::convert::From<&Self> for LegendVariant1SymbolStrokeColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant1SymbolStrokeColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant1SymbolStrokeWidth`"]
@@ -54871,9 +54847,9 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant1TitleBasel
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant1TitleColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant1TitleColor {
     fn from(value: &LegendVariant1TitleColor) -> Self {
@@ -54882,7 +54858,7 @@ impl ::std::convert::From<&Self> for LegendVariant1TitleColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant1TitleColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant1TitleFont`"]
@@ -55609,9 +55585,9 @@ impl ::std::default::Default for LegendVariant2Encode {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant2FillColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant2FillColor {
     fn from(value: &LegendVariant2FillColor) -> Self {
@@ -55620,7 +55596,7 @@ impl ::std::convert::From<&Self> for LegendVariant2FillColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant2FillColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant2Format`"]
@@ -55679,8 +55655,8 @@ impl ::std::convert::From<ColorValue> for LegendVariant2FillColor {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LegendVariant2Format {
-    Variant0(::std::string::String),
-    Variant1 {
+    String(::std::string::String),
+    Object {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         date: ::std::option::Option<::std::string::String>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -55702,7 +55678,7 @@ pub enum LegendVariant2Format {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         year: ::std::option::Option<::std::string::String>,
     },
-    Variant2(SignalRef),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for LegendVariant2Format {
     fn from(value: &LegendVariant2Format) -> Self {
@@ -55711,7 +55687,7 @@ impl ::std::convert::From<&Self> for LegendVariant2Format {
 }
 impl ::std::convert::From<SignalRef> for LegendVariant2Format {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`LegendVariant2FormatType`"]
@@ -55898,9 +55874,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant2GradientOpacity {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant2GradientStrokeColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant2GradientStrokeColor {
     fn from(value: &LegendVariant2GradientStrokeColor) -> Self {
@@ -55909,7 +55885,7 @@ impl ::std::convert::From<&Self> for LegendVariant2GradientStrokeColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant2GradientStrokeColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant2GradientStrokeWidth`"]
@@ -56360,9 +56336,9 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant2LabelBasel
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant2LabelColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant2LabelColor {
     fn from(value: &LegendVariant2LabelColor) -> Self {
@@ -56371,7 +56347,7 @@ impl ::std::convert::From<&Self> for LegendVariant2LabelColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant2LabelColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant2LabelFont`"]
@@ -56990,9 +56966,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant2Padding {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant2StrokeColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant2StrokeColor {
     fn from(value: &LegendVariant2StrokeColor) -> Self {
@@ -57001,7 +56977,7 @@ impl ::std::convert::From<&Self> for LegendVariant2StrokeColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant2StrokeColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant2SymbolDash`"]
@@ -57106,9 +57082,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant2SymbolDashOffset {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant2SymbolFillColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant2SymbolFillColor {
     fn from(value: &LegendVariant2SymbolFillColor) -> Self {
@@ -57117,7 +57093,7 @@ impl ::std::convert::From<&Self> for LegendVariant2SymbolFillColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant2SymbolFillColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant2SymbolOffset`"]
@@ -57257,9 +57233,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant2SymbolSize {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant2SymbolStrokeColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant2SymbolStrokeColor {
     fn from(value: &LegendVariant2SymbolStrokeColor) -> Self {
@@ -57268,7 +57244,7 @@ impl ::std::convert::From<&Self> for LegendVariant2SymbolStrokeColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant2SymbolStrokeColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant2SymbolStrokeWidth`"]
@@ -57756,9 +57732,9 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant2TitleBasel
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant2TitleColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant2TitleColor {
     fn from(value: &LegendVariant2TitleColor) -> Self {
@@ -57767,7 +57743,7 @@ impl ::std::convert::From<&Self> for LegendVariant2TitleColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant2TitleColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant2TitleFont`"]
@@ -58494,9 +58470,9 @@ impl ::std::default::Default for LegendVariant3Encode {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant3FillColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant3FillColor {
     fn from(value: &LegendVariant3FillColor) -> Self {
@@ -58505,7 +58481,7 @@ impl ::std::convert::From<&Self> for LegendVariant3FillColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant3FillColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant3Format`"]
@@ -58564,8 +58540,8 @@ impl ::std::convert::From<ColorValue> for LegendVariant3FillColor {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LegendVariant3Format {
-    Variant0(::std::string::String),
-    Variant1 {
+    String(::std::string::String),
+    Object {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         date: ::std::option::Option<::std::string::String>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -58587,7 +58563,7 @@ pub enum LegendVariant3Format {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         year: ::std::option::Option<::std::string::String>,
     },
-    Variant2(SignalRef),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for LegendVariant3Format {
     fn from(value: &LegendVariant3Format) -> Self {
@@ -58596,7 +58572,7 @@ impl ::std::convert::From<&Self> for LegendVariant3Format {
 }
 impl ::std::convert::From<SignalRef> for LegendVariant3Format {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`LegendVariant3FormatType`"]
@@ -58783,9 +58759,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant3GradientOpacity {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant3GradientStrokeColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant3GradientStrokeColor {
     fn from(value: &LegendVariant3GradientStrokeColor) -> Self {
@@ -58794,7 +58770,7 @@ impl ::std::convert::From<&Self> for LegendVariant3GradientStrokeColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant3GradientStrokeColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant3GradientStrokeWidth`"]
@@ -59245,9 +59221,9 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant3LabelBasel
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant3LabelColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant3LabelColor {
     fn from(value: &LegendVariant3LabelColor) -> Self {
@@ -59256,7 +59232,7 @@ impl ::std::convert::From<&Self> for LegendVariant3LabelColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant3LabelColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant3LabelFont`"]
@@ -59875,9 +59851,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant3Padding {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant3StrokeColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant3StrokeColor {
     fn from(value: &LegendVariant3StrokeColor) -> Self {
@@ -59886,7 +59862,7 @@ impl ::std::convert::From<&Self> for LegendVariant3StrokeColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant3StrokeColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant3SymbolDash`"]
@@ -59991,9 +59967,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant3SymbolDashOffset {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant3SymbolFillColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant3SymbolFillColor {
     fn from(value: &LegendVariant3SymbolFillColor) -> Self {
@@ -60002,7 +59978,7 @@ impl ::std::convert::From<&Self> for LegendVariant3SymbolFillColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant3SymbolFillColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant3SymbolOffset`"]
@@ -60142,9 +60118,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant3SymbolSize {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant3SymbolStrokeColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant3SymbolStrokeColor {
     fn from(value: &LegendVariant3SymbolStrokeColor) -> Self {
@@ -60153,7 +60129,7 @@ impl ::std::convert::From<&Self> for LegendVariant3SymbolStrokeColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant3SymbolStrokeColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant3SymbolStrokeWidth`"]
@@ -60641,9 +60617,9 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant3TitleBasel
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant3TitleColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant3TitleColor {
     fn from(value: &LegendVariant3TitleColor) -> Self {
@@ -60652,7 +60628,7 @@ impl ::std::convert::From<&Self> for LegendVariant3TitleColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant3TitleColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant3TitleFont`"]
@@ -61379,9 +61355,9 @@ impl ::std::default::Default for LegendVariant4Encode {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant4FillColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant4FillColor {
     fn from(value: &LegendVariant4FillColor) -> Self {
@@ -61390,7 +61366,7 @@ impl ::std::convert::From<&Self> for LegendVariant4FillColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant4FillColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant4Format`"]
@@ -61449,8 +61425,8 @@ impl ::std::convert::From<ColorValue> for LegendVariant4FillColor {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LegendVariant4Format {
-    Variant0(::std::string::String),
-    Variant1 {
+    String(::std::string::String),
+    Object {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         date: ::std::option::Option<::std::string::String>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -61472,7 +61448,7 @@ pub enum LegendVariant4Format {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         year: ::std::option::Option<::std::string::String>,
     },
-    Variant2(SignalRef),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for LegendVariant4Format {
     fn from(value: &LegendVariant4Format) -> Self {
@@ -61481,7 +61457,7 @@ impl ::std::convert::From<&Self> for LegendVariant4Format {
 }
 impl ::std::convert::From<SignalRef> for LegendVariant4Format {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`LegendVariant4FormatType`"]
@@ -61668,9 +61644,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant4GradientOpacity {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant4GradientStrokeColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant4GradientStrokeColor {
     fn from(value: &LegendVariant4GradientStrokeColor) -> Self {
@@ -61679,7 +61655,7 @@ impl ::std::convert::From<&Self> for LegendVariant4GradientStrokeColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant4GradientStrokeColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant4GradientStrokeWidth`"]
@@ -62130,9 +62106,9 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant4LabelBasel
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant4LabelColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant4LabelColor {
     fn from(value: &LegendVariant4LabelColor) -> Self {
@@ -62141,7 +62117,7 @@ impl ::std::convert::From<&Self> for LegendVariant4LabelColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant4LabelColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant4LabelFont`"]
@@ -62760,9 +62736,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant4Padding {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant4StrokeColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant4StrokeColor {
     fn from(value: &LegendVariant4StrokeColor) -> Self {
@@ -62771,7 +62747,7 @@ impl ::std::convert::From<&Self> for LegendVariant4StrokeColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant4StrokeColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant4SymbolDash`"]
@@ -62876,9 +62852,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant4SymbolDashOffset {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant4SymbolFillColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant4SymbolFillColor {
     fn from(value: &LegendVariant4SymbolFillColor) -> Self {
@@ -62887,7 +62863,7 @@ impl ::std::convert::From<&Self> for LegendVariant4SymbolFillColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant4SymbolFillColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant4SymbolOffset`"]
@@ -63027,9 +63003,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant4SymbolSize {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant4SymbolStrokeColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant4SymbolStrokeColor {
     fn from(value: &LegendVariant4SymbolStrokeColor) -> Self {
@@ -63038,7 +63014,7 @@ impl ::std::convert::From<&Self> for LegendVariant4SymbolStrokeColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant4SymbolStrokeColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant4SymbolStrokeWidth`"]
@@ -63526,9 +63502,9 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant4TitleBasel
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant4TitleColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant4TitleColor {
     fn from(value: &LegendVariant4TitleColor) -> Self {
@@ -63537,7 +63513,7 @@ impl ::std::convert::From<&Self> for LegendVariant4TitleColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant4TitleColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant4TitleFont`"]
@@ -64264,9 +64240,9 @@ impl ::std::default::Default for LegendVariant5Encode {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant5FillColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant5FillColor {
     fn from(value: &LegendVariant5FillColor) -> Self {
@@ -64275,7 +64251,7 @@ impl ::std::convert::From<&Self> for LegendVariant5FillColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant5FillColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant5Format`"]
@@ -64334,8 +64310,8 @@ impl ::std::convert::From<ColorValue> for LegendVariant5FillColor {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LegendVariant5Format {
-    Variant0(::std::string::String),
-    Variant1 {
+    String(::std::string::String),
+    Object {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         date: ::std::option::Option<::std::string::String>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -64357,7 +64333,7 @@ pub enum LegendVariant5Format {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         year: ::std::option::Option<::std::string::String>,
     },
-    Variant2(SignalRef),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for LegendVariant5Format {
     fn from(value: &LegendVariant5Format) -> Self {
@@ -64366,7 +64342,7 @@ impl ::std::convert::From<&Self> for LegendVariant5Format {
 }
 impl ::std::convert::From<SignalRef> for LegendVariant5Format {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`LegendVariant5FormatType`"]
@@ -64553,9 +64529,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant5GradientOpacity {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant5GradientStrokeColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant5GradientStrokeColor {
     fn from(value: &LegendVariant5GradientStrokeColor) -> Self {
@@ -64564,7 +64540,7 @@ impl ::std::convert::From<&Self> for LegendVariant5GradientStrokeColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant5GradientStrokeColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant5GradientStrokeWidth`"]
@@ -65015,9 +64991,9 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant5LabelBasel
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant5LabelColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant5LabelColor {
     fn from(value: &LegendVariant5LabelColor) -> Self {
@@ -65026,7 +65002,7 @@ impl ::std::convert::From<&Self> for LegendVariant5LabelColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant5LabelColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant5LabelFont`"]
@@ -65645,9 +65621,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant5Padding {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant5StrokeColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant5StrokeColor {
     fn from(value: &LegendVariant5StrokeColor) -> Self {
@@ -65656,7 +65632,7 @@ impl ::std::convert::From<&Self> for LegendVariant5StrokeColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant5StrokeColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant5SymbolDash`"]
@@ -65761,9 +65737,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant5SymbolDashOffset {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant5SymbolFillColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant5SymbolFillColor {
     fn from(value: &LegendVariant5SymbolFillColor) -> Self {
@@ -65772,7 +65748,7 @@ impl ::std::convert::From<&Self> for LegendVariant5SymbolFillColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant5SymbolFillColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant5SymbolOffset`"]
@@ -65912,9 +65888,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant5SymbolSize {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant5SymbolStrokeColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant5SymbolStrokeColor {
     fn from(value: &LegendVariant5SymbolStrokeColor) -> Self {
@@ -65923,7 +65899,7 @@ impl ::std::convert::From<&Self> for LegendVariant5SymbolStrokeColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant5SymbolStrokeColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant5SymbolStrokeWidth`"]
@@ -66411,9 +66387,9 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant5TitleBasel
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant5TitleColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant5TitleColor {
     fn from(value: &LegendVariant5TitleColor) -> Self {
@@ -66422,7 +66398,7 @@ impl ::std::convert::From<&Self> for LegendVariant5TitleColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant5TitleColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant5TitleFont`"]
@@ -67149,9 +67125,9 @@ impl ::std::default::Default for LegendVariant6Encode {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant6FillColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant6FillColor {
     fn from(value: &LegendVariant6FillColor) -> Self {
@@ -67160,7 +67136,7 @@ impl ::std::convert::From<&Self> for LegendVariant6FillColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant6FillColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant6Format`"]
@@ -67219,8 +67195,8 @@ impl ::std::convert::From<ColorValue> for LegendVariant6FillColor {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum LegendVariant6Format {
-    Variant0(::std::string::String),
-    Variant1 {
+    String(::std::string::String),
+    Object {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         date: ::std::option::Option<::std::string::String>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -67242,7 +67218,7 @@ pub enum LegendVariant6Format {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         year: ::std::option::Option<::std::string::String>,
     },
-    Variant2(SignalRef),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for LegendVariant6Format {
     fn from(value: &LegendVariant6Format) -> Self {
@@ -67251,7 +67227,7 @@ impl ::std::convert::From<&Self> for LegendVariant6Format {
 }
 impl ::std::convert::From<SignalRef> for LegendVariant6Format {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`LegendVariant6FormatType`"]
@@ -67438,9 +67414,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant6GradientOpacity {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant6GradientStrokeColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant6GradientStrokeColor {
     fn from(value: &LegendVariant6GradientStrokeColor) -> Self {
@@ -67449,7 +67425,7 @@ impl ::std::convert::From<&Self> for LegendVariant6GradientStrokeColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant6GradientStrokeColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant6GradientStrokeWidth`"]
@@ -67900,9 +67876,9 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant6LabelBasel
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant6LabelColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant6LabelColor {
     fn from(value: &LegendVariant6LabelColor) -> Self {
@@ -67911,7 +67887,7 @@ impl ::std::convert::From<&Self> for LegendVariant6LabelColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant6LabelColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant6LabelFont`"]
@@ -68530,9 +68506,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant6Padding {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant6StrokeColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant6StrokeColor {
     fn from(value: &LegendVariant6StrokeColor) -> Self {
@@ -68541,7 +68517,7 @@ impl ::std::convert::From<&Self> for LegendVariant6StrokeColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant6StrokeColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant6SymbolDash`"]
@@ -68646,9 +68622,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant6SymbolDashOffset {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant6SymbolFillColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant6SymbolFillColor {
     fn from(value: &LegendVariant6SymbolFillColor) -> Self {
@@ -68657,7 +68633,7 @@ impl ::std::convert::From<&Self> for LegendVariant6SymbolFillColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant6SymbolFillColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant6SymbolOffset`"]
@@ -68797,9 +68773,9 @@ impl ::std::convert::From<NumberValue> for LegendVariant6SymbolSize {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant6SymbolStrokeColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant6SymbolStrokeColor {
     fn from(value: &LegendVariant6SymbolStrokeColor) -> Self {
@@ -68808,7 +68784,7 @@ impl ::std::convert::From<&Self> for LegendVariant6SymbolStrokeColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant6SymbolStrokeColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant6SymbolStrokeWidth`"]
@@ -69296,9 +69272,9 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant6TitleBasel
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LegendVariant6TitleColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
 impl ::std::convert::From<&Self> for LegendVariant6TitleColor {
     fn from(value: &LegendVariant6TitleColor) -> Self {
@@ -69307,7 +69283,7 @@ impl ::std::convert::From<&Self> for LegendVariant6TitleColor {
 }
 impl ::std::convert::From<ColorValue> for LegendVariant6TitleColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
 #[doc = "`LegendVariant6TitleFont`"]
@@ -70141,8 +70117,8 @@ impl ::std::convert::From<&LinkpathTransform> for LinkpathTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LinkpathTransformAs {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for LinkpathTransformAs {
     fn from(value: &LinkpathTransformAs) -> Self {
@@ -70151,12 +70127,12 @@ impl ::std::convert::From<&Self> for LinkpathTransformAs {
 }
 impl ::std::default::Default for LinkpathTransformAs {
     fn default() -> Self {
-        LinkpathTransformAs::Variant0("path".to_string())
+        LinkpathTransformAs::String("path".to_string())
     }
 }
 impl ::std::convert::From<SignalRef> for LinkpathTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`LinkpathTransformOrient`"]
@@ -70464,7 +70440,7 @@ impl ::std::convert::From<&Self> for LinkpathTransformSourceX {
 }
 impl ::std::default::Default for LinkpathTransformSourceX {
     fn default() -> Self {
-        LinkpathTransformSourceX::ScaleField(ScaleField(StringOrSignal::Variant0(
+        LinkpathTransformSourceX::ScaleField(ScaleField(StringOrSignal::String(
             "source.x".to_string(),
         )))
     }
@@ -70519,7 +70495,7 @@ impl ::std::convert::From<&Self> for LinkpathTransformSourceY {
 }
 impl ::std::default::Default for LinkpathTransformSourceY {
     fn default() -> Self {
-        LinkpathTransformSourceY::ScaleField(ScaleField(StringOrSignal::Variant0(
+        LinkpathTransformSourceY::ScaleField(ScaleField(StringOrSignal::String(
             "source.y".to_string(),
         )))
     }
@@ -70574,7 +70550,7 @@ impl ::std::convert::From<&Self> for LinkpathTransformTargetX {
 }
 impl ::std::default::Default for LinkpathTransformTargetX {
     fn default() -> Self {
-        LinkpathTransformTargetX::ScaleField(ScaleField(StringOrSignal::Variant0(
+        LinkpathTransformTargetX::ScaleField(ScaleField(StringOrSignal::String(
             "target.x".to_string(),
         )))
     }
@@ -70629,7 +70605,7 @@ impl ::std::convert::From<&Self> for LinkpathTransformTargetY {
 }
 impl ::std::default::Default for LinkpathTransformTargetY {
     fn default() -> Self {
-        LinkpathTransformTargetY::ScaleField(ScaleField(StringOrSignal::Variant0(
+        LinkpathTransformTargetY::ScaleField(ScaleField(StringOrSignal::String(
             "target.y".to_string(),
         )))
     }
@@ -70751,9 +70727,9 @@ impl ::std::convert::TryFrom<::std::string::String> for LinkpathTransformType {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum Listener {
-    Variant0(SignalRef),
-    Variant1 { scale: ::std::string::String },
-    Variant2(Stream),
+    SignalRef(SignalRef),
+    Object { scale: ::std::string::String },
+    Stream(Stream),
 }
 impl ::std::convert::From<&Self> for Listener {
     fn from(value: &Listener) -> Self {
@@ -70762,12 +70738,12 @@ impl ::std::convert::From<&Self> for Listener {
 }
 impl ::std::convert::From<SignalRef> for Listener {
     fn from(value: SignalRef) -> Self {
-        Self::Variant0(value)
+        Self::SignalRef(value)
     }
 }
 impl ::std::convert::From<Stream> for Listener {
     fn from(value: Stream) -> Self {
-        Self::Variant2(value)
+        Self::Stream(value)
     }
 }
 #[doc = "`LoessTransform`"]
@@ -70931,25 +70907,25 @@ impl ::std::convert::From<&LoessTransform> for LoessTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LoessTransformAs {
-    Variant0(::std::vec::Vec<LoessTransformAsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<LoessTransformAsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for LoessTransformAs {
     fn from(value: &LoessTransformAs) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<LoessTransformAsVariant0Item>> for LoessTransformAs {
-    fn from(value: ::std::vec::Vec<LoessTransformAsVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<LoessTransformAsArrayItem>> for LoessTransformAs {
+    fn from(value: ::std::vec::Vec<LoessTransformAsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for LoessTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`LoessTransformAsVariant0Item`"]
+#[doc = "`LoessTransformAsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -70968,18 +70944,18 @@ impl ::std::convert::From<SignalRef> for LoessTransformAs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum LoessTransformAsVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum LoessTransformAsArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for LoessTransformAsVariant0Item {
-    fn from(value: &LoessTransformAsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for LoessTransformAsArrayItem {
+    fn from(value: &LoessTransformAsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for LoessTransformAsVariant0Item {
+impl ::std::convert::From<SignalRef> for LoessTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`LoessTransformBandwidth`"]
@@ -71003,8 +70979,8 @@ impl ::std::convert::From<SignalRef> for LoessTransformAsVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LoessTransformBandwidth {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for LoessTransformBandwidth {
     fn from(value: &LoessTransformBandwidth) -> Self {
@@ -71013,17 +70989,17 @@ impl ::std::convert::From<&Self> for LoessTransformBandwidth {
 }
 impl ::std::default::Default for LoessTransformBandwidth {
     fn default() -> Self {
-        LoessTransformBandwidth::Variant0(0.3_f64)
+        LoessTransformBandwidth::Number(0.3_f64)
     }
 }
 impl ::std::convert::From<f64> for LoessTransformBandwidth {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for LoessTransformBandwidth {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`LoessTransformGroupby`"]
@@ -71059,27 +71035,27 @@ impl ::std::convert::From<SignalRef> for LoessTransformBandwidth {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LoessTransformGroupby {
-    Variant0(::std::vec::Vec<LoessTransformGroupbyVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<LoessTransformGroupbyArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for LoessTransformGroupby {
     fn from(value: &LoessTransformGroupby) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<LoessTransformGroupbyVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<LoessTransformGroupbyArrayItem>>
     for LoessTransformGroupby
 {
-    fn from(value: ::std::vec::Vec<LoessTransformGroupbyVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<LoessTransformGroupbyArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for LoessTransformGroupby {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`LoessTransformGroupbyVariant0Item`"]
+#[doc = "`LoessTransformGroupbyArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -71101,27 +71077,27 @@ impl ::std::convert::From<SignalRef> for LoessTransformGroupby {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum LoessTransformGroupbyVariant0Item {
+pub enum LoessTransformGroupbyArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for LoessTransformGroupbyVariant0Item {
-    fn from(value: &LoessTransformGroupbyVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for LoessTransformGroupbyArrayItem {
+    fn from(value: &LoessTransformGroupbyArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<ScaleField> for LoessTransformGroupbyVariant0Item {
+impl ::std::convert::From<ScaleField> for LoessTransformGroupbyArrayItem {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
     }
 }
-impl ::std::convert::From<ParamField> for LoessTransformGroupbyVariant0Item {
+impl ::std::convert::From<ParamField> for LoessTransformGroupbyArrayItem {
     fn from(value: ParamField) -> Self {
         Self::ParamField(value)
     }
 }
-impl ::std::convert::From<Expr> for LoessTransformGroupbyVariant0Item {
+impl ::std::convert::From<Expr> for LoessTransformGroupbyArrayItem {
     fn from(value: Expr) -> Self {
         Self::Expr(value)
     }
@@ -71457,25 +71433,25 @@ impl ::std::convert::From<&LookupTransform> for LookupTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LookupTransformAs {
-    Variant0(::std::vec::Vec<LookupTransformAsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<LookupTransformAsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for LookupTransformAs {
     fn from(value: &LookupTransformAs) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<LookupTransformAsVariant0Item>> for LookupTransformAs {
-    fn from(value: ::std::vec::Vec<LookupTransformAsVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<LookupTransformAsArrayItem>> for LookupTransformAs {
+    fn from(value: ::std::vec::Vec<LookupTransformAsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for LookupTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`LookupTransformAsVariant0Item`"]
+#[doc = "`LookupTransformAsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -71494,18 +71470,18 @@ impl ::std::convert::From<SignalRef> for LookupTransformAs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum LookupTransformAsVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum LookupTransformAsArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for LookupTransformAsVariant0Item {
-    fn from(value: &LookupTransformAsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for LookupTransformAsArrayItem {
+    fn from(value: &LookupTransformAsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for LookupTransformAsVariant0Item {
+impl ::std::convert::From<SignalRef> for LookupTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`LookupTransformFields`"]
@@ -71541,27 +71517,27 @@ impl ::std::convert::From<SignalRef> for LookupTransformAsVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LookupTransformFields {
-    Variant0(::std::vec::Vec<LookupTransformFieldsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<LookupTransformFieldsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for LookupTransformFields {
     fn from(value: &LookupTransformFields) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<LookupTransformFieldsVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<LookupTransformFieldsArrayItem>>
     for LookupTransformFields
 {
-    fn from(value: ::std::vec::Vec<LookupTransformFieldsVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<LookupTransformFieldsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for LookupTransformFields {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`LookupTransformFieldsVariant0Item`"]
+#[doc = "`LookupTransformFieldsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -71583,27 +71559,27 @@ impl ::std::convert::From<SignalRef> for LookupTransformFields {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum LookupTransformFieldsVariant0Item {
+pub enum LookupTransformFieldsArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for LookupTransformFieldsVariant0Item {
-    fn from(value: &LookupTransformFieldsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for LookupTransformFieldsArrayItem {
+    fn from(value: &LookupTransformFieldsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<ScaleField> for LookupTransformFieldsVariant0Item {
+impl ::std::convert::From<ScaleField> for LookupTransformFieldsArrayItem {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
     }
 }
-impl ::std::convert::From<ParamField> for LookupTransformFieldsVariant0Item {
+impl ::std::convert::From<ParamField> for LookupTransformFieldsArrayItem {
     fn from(value: ParamField) -> Self {
         Self::ParamField(value)
     }
 }
-impl ::std::convert::From<Expr> for LookupTransformFieldsVariant0Item {
+impl ::std::convert::From<Expr> for LookupTransformFieldsArrayItem {
     fn from(value: Expr) -> Self {
         Self::Expr(value)
     }
@@ -71759,27 +71735,27 @@ impl ::std::convert::TryFrom<::std::string::String> for LookupTransformType {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum LookupTransformValues {
-    Variant0(::std::vec::Vec<LookupTransformValuesVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<LookupTransformValuesArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for LookupTransformValues {
     fn from(value: &LookupTransformValues) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<LookupTransformValuesVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<LookupTransformValuesArrayItem>>
     for LookupTransformValues
 {
-    fn from(value: ::std::vec::Vec<LookupTransformValuesVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<LookupTransformValuesArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for LookupTransformValues {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`LookupTransformValuesVariant0Item`"]
+#[doc = "`LookupTransformValuesArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -71801,27 +71777,27 @@ impl ::std::convert::From<SignalRef> for LookupTransformValues {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum LookupTransformValuesVariant0Item {
+pub enum LookupTransformValuesArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for LookupTransformValuesVariant0Item {
-    fn from(value: &LookupTransformValuesVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for LookupTransformValuesArrayItem {
+    fn from(value: &LookupTransformValuesArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<ScaleField> for LookupTransformValuesVariant0Item {
+impl ::std::convert::From<ScaleField> for LookupTransformValuesArrayItem {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
     }
 }
-impl ::std::convert::From<ParamField> for LookupTransformValuesVariant0Item {
+impl ::std::convert::From<ParamField> for LookupTransformValuesArrayItem {
     fn from(value: ParamField) -> Self {
         Self::ParamField(value)
     }
 }
-impl ::std::convert::From<Expr> for LookupTransformValuesVariant0Item {
+impl ::std::convert::From<Expr> for LookupTransformValuesArrayItem {
     fn from(value: Expr) -> Self {
         Self::Expr(value)
     }
@@ -72430,8 +72406,8 @@ impl ::std::convert::From<&NestTransform> for NestTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum NestTransformGenerate {
-    Variant0(bool),
-    Variant1(SignalRef),
+    Boolean(bool),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for NestTransformGenerate {
     fn from(value: &NestTransformGenerate) -> Self {
@@ -72440,12 +72416,12 @@ impl ::std::convert::From<&Self> for NestTransformGenerate {
 }
 impl ::std::convert::From<bool> for NestTransformGenerate {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<SignalRef> for NestTransformGenerate {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`NestTransformKeys`"]
@@ -72481,25 +72457,25 @@ impl ::std::convert::From<SignalRef> for NestTransformGenerate {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum NestTransformKeys {
-    Variant0(::std::vec::Vec<NestTransformKeysVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<NestTransformKeysArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for NestTransformKeys {
     fn from(value: &NestTransformKeys) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<NestTransformKeysVariant0Item>> for NestTransformKeys {
-    fn from(value: ::std::vec::Vec<NestTransformKeysVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<NestTransformKeysArrayItem>> for NestTransformKeys {
+    fn from(value: ::std::vec::Vec<NestTransformKeysArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for NestTransformKeys {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`NestTransformKeysVariant0Item`"]
+#[doc = "`NestTransformKeysArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -72521,27 +72497,27 @@ impl ::std::convert::From<SignalRef> for NestTransformKeys {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum NestTransformKeysVariant0Item {
+pub enum NestTransformKeysArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for NestTransformKeysVariant0Item {
-    fn from(value: &NestTransformKeysVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for NestTransformKeysArrayItem {
+    fn from(value: &NestTransformKeysArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<ScaleField> for NestTransformKeysVariant0Item {
+impl ::std::convert::From<ScaleField> for NestTransformKeysArrayItem {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
     }
 }
-impl ::std::convert::From<ParamField> for NestTransformKeysVariant0Item {
+impl ::std::convert::From<ParamField> for NestTransformKeysArrayItem {
     fn from(value: ParamField) -> Self {
         Self::ParamField(value)
     }
 }
-impl ::std::convert::From<Expr> for NestTransformKeysVariant0Item {
+impl ::std::convert::From<Expr> for NestTransformKeysArrayItem {
     fn from(value: Expr) -> Self {
         Self::Expr(value)
     }
@@ -72734,8 +72710,8 @@ impl ::std::default::Default for NumberModifiers {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum NumberModifiersBand {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for NumberModifiersBand {
     fn from(value: &NumberModifiersBand) -> Self {
@@ -72746,9 +72722,9 @@ impl ::std::str::FromStr for NumberModifiersBand {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -72779,19 +72755,19 @@ impl ::std::convert::TryFrom<::std::string::String> for NumberModifiersBand {
 impl ::std::fmt::Display for NumberModifiersBand {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for NumberModifiersBand {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for NumberModifiersBand {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`NumberModifiersExponent`"]
@@ -72928,8 +72904,8 @@ impl ::std::convert::From<NumberValue> for NumberModifiersOffset {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum NumberOrSignal {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for NumberOrSignal {
     fn from(value: &NumberOrSignal) -> Self {
@@ -72938,12 +72914,12 @@ impl ::std::convert::From<&Self> for NumberOrSignal {
 }
 impl ::std::convert::From<f64> for NumberOrSignal {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for NumberOrSignal {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`NumberValue`"]
@@ -73523,8 +73499,8 @@ impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant0 {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant0Variant0Band {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant0Variant0Band {
     fn from(value: &NumberValueVariant0ItemVariant0Variant0Band) -> Self {
@@ -73535,9 +73511,9 @@ impl ::std::str::FromStr for NumberValueVariant0ItemVariant0Variant0Band {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -73572,19 +73548,19 @@ impl ::std::convert::TryFrom<::std::string::String>
 impl ::std::fmt::Display for NumberValueVariant0ItemVariant0Variant0Band {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for NumberValueVariant0ItemVariant0Variant0Band {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for NumberValueVariant0ItemVariant0Variant0Band {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`NumberValueVariant0ItemVariant0Variant0Exponent`"]
@@ -73721,8 +73697,8 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant0Varian
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant0Variant1Band {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant0Variant1Band {
     fn from(value: &NumberValueVariant0ItemVariant0Variant1Band) -> Self {
@@ -73733,9 +73709,9 @@ impl ::std::str::FromStr for NumberValueVariant0ItemVariant0Variant1Band {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -73770,19 +73746,19 @@ impl ::std::convert::TryFrom<::std::string::String>
 impl ::std::fmt::Display for NumberValueVariant0ItemVariant0Variant1Band {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for NumberValueVariant0ItemVariant0Variant1Band {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for NumberValueVariant0ItemVariant0Variant1Band {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`NumberValueVariant0ItemVariant0Variant1Exponent`"]
@@ -73919,8 +73895,8 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant0Varian
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant0Variant2Band {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant0Variant2Band {
     fn from(value: &NumberValueVariant0ItemVariant0Variant2Band) -> Self {
@@ -73931,9 +73907,9 @@ impl ::std::str::FromStr for NumberValueVariant0ItemVariant0Variant2Band {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -73968,19 +73944,19 @@ impl ::std::convert::TryFrom<::std::string::String>
 impl ::std::fmt::Display for NumberValueVariant0ItemVariant0Variant2Band {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for NumberValueVariant0ItemVariant0Variant2Band {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for NumberValueVariant0ItemVariant0Variant2Band {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`NumberValueVariant0ItemVariant0Variant2Exponent`"]
@@ -74117,8 +74093,8 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant0Varian
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant0Variant3Band {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant0Variant3Band {
     fn from(value: &NumberValueVariant0ItemVariant0Variant3Band) -> Self {
@@ -74129,9 +74105,9 @@ impl ::std::str::FromStr for NumberValueVariant0ItemVariant0Variant3Band {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -74166,19 +74142,19 @@ impl ::std::convert::TryFrom<::std::string::String>
 impl ::std::fmt::Display for NumberValueVariant0ItemVariant0Variant3Band {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for NumberValueVariant0ItemVariant0Variant3Band {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for NumberValueVariant0ItemVariant0Variant3Band {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`NumberValueVariant0ItemVariant0Variant3Exponent`"]
@@ -74315,8 +74291,8 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant0Varian
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant0Variant3Range {
     fn from(value: &NumberValueVariant0ItemVariant0Variant3Range) -> Self {
@@ -74327,9 +74303,9 @@ impl ::std::str::FromStr for NumberValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -74364,19 +74340,19 @@ impl ::std::convert::TryFrom<::std::string::String>
 impl ::std::fmt::Display for NumberValueVariant0ItemVariant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for NumberValueVariant0ItemVariant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for NumberValueVariant0ItemVariant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`NumberValueVariant0ItemVariant1`"]
@@ -75174,8 +75150,8 @@ impl ::std::convert::From<&Self> for NumberValueVariant1Variant0 {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant0Variant0Band {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for NumberValueVariant1Variant0Variant0Band {
     fn from(value: &NumberValueVariant1Variant0Variant0Band) -> Self {
@@ -75186,9 +75162,9 @@ impl ::std::str::FromStr for NumberValueVariant1Variant0Variant0Band {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -75219,19 +75195,19 @@ impl ::std::convert::TryFrom<::std::string::String> for NumberValueVariant1Varia
 impl ::std::fmt::Display for NumberValueVariant1Variant0Variant0Band {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for NumberValueVariant1Variant0Variant0Band {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for NumberValueVariant1Variant0Variant0Band {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`NumberValueVariant1Variant0Variant0Exponent`"]
@@ -75374,8 +75350,8 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant0Variant1Band {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for NumberValueVariant1Variant0Variant1Band {
     fn from(value: &NumberValueVariant1Variant0Variant1Band) -> Self {
@@ -75386,9 +75362,9 @@ impl ::std::str::FromStr for NumberValueVariant1Variant0Variant1Band {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -75419,19 +75395,19 @@ impl ::std::convert::TryFrom<::std::string::String> for NumberValueVariant1Varia
 impl ::std::fmt::Display for NumberValueVariant1Variant0Variant1Band {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for NumberValueVariant1Variant0Variant1Band {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for NumberValueVariant1Variant0Variant1Band {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`NumberValueVariant1Variant0Variant1Exponent`"]
@@ -75574,8 +75550,8 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant0Variant2Band {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for NumberValueVariant1Variant0Variant2Band {
     fn from(value: &NumberValueVariant1Variant0Variant2Band) -> Self {
@@ -75586,9 +75562,9 @@ impl ::std::str::FromStr for NumberValueVariant1Variant0Variant2Band {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -75619,19 +75595,19 @@ impl ::std::convert::TryFrom<::std::string::String> for NumberValueVariant1Varia
 impl ::std::fmt::Display for NumberValueVariant1Variant0Variant2Band {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for NumberValueVariant1Variant0Variant2Band {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for NumberValueVariant1Variant0Variant2Band {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`NumberValueVariant1Variant0Variant2Exponent`"]
@@ -75774,8 +75750,8 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant0Variant3Band {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for NumberValueVariant1Variant0Variant3Band {
     fn from(value: &NumberValueVariant1Variant0Variant3Band) -> Self {
@@ -75786,9 +75762,9 @@ impl ::std::str::FromStr for NumberValueVariant1Variant0Variant3Band {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -75819,19 +75795,19 @@ impl ::std::convert::TryFrom<::std::string::String> for NumberValueVariant1Varia
 impl ::std::fmt::Display for NumberValueVariant1Variant0Variant3Band {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for NumberValueVariant1Variant0Variant3Band {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for NumberValueVariant1Variant0Variant3Band {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`NumberValueVariant1Variant0Variant3Exponent`"]
@@ -75974,8 +75950,8 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for NumberValueVariant1Variant0Variant3Range {
     fn from(value: &NumberValueVariant1Variant0Variant3Range) -> Self {
@@ -75986,9 +75962,9 @@ impl ::std::str::FromStr for NumberValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -76019,19 +75995,19 @@ impl ::std::convert::TryFrom<::std::string::String> for NumberValueVariant1Varia
 impl ::std::fmt::Display for NumberValueVariant1Variant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for NumberValueVariant1Variant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for NumberValueVariant1Variant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`NumberValueVariant1Variant1`"]
@@ -76707,9 +76683,9 @@ impl ::std::convert::From<&Self> for OnEventsItem {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum OnEventsItemVariant0Events {
-    Variant0(Selector),
-    Variant1(Listener),
-    Variant2(::std::vec::Vec<Listener>),
+    Selector(Selector),
+    Listener(Listener),
+    Array(::std::vec::Vec<Listener>),
 }
 impl ::std::convert::From<&Self> for OnEventsItemVariant0Events {
     fn from(value: &OnEventsItemVariant0Events) -> Self {
@@ -76718,17 +76694,17 @@ impl ::std::convert::From<&Self> for OnEventsItemVariant0Events {
 }
 impl ::std::convert::From<Selector> for OnEventsItemVariant0Events {
     fn from(value: Selector) -> Self {
-        Self::Variant0(value)
+        Self::Selector(value)
     }
 }
 impl ::std::convert::From<Listener> for OnEventsItemVariant0Events {
     fn from(value: Listener) -> Self {
-        Self::Variant1(value)
+        Self::Listener(value)
     }
 }
 impl ::std::convert::From<::std::vec::Vec<Listener>> for OnEventsItemVariant0Events {
     fn from(value: ::std::vec::Vec<Listener>) -> Self {
-        Self::Variant2(value)
+        Self::Array(value)
     }
 }
 #[doc = "`OnEventsItemVariant1Events`"]
@@ -76758,9 +76734,9 @@ impl ::std::convert::From<::std::vec::Vec<Listener>> for OnEventsItemVariant0Eve
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum OnEventsItemVariant1Events {
-    Variant0(Selector),
-    Variant1(Listener),
-    Variant2(::std::vec::Vec<Listener>),
+    Selector(Selector),
+    Listener(Listener),
+    Array(::std::vec::Vec<Listener>),
 }
 impl ::std::convert::From<&Self> for OnEventsItemVariant1Events {
     fn from(value: &OnEventsItemVariant1Events) -> Self {
@@ -76769,17 +76745,17 @@ impl ::std::convert::From<&Self> for OnEventsItemVariant1Events {
 }
 impl ::std::convert::From<Selector> for OnEventsItemVariant1Events {
     fn from(value: Selector) -> Self {
-        Self::Variant0(value)
+        Self::Selector(value)
     }
 }
 impl ::std::convert::From<Listener> for OnEventsItemVariant1Events {
     fn from(value: Listener) -> Self {
-        Self::Variant1(value)
+        Self::Listener(value)
     }
 }
 impl ::std::convert::From<::std::vec::Vec<Listener>> for OnEventsItemVariant1Events {
     fn from(value: ::std::vec::Vec<Listener>) -> Self {
-        Self::Variant2(value)
+        Self::Array(value)
     }
 }
 #[doc = "`OnEventsItemVariant1Update`"]
@@ -76814,10 +76790,10 @@ impl ::std::convert::From<::std::vec::Vec<Listener>> for OnEventsItemVariant1Eve
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum OnEventsItemVariant1Update {
-    Variant0(ExprString),
-    Variant1(Expr),
-    Variant2(SignalRef),
-    Variant3 { value: ::serde_json::Value },
+    ExprString(ExprString),
+    Expr(Expr),
+    SignalRef(SignalRef),
+    Object { value: ::serde_json::Value },
 }
 impl ::std::convert::From<&Self> for OnEventsItemVariant1Update {
     fn from(value: &OnEventsItemVariant1Update) -> Self {
@@ -76826,17 +76802,17 @@ impl ::std::convert::From<&Self> for OnEventsItemVariant1Update {
 }
 impl ::std::convert::From<ExprString> for OnEventsItemVariant1Update {
     fn from(value: ExprString) -> Self {
-        Self::Variant0(value)
+        Self::ExprString(value)
     }
 }
 impl ::std::convert::From<Expr> for OnEventsItemVariant1Update {
     fn from(value: Expr) -> Self {
-        Self::Variant1(value)
+        Self::Expr(value)
     }
 }
 impl ::std::convert::From<SignalRef> for OnEventsItemVariant1Update {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`OnMarkTrigger`"]
@@ -77079,8 +77055,8 @@ impl ::std::convert::From<&OnTriggerItem> for OnTriggerItem {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum OnTriggerItemRemove {
-    Variant0(bool),
-    Variant1(ExprString),
+    Boolean(bool),
+    ExprString(ExprString),
 }
 impl ::std::convert::From<&Self> for OnTriggerItemRemove {
     fn from(value: &OnTriggerItemRemove) -> Self {
@@ -77090,19 +77066,19 @@ impl ::std::convert::From<&Self> for OnTriggerItemRemove {
 impl ::std::fmt::Display for OnTriggerItemRemove {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+            Self::ExprString(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<bool> for OnTriggerItemRemove {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<ExprString> for OnTriggerItemRemove {
     fn from(value: ExprString) -> Self {
-        Self::Variant1(value)
+        Self::ExprString(value)
     }
 }
 #[doc = "`OrientValue`"]
@@ -77689,8 +77665,8 @@ impl ::std::convert::TryFrom<::std::string::String>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum OrientValueVariant0ItemVariant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for OrientValueVariant0ItemVariant0Variant3Range {
     fn from(value: &OrientValueVariant0ItemVariant0Variant3Range) -> Self {
@@ -77701,9 +77677,9 @@ impl ::std::str::FromStr for OrientValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -77738,19 +77714,19 @@ impl ::std::convert::TryFrom<::std::string::String>
 impl ::std::fmt::Display for OrientValueVariant0ItemVariant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for OrientValueVariant0ItemVariant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for OrientValueVariant0ItemVariant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`OrientValueVariant0ItemVariant1`"]
@@ -78341,8 +78317,8 @@ impl ::std::convert::TryFrom<::std::string::String> for OrientValueVariant1Varia
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum OrientValueVariant1Variant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for OrientValueVariant1Variant0Variant3Range {
     fn from(value: &OrientValueVariant1Variant0Variant3Range) -> Self {
@@ -78353,9 +78329,9 @@ impl ::std::str::FromStr for OrientValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -78386,19 +78362,19 @@ impl ::std::convert::TryFrom<::std::string::String> for OrientValueVariant1Varia
 impl ::std::fmt::Display for OrientValueVariant1Variant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for OrientValueVariant1Variant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for OrientValueVariant1Variant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`OrientValueVariant1Variant1`"]
@@ -78811,8 +78787,8 @@ impl ::std::convert::From<&PackTransform> for PackTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum PackTransformAs {
-    Variant0([PackTransformAsVariant0Item; 5usize]),
-    Variant1(SignalRef),
+    Array([PackTransformAsArrayItem; 5usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for PackTransformAs {
     fn from(value: &PackTransformAs) -> Self {
@@ -78821,26 +78797,26 @@ impl ::std::convert::From<&Self> for PackTransformAs {
 }
 impl ::std::default::Default for PackTransformAs {
     fn default() -> Self {
-        PackTransformAs::Variant0([
-            PackTransformAsVariant0Item::Variant0("x".to_string()),
-            PackTransformAsVariant0Item::Variant0("y".to_string()),
-            PackTransformAsVariant0Item::Variant0("r".to_string()),
-            PackTransformAsVariant0Item::Variant0("depth".to_string()),
-            PackTransformAsVariant0Item::Variant0("children".to_string()),
+        PackTransformAs::Array([
+            PackTransformAsArrayItem::String("x".to_string()),
+            PackTransformAsArrayItem::String("y".to_string()),
+            PackTransformAsArrayItem::String("r".to_string()),
+            PackTransformAsArrayItem::String("depth".to_string()),
+            PackTransformAsArrayItem::String("children".to_string()),
         ])
     }
 }
-impl ::std::convert::From<[PackTransformAsVariant0Item; 5usize]> for PackTransformAs {
-    fn from(value: [PackTransformAsVariant0Item; 5usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[PackTransformAsArrayItem; 5usize]> for PackTransformAs {
+    fn from(value: [PackTransformAsArrayItem; 5usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for PackTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`PackTransformAsVariant0Item`"]
+#[doc = "`PackTransformAsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -78859,18 +78835,18 @@ impl ::std::convert::From<SignalRef> for PackTransformAs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum PackTransformAsVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum PackTransformAsArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for PackTransformAsVariant0Item {
-    fn from(value: &PackTransformAsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for PackTransformAsArrayItem {
+    fn from(value: &PackTransformAsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for PackTransformAsVariant0Item {
+impl ::std::convert::From<SignalRef> for PackTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`PackTransformField`"]
@@ -78940,8 +78916,8 @@ impl ::std::convert::From<Expr> for PackTransformField {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum PackTransformPadding {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for PackTransformPadding {
     fn from(value: &PackTransformPadding) -> Self {
@@ -78950,12 +78926,12 @@ impl ::std::convert::From<&Self> for PackTransformPadding {
 }
 impl ::std::convert::From<f64> for PackTransformPadding {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for PackTransformPadding {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`PackTransformRadius`"]
@@ -79037,25 +79013,25 @@ impl ::std::convert::From<Expr> for PackTransformRadius {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum PackTransformSize {
-    Variant0([PackTransformSizeVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([PackTransformSizeArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for PackTransformSize {
     fn from(value: &PackTransformSize) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<[PackTransformSizeVariant0Item; 2usize]> for PackTransformSize {
-    fn from(value: [PackTransformSizeVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[PackTransformSizeArrayItem; 2usize]> for PackTransformSize {
+    fn from(value: [PackTransformSizeArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for PackTransformSize {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`PackTransformSizeVariant0Item`"]
+#[doc = "`PackTransformSizeArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79074,23 +79050,23 @@ impl ::std::convert::From<SignalRef> for PackTransformSize {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum PackTransformSizeVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum PackTransformSizeArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for PackTransformSizeVariant0Item {
-    fn from(value: &PackTransformSizeVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for PackTransformSizeArrayItem {
+    fn from(value: &PackTransformSizeArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for PackTransformSizeVariant0Item {
+impl ::std::convert::From<f64> for PackTransformSizeArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for PackTransformSizeVariant0Item {
+impl ::std::convert::From<SignalRef> for PackTransformSizeArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`PackTransformType`"]
@@ -79202,8 +79178,8 @@ impl ::std::convert::TryFrom<::std::string::String> for PackTransformType {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Padding {
-    Variant0(f64),
-    Variant1 {
+    Number(f64),
+    Object {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         bottom: ::std::option::Option<f64>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -79213,7 +79189,7 @@ pub enum Padding {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         top: ::std::option::Option<f64>,
     },
-    Variant2(SignalRef),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for Padding {
     fn from(value: &Padding) -> Self {
@@ -79222,12 +79198,12 @@ impl ::std::convert::From<&Self> for Padding {
 }
 impl ::std::convert::From<f64> for Padding {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for Padding {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ParamField`"]
@@ -79445,8 +79421,8 @@ impl ::std::convert::From<&PartitionTransform> for PartitionTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum PartitionTransformAs {
-    Variant0([PartitionTransformAsVariant0Item; 6usize]),
-    Variant1(SignalRef),
+    Array([PartitionTransformAsArrayItem; 6usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for PartitionTransformAs {
     fn from(value: &PartitionTransformAs) -> Self {
@@ -79455,27 +79431,27 @@ impl ::std::convert::From<&Self> for PartitionTransformAs {
 }
 impl ::std::default::Default for PartitionTransformAs {
     fn default() -> Self {
-        PartitionTransformAs::Variant0([
-            PartitionTransformAsVariant0Item::Variant0("x0".to_string()),
-            PartitionTransformAsVariant0Item::Variant0("y0".to_string()),
-            PartitionTransformAsVariant0Item::Variant0("x1".to_string()),
-            PartitionTransformAsVariant0Item::Variant0("y1".to_string()),
-            PartitionTransformAsVariant0Item::Variant0("depth".to_string()),
-            PartitionTransformAsVariant0Item::Variant0("children".to_string()),
+        PartitionTransformAs::Array([
+            PartitionTransformAsArrayItem::String("x0".to_string()),
+            PartitionTransformAsArrayItem::String("y0".to_string()),
+            PartitionTransformAsArrayItem::String("x1".to_string()),
+            PartitionTransformAsArrayItem::String("y1".to_string()),
+            PartitionTransformAsArrayItem::String("depth".to_string()),
+            PartitionTransformAsArrayItem::String("children".to_string()),
         ])
     }
 }
-impl ::std::convert::From<[PartitionTransformAsVariant0Item; 6usize]> for PartitionTransformAs {
-    fn from(value: [PartitionTransformAsVariant0Item; 6usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[PartitionTransformAsArrayItem; 6usize]> for PartitionTransformAs {
+    fn from(value: [PartitionTransformAsArrayItem; 6usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for PartitionTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`PartitionTransformAsVariant0Item`"]
+#[doc = "`PartitionTransformAsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79494,18 +79470,18 @@ impl ::std::convert::From<SignalRef> for PartitionTransformAs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum PartitionTransformAsVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum PartitionTransformAsArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for PartitionTransformAsVariant0Item {
-    fn from(value: &PartitionTransformAsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for PartitionTransformAsArrayItem {
+    fn from(value: &PartitionTransformAsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for PartitionTransformAsVariant0Item {
+impl ::std::convert::From<SignalRef> for PartitionTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`PartitionTransformField`"]
@@ -79575,8 +79551,8 @@ impl ::std::convert::From<Expr> for PartitionTransformField {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum PartitionTransformPadding {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for PartitionTransformPadding {
     fn from(value: &PartitionTransformPadding) -> Self {
@@ -79585,12 +79561,12 @@ impl ::std::convert::From<&Self> for PartitionTransformPadding {
 }
 impl ::std::convert::From<f64> for PartitionTransformPadding {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for PartitionTransformPadding {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`PartitionTransformRound`"]
@@ -79613,8 +79589,8 @@ impl ::std::convert::From<SignalRef> for PartitionTransformPadding {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum PartitionTransformRound {
-    Variant0(bool),
-    Variant1(SignalRef),
+    Boolean(bool),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for PartitionTransformRound {
     fn from(value: &PartitionTransformRound) -> Self {
@@ -79623,12 +79599,12 @@ impl ::std::convert::From<&Self> for PartitionTransformRound {
 }
 impl ::std::convert::From<bool> for PartitionTransformRound {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<SignalRef> for PartitionTransformRound {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`PartitionTransformSize`"]
@@ -79663,25 +79639,25 @@ impl ::std::convert::From<SignalRef> for PartitionTransformRound {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum PartitionTransformSize {
-    Variant0([PartitionTransformSizeVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([PartitionTransformSizeArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for PartitionTransformSize {
     fn from(value: &PartitionTransformSize) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<[PartitionTransformSizeVariant0Item; 2usize]> for PartitionTransformSize {
-    fn from(value: [PartitionTransformSizeVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[PartitionTransformSizeArrayItem; 2usize]> for PartitionTransformSize {
+    fn from(value: [PartitionTransformSizeArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for PartitionTransformSize {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`PartitionTransformSizeVariant0Item`"]
+#[doc = "`PartitionTransformSizeArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79700,23 +79676,23 @@ impl ::std::convert::From<SignalRef> for PartitionTransformSize {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum PartitionTransformSizeVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum PartitionTransformSizeArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for PartitionTransformSizeVariant0Item {
-    fn from(value: &PartitionTransformSizeVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for PartitionTransformSizeArrayItem {
+    fn from(value: &PartitionTransformSizeArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for PartitionTransformSizeVariant0Item {
+impl ::std::convert::From<f64> for PartitionTransformSizeArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for PartitionTransformSizeVariant0Item {
+impl ::std::convert::From<SignalRef> for PartitionTransformSizeArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`PartitionTransformType`"]
@@ -79947,8 +79923,8 @@ impl ::std::convert::From<&PieTransform> for PieTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum PieTransformAs {
-    Variant0([PieTransformAsVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([PieTransformAsArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for PieTransformAs {
     fn from(value: &PieTransformAs) -> Self {
@@ -79957,23 +79933,23 @@ impl ::std::convert::From<&Self> for PieTransformAs {
 }
 impl ::std::default::Default for PieTransformAs {
     fn default() -> Self {
-        PieTransformAs::Variant0([
-            PieTransformAsVariant0Item::Variant0("startAngle".to_string()),
-            PieTransformAsVariant0Item::Variant0("endAngle".to_string()),
+        PieTransformAs::Array([
+            PieTransformAsArrayItem::String("startAngle".to_string()),
+            PieTransformAsArrayItem::String("endAngle".to_string()),
         ])
     }
 }
-impl ::std::convert::From<[PieTransformAsVariant0Item; 2usize]> for PieTransformAs {
-    fn from(value: [PieTransformAsVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[PieTransformAsArrayItem; 2usize]> for PieTransformAs {
+    fn from(value: [PieTransformAsArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for PieTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`PieTransformAsVariant0Item`"]
+#[doc = "`PieTransformAsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -79992,18 +79968,18 @@ impl ::std::convert::From<SignalRef> for PieTransformAs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum PieTransformAsVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum PieTransformAsArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for PieTransformAsVariant0Item {
-    fn from(value: &PieTransformAsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for PieTransformAsArrayItem {
+    fn from(value: &PieTransformAsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for PieTransformAsVariant0Item {
+impl ::std::convert::From<SignalRef> for PieTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`PieTransformEndAngle`"]
@@ -80027,8 +80003,8 @@ impl ::std::convert::From<SignalRef> for PieTransformAsVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum PieTransformEndAngle {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for PieTransformEndAngle {
     fn from(value: &PieTransformEndAngle) -> Self {
@@ -80037,17 +80013,17 @@ impl ::std::convert::From<&Self> for PieTransformEndAngle {
 }
 impl ::std::default::Default for PieTransformEndAngle {
     fn default() -> Self {
-        PieTransformEndAngle::Variant0(6.283185307179586_f64)
+        PieTransformEndAngle::Number(6.283185307179586_f64)
     }
 }
 impl ::std::convert::From<f64> for PieTransformEndAngle {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for PieTransformEndAngle {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`PieTransformField`"]
@@ -80117,8 +80093,8 @@ impl ::std::convert::From<Expr> for PieTransformField {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum PieTransformSort {
-    Variant0(bool),
-    Variant1(SignalRef),
+    Boolean(bool),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for PieTransformSort {
     fn from(value: &PieTransformSort) -> Self {
@@ -80127,12 +80103,12 @@ impl ::std::convert::From<&Self> for PieTransformSort {
 }
 impl ::std::convert::From<bool> for PieTransformSort {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<SignalRef> for PieTransformSort {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`PieTransformStartAngle`"]
@@ -80155,8 +80131,8 @@ impl ::std::convert::From<SignalRef> for PieTransformSort {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum PieTransformStartAngle {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for PieTransformStartAngle {
     fn from(value: &PieTransformStartAngle) -> Self {
@@ -80165,12 +80141,12 @@ impl ::std::convert::From<&Self> for PieTransformStartAngle {
 }
 impl ::std::convert::From<f64> for PieTransformStartAngle {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for PieTransformStartAngle {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`PieTransformType`"]
@@ -80481,27 +80457,27 @@ impl ::std::convert::From<Expr> for PivotTransformField {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum PivotTransformGroupby {
-    Variant0(::std::vec::Vec<PivotTransformGroupbyVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<PivotTransformGroupbyArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for PivotTransformGroupby {
     fn from(value: &PivotTransformGroupby) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<PivotTransformGroupbyVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<PivotTransformGroupbyArrayItem>>
     for PivotTransformGroupby
 {
-    fn from(value: ::std::vec::Vec<PivotTransformGroupbyVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<PivotTransformGroupbyArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for PivotTransformGroupby {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`PivotTransformGroupbyVariant0Item`"]
+#[doc = "`PivotTransformGroupbyArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -80523,27 +80499,27 @@ impl ::std::convert::From<SignalRef> for PivotTransformGroupby {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum PivotTransformGroupbyVariant0Item {
+pub enum PivotTransformGroupbyArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for PivotTransformGroupbyVariant0Item {
-    fn from(value: &PivotTransformGroupbyVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for PivotTransformGroupbyArrayItem {
+    fn from(value: &PivotTransformGroupbyArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<ScaleField> for PivotTransformGroupbyVariant0Item {
+impl ::std::convert::From<ScaleField> for PivotTransformGroupbyArrayItem {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
     }
 }
-impl ::std::convert::From<ParamField> for PivotTransformGroupbyVariant0Item {
+impl ::std::convert::From<ParamField> for PivotTransformGroupbyArrayItem {
     fn from(value: ParamField) -> Self {
         Self::ParamField(value)
     }
 }
-impl ::std::convert::From<Expr> for PivotTransformGroupbyVariant0Item {
+impl ::std::convert::From<Expr> for PivotTransformGroupbyArrayItem {
     fn from(value: Expr) -> Self {
         Self::Expr(value)
     }
@@ -80615,8 +80591,8 @@ impl ::std::convert::From<Expr> for PivotTransformKey {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum PivotTransformLimit {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for PivotTransformLimit {
     fn from(value: &PivotTransformLimit) -> Self {
@@ -80625,12 +80601,12 @@ impl ::std::convert::From<&Self> for PivotTransformLimit {
 }
 impl ::std::convert::From<f64> for PivotTransformLimit {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for PivotTransformLimit {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`PivotTransformOp`"]
@@ -81130,25 +81106,25 @@ impl ::std::convert::From<&ProjectTransform> for ProjectTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ProjectTransformAs {
-    Variant0(::std::vec::Vec<ProjectTransformAsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<ProjectTransformAsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ProjectTransformAs {
     fn from(value: &ProjectTransformAs) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ProjectTransformAsVariant0Item>> for ProjectTransformAs {
-    fn from(value: ::std::vec::Vec<ProjectTransformAsVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<ProjectTransformAsArrayItem>> for ProjectTransformAs {
+    fn from(value: ::std::vec::Vec<ProjectTransformAsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ProjectTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ProjectTransformAsVariant0Item`"]
+#[doc = "`ProjectTransformAsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81170,19 +81146,19 @@ impl ::std::convert::From<SignalRef> for ProjectTransformAs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ProjectTransformAsVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
-    Variant2,
+pub enum ProjectTransformAsArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
+    Null,
 }
-impl ::std::convert::From<&Self> for ProjectTransformAsVariant0Item {
-    fn from(value: &ProjectTransformAsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for ProjectTransformAsArrayItem {
+    fn from(value: &ProjectTransformAsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for ProjectTransformAsVariant0Item {
+impl ::std::convert::From<SignalRef> for ProjectTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ProjectTransformFields`"]
@@ -81218,27 +81194,27 @@ impl ::std::convert::From<SignalRef> for ProjectTransformAsVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ProjectTransformFields {
-    Variant0(::std::vec::Vec<ProjectTransformFieldsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<ProjectTransformFieldsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ProjectTransformFields {
     fn from(value: &ProjectTransformFields) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ProjectTransformFieldsVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<ProjectTransformFieldsArrayItem>>
     for ProjectTransformFields
 {
-    fn from(value: ::std::vec::Vec<ProjectTransformFieldsVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<ProjectTransformFieldsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ProjectTransformFields {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ProjectTransformFieldsVariant0Item`"]
+#[doc = "`ProjectTransformFieldsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81260,27 +81236,27 @@ impl ::std::convert::From<SignalRef> for ProjectTransformFields {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ProjectTransformFieldsVariant0Item {
+pub enum ProjectTransformFieldsArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for ProjectTransformFieldsVariant0Item {
-    fn from(value: &ProjectTransformFieldsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for ProjectTransformFieldsArrayItem {
+    fn from(value: &ProjectTransformFieldsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<ScaleField> for ProjectTransformFieldsVariant0Item {
+impl ::std::convert::From<ScaleField> for ProjectTransformFieldsArrayItem {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
     }
 }
-impl ::std::convert::From<ParamField> for ProjectTransformFieldsVariant0Item {
+impl ::std::convert::From<ParamField> for ProjectTransformFieldsArrayItem {
     fn from(value: ParamField) -> Self {
         Self::ParamField(value)
     }
 }
-impl ::std::convert::From<Expr> for ProjectTransformFieldsVariant0Item {
+impl ::std::convert::From<Expr> for ProjectTransformFieldsArrayItem {
     fn from(value: Expr) -> Self {
         Self::Expr(value)
     }
@@ -81605,8 +81581,8 @@ impl ::std::convert::From<&Projection> for Projection {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ProjectionCenter {
-    Variant0([NumberOrSignal; 2usize]),
-    Variant1(SignalRef),
+    Array([NumberOrSignal; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ProjectionCenter {
     fn from(value: &ProjectionCenter) -> Self {
@@ -81615,12 +81591,12 @@ impl ::std::convert::From<&Self> for ProjectionCenter {
 }
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ProjectionCenter {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ProjectionCenter {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ProjectionClipExtent`"]
@@ -81660,25 +81636,25 @@ impl ::std::convert::From<SignalRef> for ProjectionCenter {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ProjectionClipExtent {
-    Variant0([ProjectionClipExtentVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([ProjectionClipExtentArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ProjectionClipExtent {
     fn from(value: &ProjectionClipExtent) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<[ProjectionClipExtentVariant0Item; 2usize]> for ProjectionClipExtent {
-    fn from(value: [ProjectionClipExtentVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[ProjectionClipExtentArrayItem; 2usize]> for ProjectionClipExtent {
+    fn from(value: [ProjectionClipExtentArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ProjectionClipExtent {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ProjectionClipExtentVariant0Item`"]
+#[doc = "`ProjectionClipExtentArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81702,23 +81678,23 @@ impl ::std::convert::From<SignalRef> for ProjectionClipExtent {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ProjectionClipExtentVariant0Item {
-    Variant0([NumberOrSignal; 2usize]),
-    Variant1(SignalRef),
+pub enum ProjectionClipExtentArrayItem {
+    Array([NumberOrSignal; 2usize]),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ProjectionClipExtentVariant0Item {
-    fn from(value: &ProjectionClipExtentVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for ProjectionClipExtentArrayItem {
+    fn from(value: &ProjectionClipExtentArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<[NumberOrSignal; 2usize]> for ProjectionClipExtentVariant0Item {
+impl ::std::convert::From<[NumberOrSignal; 2usize]> for ProjectionClipExtentArrayItem {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
-impl ::std::convert::From<SignalRef> for ProjectionClipExtentVariant0Item {
+impl ::std::convert::From<SignalRef> for ProjectionClipExtentArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ProjectionExtent`"]
@@ -81758,25 +81734,25 @@ impl ::std::convert::From<SignalRef> for ProjectionClipExtentVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ProjectionExtent {
-    Variant0([ProjectionExtentVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([ProjectionExtentArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ProjectionExtent {
     fn from(value: &ProjectionExtent) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<[ProjectionExtentVariant0Item; 2usize]> for ProjectionExtent {
-    fn from(value: [ProjectionExtentVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[ProjectionExtentArrayItem; 2usize]> for ProjectionExtent {
+    fn from(value: [ProjectionExtentArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ProjectionExtent {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ProjectionExtentVariant0Item`"]
+#[doc = "`ProjectionExtentArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -81800,23 +81776,23 @@ impl ::std::convert::From<SignalRef> for ProjectionExtent {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ProjectionExtentVariant0Item {
-    Variant0([NumberOrSignal; 2usize]),
-    Variant1(SignalRef),
+pub enum ProjectionExtentArrayItem {
+    Array([NumberOrSignal; 2usize]),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ProjectionExtentVariant0Item {
-    fn from(value: &ProjectionExtentVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for ProjectionExtentArrayItem {
+    fn from(value: &ProjectionExtentArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<[NumberOrSignal; 2usize]> for ProjectionExtentVariant0Item {
+impl ::std::convert::From<[NumberOrSignal; 2usize]> for ProjectionExtentArrayItem {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
-impl ::std::convert::From<SignalRef> for ProjectionExtentVariant0Item {
+impl ::std::convert::From<SignalRef> for ProjectionExtentArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ProjectionFit`"]
@@ -81839,8 +81815,8 @@ impl ::std::convert::From<SignalRef> for ProjectionExtentVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ProjectionFit {
-    Variant0(::serde_json::Map<::std::string::String, ::serde_json::Value>),
-    Variant1(::std::vec::Vec<::serde_json::Value>),
+    Object(::serde_json::Map<::std::string::String, ::serde_json::Value>),
+    Array(::std::vec::Vec<::serde_json::Value>),
 }
 impl ::std::convert::From<&Self> for ProjectionFit {
     fn from(value: &ProjectionFit) -> Self {
@@ -81851,12 +81827,12 @@ impl ::std::convert::From<::serde_json::Map<::std::string::String, ::serde_json:
     for ProjectionFit
 {
     fn from(value: ::serde_json::Map<::std::string::String, ::serde_json::Value>) -> Self {
-        Self::Variant0(value)
+        Self::Object(value)
     }
 }
 impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ProjectionFit {
     fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
-        Self::Variant1(value)
+        Self::Array(value)
     }
 }
 #[doc = "`ProjectionParallels`"]
@@ -81884,8 +81860,8 @@ impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ProjectionFi
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ProjectionParallels {
-    Variant0([NumberOrSignal; 2usize]),
-    Variant1(SignalRef),
+    Array([NumberOrSignal; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ProjectionParallels {
     fn from(value: &ProjectionParallels) -> Self {
@@ -81894,12 +81870,12 @@ impl ::std::convert::From<&Self> for ProjectionParallels {
 }
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ProjectionParallels {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ProjectionParallels {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ProjectionRotate`"]
@@ -81927,8 +81903,8 @@ impl ::std::convert::From<SignalRef> for ProjectionParallels {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ProjectionRotate {
-    Variant0(::std::vec::Vec<NumberOrSignal>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<NumberOrSignal>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ProjectionRotate {
     fn from(value: &ProjectionRotate) -> Self {
@@ -81937,12 +81913,12 @@ impl ::std::convert::From<&Self> for ProjectionRotate {
 }
 impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ProjectionRotate {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ProjectionRotate {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ProjectionSize`"]
@@ -81970,8 +81946,8 @@ impl ::std::convert::From<SignalRef> for ProjectionRotate {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ProjectionSize {
-    Variant0([NumberOrSignal; 2usize]),
-    Variant1(SignalRef),
+    Array([NumberOrSignal; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ProjectionSize {
     fn from(value: &ProjectionSize) -> Self {
@@ -81980,12 +81956,12 @@ impl ::std::convert::From<&Self> for ProjectionSize {
 }
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ProjectionSize {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ProjectionSize {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ProjectionTranslate`"]
@@ -82013,8 +81989,8 @@ impl ::std::convert::From<SignalRef> for ProjectionSize {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ProjectionTranslate {
-    Variant0([NumberOrSignal; 2usize]),
-    Variant1(SignalRef),
+    Array([NumberOrSignal; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ProjectionTranslate {
     fn from(value: &ProjectionTranslate) -> Self {
@@ -82023,12 +81999,12 @@ impl ::std::convert::From<&Self> for ProjectionTranslate {
 }
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ProjectionTranslate {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ProjectionTranslate {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`QuantileTransform`"]
@@ -82203,8 +82179,8 @@ impl ::std::convert::From<&QuantileTransform> for QuantileTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum QuantileTransformAs {
-    Variant0(::std::vec::Vec<QuantileTransformAsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<QuantileTransformAsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for QuantileTransformAs {
     fn from(value: &QuantileTransformAs) -> Self {
@@ -82213,25 +82189,23 @@ impl ::std::convert::From<&Self> for QuantileTransformAs {
 }
 impl ::std::default::Default for QuantileTransformAs {
     fn default() -> Self {
-        QuantileTransformAs::Variant0(vec![
-            QuantileTransformAsVariant0Item::Variant0("prob".to_string()),
-            QuantileTransformAsVariant0Item::Variant0("value".to_string()),
+        QuantileTransformAs::Array(vec![
+            QuantileTransformAsArrayItem::String("prob".to_string()),
+            QuantileTransformAsArrayItem::String("value".to_string()),
         ])
     }
 }
-impl ::std::convert::From<::std::vec::Vec<QuantileTransformAsVariant0Item>>
-    for QuantileTransformAs
-{
-    fn from(value: ::std::vec::Vec<QuantileTransformAsVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<QuantileTransformAsArrayItem>> for QuantileTransformAs {
+    fn from(value: ::std::vec::Vec<QuantileTransformAsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for QuantileTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`QuantileTransformAsVariant0Item`"]
+#[doc = "`QuantileTransformAsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82250,18 +82224,18 @@ impl ::std::convert::From<SignalRef> for QuantileTransformAs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum QuantileTransformAsVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum QuantileTransformAsArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for QuantileTransformAsVariant0Item {
-    fn from(value: &QuantileTransformAsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for QuantileTransformAsArrayItem {
+    fn from(value: &QuantileTransformAsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for QuantileTransformAsVariant0Item {
+impl ::std::convert::From<SignalRef> for QuantileTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`QuantileTransformField`"]
@@ -82344,27 +82318,27 @@ impl ::std::convert::From<Expr> for QuantileTransformField {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum QuantileTransformGroupby {
-    Variant0(::std::vec::Vec<QuantileTransformGroupbyVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<QuantileTransformGroupbyArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for QuantileTransformGroupby {
     fn from(value: &QuantileTransformGroupby) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<QuantileTransformGroupbyVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<QuantileTransformGroupbyArrayItem>>
     for QuantileTransformGroupby
 {
-    fn from(value: ::std::vec::Vec<QuantileTransformGroupbyVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<QuantileTransformGroupbyArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for QuantileTransformGroupby {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`QuantileTransformGroupbyVariant0Item`"]
+#[doc = "`QuantileTransformGroupbyArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82386,27 +82360,27 @@ impl ::std::convert::From<SignalRef> for QuantileTransformGroupby {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum QuantileTransformGroupbyVariant0Item {
+pub enum QuantileTransformGroupbyArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for QuantileTransformGroupbyVariant0Item {
-    fn from(value: &QuantileTransformGroupbyVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for QuantileTransformGroupbyArrayItem {
+    fn from(value: &QuantileTransformGroupbyArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<ScaleField> for QuantileTransformGroupbyVariant0Item {
+impl ::std::convert::From<ScaleField> for QuantileTransformGroupbyArrayItem {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
     }
 }
-impl ::std::convert::From<ParamField> for QuantileTransformGroupbyVariant0Item {
+impl ::std::convert::From<ParamField> for QuantileTransformGroupbyArrayItem {
     fn from(value: ParamField) -> Self {
         Self::ParamField(value)
     }
 }
-impl ::std::convert::From<Expr> for QuantileTransformGroupbyVariant0Item {
+impl ::std::convert::From<Expr> for QuantileTransformGroupbyArrayItem {
     fn from(value: Expr) -> Self {
         Self::Expr(value)
     }
@@ -82441,27 +82415,27 @@ impl ::std::convert::From<Expr> for QuantileTransformGroupbyVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum QuantileTransformProbs {
-    Variant0(::std::vec::Vec<QuantileTransformProbsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<QuantileTransformProbsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for QuantileTransformProbs {
     fn from(value: &QuantileTransformProbs) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<QuantileTransformProbsVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<QuantileTransformProbsArrayItem>>
     for QuantileTransformProbs
 {
-    fn from(value: ::std::vec::Vec<QuantileTransformProbsVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<QuantileTransformProbsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for QuantileTransformProbs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`QuantileTransformProbsVariant0Item`"]
+#[doc = "`QuantileTransformProbsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -82480,23 +82454,23 @@ impl ::std::convert::From<SignalRef> for QuantileTransformProbs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum QuantileTransformProbsVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum QuantileTransformProbsArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for QuantileTransformProbsVariant0Item {
-    fn from(value: &QuantileTransformProbsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for QuantileTransformProbsArrayItem {
+    fn from(value: &QuantileTransformProbsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for QuantileTransformProbsVariant0Item {
+impl ::std::convert::From<f64> for QuantileTransformProbsArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for QuantileTransformProbsVariant0Item {
+impl ::std::convert::From<SignalRef> for QuantileTransformProbsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`QuantileTransformStep`"]
@@ -82520,8 +82494,8 @@ impl ::std::convert::From<SignalRef> for QuantileTransformProbsVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum QuantileTransformStep {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for QuantileTransformStep {
     fn from(value: &QuantileTransformStep) -> Self {
@@ -82530,17 +82504,17 @@ impl ::std::convert::From<&Self> for QuantileTransformStep {
 }
 impl ::std::default::Default for QuantileTransformStep {
     fn default() -> Self {
-        QuantileTransformStep::Variant0(0.01_f64)
+        QuantileTransformStep::Number(0.01_f64)
     }
 }
 impl ::std::convert::From<f64> for QuantileTransformStep {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for QuantileTransformStep {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`QuantileTransformType`"]
@@ -82966,27 +82940,27 @@ impl ::std::convert::From<&RegressionTransform> for RegressionTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum RegressionTransformAs {
-    Variant0(::std::vec::Vec<RegressionTransformAsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<RegressionTransformAsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for RegressionTransformAs {
     fn from(value: &RegressionTransformAs) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<RegressionTransformAsVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<RegressionTransformAsArrayItem>>
     for RegressionTransformAs
 {
-    fn from(value: ::std::vec::Vec<RegressionTransformAsVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<RegressionTransformAsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for RegressionTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`RegressionTransformAsVariant0Item`"]
+#[doc = "`RegressionTransformAsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83005,18 +82979,18 @@ impl ::std::convert::From<SignalRef> for RegressionTransformAs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum RegressionTransformAsVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum RegressionTransformAsArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for RegressionTransformAsVariant0Item {
-    fn from(value: &RegressionTransformAsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for RegressionTransformAsArrayItem {
+    fn from(value: &RegressionTransformAsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for RegressionTransformAsVariant0Item {
+impl ::std::convert::From<SignalRef> for RegressionTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`RegressionTransformExtent`"]
@@ -83051,27 +83025,27 @@ impl ::std::convert::From<SignalRef> for RegressionTransformAsVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum RegressionTransformExtent {
-    Variant0([RegressionTransformExtentVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([RegressionTransformExtentArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for RegressionTransformExtent {
     fn from(value: &RegressionTransformExtent) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<[RegressionTransformExtentVariant0Item; 2usize]>
+impl ::std::convert::From<[RegressionTransformExtentArrayItem; 2usize]>
     for RegressionTransformExtent
 {
-    fn from(value: [RegressionTransformExtentVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+    fn from(value: [RegressionTransformExtentArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for RegressionTransformExtent {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`RegressionTransformExtentVariant0Item`"]
+#[doc = "`RegressionTransformExtentArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83090,23 +83064,23 @@ impl ::std::convert::From<SignalRef> for RegressionTransformExtent {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum RegressionTransformExtentVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum RegressionTransformExtentArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for RegressionTransformExtentVariant0Item {
-    fn from(value: &RegressionTransformExtentVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for RegressionTransformExtentArrayItem {
+    fn from(value: &RegressionTransformExtentArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for RegressionTransformExtentVariant0Item {
+impl ::std::convert::From<f64> for RegressionTransformExtentArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for RegressionTransformExtentVariant0Item {
+impl ::std::convert::From<SignalRef> for RegressionTransformExtentArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`RegressionTransformGroupby`"]
@@ -83142,27 +83116,27 @@ impl ::std::convert::From<SignalRef> for RegressionTransformExtentVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum RegressionTransformGroupby {
-    Variant0(::std::vec::Vec<RegressionTransformGroupbyVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<RegressionTransformGroupbyArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for RegressionTransformGroupby {
     fn from(value: &RegressionTransformGroupby) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<RegressionTransformGroupbyVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<RegressionTransformGroupbyArrayItem>>
     for RegressionTransformGroupby
 {
-    fn from(value: ::std::vec::Vec<RegressionTransformGroupbyVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<RegressionTransformGroupbyArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for RegressionTransformGroupby {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`RegressionTransformGroupbyVariant0Item`"]
+#[doc = "`RegressionTransformGroupbyArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -83184,27 +83158,27 @@ impl ::std::convert::From<SignalRef> for RegressionTransformGroupby {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum RegressionTransformGroupbyVariant0Item {
+pub enum RegressionTransformGroupbyArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for RegressionTransformGroupbyVariant0Item {
-    fn from(value: &RegressionTransformGroupbyVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for RegressionTransformGroupbyArrayItem {
+    fn from(value: &RegressionTransformGroupbyArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<ScaleField> for RegressionTransformGroupbyVariant0Item {
+impl ::std::convert::From<ScaleField> for RegressionTransformGroupbyArrayItem {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
     }
 }
-impl ::std::convert::From<ParamField> for RegressionTransformGroupbyVariant0Item {
+impl ::std::convert::From<ParamField> for RegressionTransformGroupbyArrayItem {
     fn from(value: ParamField) -> Self {
         Self::ParamField(value)
     }
 }
-impl ::std::convert::From<Expr> for RegressionTransformGroupbyVariant0Item {
+impl ::std::convert::From<Expr> for RegressionTransformGroupbyArrayItem {
     fn from(value: Expr) -> Self {
         Self::Expr(value)
     }
@@ -83230,8 +83204,8 @@ impl ::std::convert::From<Expr> for RegressionTransformGroupbyVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum RegressionTransformMethod {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for RegressionTransformMethod {
     fn from(value: &RegressionTransformMethod) -> Self {
@@ -83240,12 +83214,12 @@ impl ::std::convert::From<&Self> for RegressionTransformMethod {
 }
 impl ::std::default::Default for RegressionTransformMethod {
     fn default() -> Self {
-        RegressionTransformMethod::Variant0("linear".to_string())
+        RegressionTransformMethod::String("linear".to_string())
     }
 }
 impl ::std::convert::From<SignalRef> for RegressionTransformMethod {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`RegressionTransformOrder`"]
@@ -83269,8 +83243,8 @@ impl ::std::convert::From<SignalRef> for RegressionTransformMethod {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum RegressionTransformOrder {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for RegressionTransformOrder {
     fn from(value: &RegressionTransformOrder) -> Self {
@@ -83279,17 +83253,17 @@ impl ::std::convert::From<&Self> for RegressionTransformOrder {
 }
 impl ::std::default::Default for RegressionTransformOrder {
     fn default() -> Self {
-        RegressionTransformOrder::Variant0(3_f64)
+        RegressionTransformOrder::Number(3_f64)
     }
 }
 impl ::std::convert::From<f64> for RegressionTransformOrder {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for RegressionTransformOrder {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`RegressionTransformParams`"]
@@ -83312,8 +83286,8 @@ impl ::std::convert::From<SignalRef> for RegressionTransformOrder {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum RegressionTransformParams {
-    Variant0(bool),
-    Variant1(SignalRef),
+    Boolean(bool),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for RegressionTransformParams {
     fn from(value: &RegressionTransformParams) -> Self {
@@ -83322,12 +83296,12 @@ impl ::std::convert::From<&Self> for RegressionTransformParams {
 }
 impl ::std::convert::From<bool> for RegressionTransformParams {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<SignalRef> for RegressionTransformParams {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`RegressionTransformType`"]
@@ -83567,8 +83541,8 @@ impl ::std::convert::From<&ResolvefilterTransform> for ResolvefilterTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ResolvefilterTransformIgnore {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ResolvefilterTransformIgnore {
     fn from(value: &ResolvefilterTransformIgnore) -> Self {
@@ -83577,12 +83551,12 @@ impl ::std::convert::From<&Self> for ResolvefilterTransformIgnore {
 }
 impl ::std::convert::From<f64> for ResolvefilterTransformIgnore {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ResolvefilterTransformIgnore {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ResolvefilterTransformType`"]
@@ -83759,8 +83733,8 @@ impl ::std::convert::From<&SampleTransform> for SampleTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum SampleTransformSize {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for SampleTransformSize {
     fn from(value: &SampleTransformSize) -> Self {
@@ -83769,17 +83743,17 @@ impl ::std::convert::From<&Self> for SampleTransformSize {
 }
 impl ::std::default::Default for SampleTransformSize {
     fn default() -> Self {
-        SampleTransformSize::Variant0(1000_f64)
+        SampleTransformSize::Number(1000_f64)
     }
 }
 impl ::std::convert::From<f64> for SampleTransformSize {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for SampleTransformSize {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`SampleTransformType`"]
@@ -86917,15 +86891,15 @@ impl ::std::convert::From<&Self> for Scale {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleBins {
-    Variant0(::std::vec::Vec<NumberOrSignal>),
-    Variant1 {
+    Array(::std::vec::Vec<NumberOrSignal>),
+    Object {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         start: ::std::option::Option<NumberOrSignal>,
         step: NumberOrSignal,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         stop: ::std::option::Option<NumberOrSignal>,
     },
-    Variant2(SignalRef),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleBins {
     fn from(value: &ScaleBins) -> Self {
@@ -86934,12 +86908,12 @@ impl ::std::convert::From<&Self> for ScaleBins {
 }
 impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleBins {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleBins {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleData`"]
@@ -87209,8 +87183,8 @@ impl ::std::convert::From<&Self> for ScaleData {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleDataVariant0Sort {
-    Variant0(bool),
-    Variant1 {
+    Boolean(bool),
+    Object {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         field: ::std::option::Option<StringOrSignal>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -87226,7 +87200,7 @@ impl ::std::convert::From<&Self> for ScaleDataVariant0Sort {
 }
 impl ::std::convert::From<bool> for ScaleDataVariant0Sort {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`ScaleDataVariant1Sort`"]
@@ -87508,31 +87482,31 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleDataVariant1SortVar
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleDataVariant2FieldsItem {
-    Variant0 {
+    Object {
         data: ::std::string::String,
         field: StringOrSignal,
     },
-    Variant1(::std::vec::Vec<ScaleDataVariant2FieldsItemVariant1Item>),
-    Variant2(SignalRef),
+    Array(::std::vec::Vec<ScaleDataVariant2FieldsItemArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleDataVariant2FieldsItem {
     fn from(value: &ScaleDataVariant2FieldsItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ScaleDataVariant2FieldsItemVariant1Item>>
+impl ::std::convert::From<::std::vec::Vec<ScaleDataVariant2FieldsItemArrayItem>>
     for ScaleDataVariant2FieldsItem
 {
-    fn from(value: ::std::vec::Vec<ScaleDataVariant2FieldsItemVariant1Item>) -> Self {
-        Self::Variant1(value)
+    fn from(value: ::std::vec::Vec<ScaleDataVariant2FieldsItemArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleDataVariant2FieldsItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ScaleDataVariant2FieldsItemVariant1Item`"]
+#[doc = "`ScaleDataVariant2FieldsItemArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -87554,33 +87528,33 @@ impl ::std::convert::From<SignalRef> for ScaleDataVariant2FieldsItem {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ScaleDataVariant2FieldsItemVariant1Item {
-    Variant0(::std::string::String),
-    Variant1(f64),
-    Variant2(bool),
+pub enum ScaleDataVariant2FieldsItemArrayItem {
+    String(::std::string::String),
+    Number(f64),
+    Boolean(bool),
 }
-impl ::std::convert::From<&Self> for ScaleDataVariant2FieldsItemVariant1Item {
-    fn from(value: &ScaleDataVariant2FieldsItemVariant1Item) -> Self {
+impl ::std::convert::From<&Self> for ScaleDataVariant2FieldsItemArrayItem {
+    fn from(value: &ScaleDataVariant2FieldsItemArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::fmt::Display for ScaleDataVariant2FieldsItemVariant1Item {
+impl ::std::fmt::Display for ScaleDataVariant2FieldsItemArrayItem {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
-            Self::Variant2(x) => x.fmt(f),
+            Self::String(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
-impl ::std::convert::From<f64> for ScaleDataVariant2FieldsItemVariant1Item {
+impl ::std::convert::From<f64> for ScaleDataVariant2FieldsItemArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant1(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<bool> for ScaleDataVariant2FieldsItemVariant1Item {
+impl ::std::convert::From<bool> for ScaleDataVariant2FieldsItemArrayItem {
     fn from(value: bool) -> Self {
-        Self::Variant2(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`ScaleDataVariant2Sort`"]
@@ -87882,9 +87856,9 @@ impl ::std::convert::From<StringOrSignal> for ScaleField {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleInterpolate {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
-    Variant2 {
+    String(::std::string::String),
+    SignalRef(SignalRef),
+    Object {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         gamma: ::std::option::Option<NumberOrSignal>,
         #[serde(rename = "type")]
@@ -87898,7 +87872,7 @@ impl ::std::convert::From<&Self> for ScaleInterpolate {
 }
 impl ::std::convert::From<SignalRef> for ScaleInterpolate {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant0Domain`"]
@@ -87949,75 +87923,31 @@ impl ::std::convert::From<SignalRef> for ScaleInterpolate {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant0Domain {
-    Variant0(::std::vec::Vec<ScaleVariant0DomainVariant0Item>),
-    Variant1(ScaleData),
-    Variant2(SignalRef),
+    Array(::std::vec::Vec<ScaleVariant0DomainArrayItem>),
+    ScaleData(ScaleData),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant0Domain {
     fn from(value: &ScaleVariant0Domain) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ScaleVariant0DomainVariant0Item>>
-    for ScaleVariant0Domain
-{
-    fn from(value: ::std::vec::Vec<ScaleVariant0DomainVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<ScaleVariant0DomainArrayItem>> for ScaleVariant0Domain {
+    fn from(value: ::std::vec::Vec<ScaleVariant0DomainArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<ScaleData> for ScaleVariant0Domain {
     fn from(value: ScaleData) -> Self {
-        Self::Variant1(value)
+        Self::ScaleData(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant0Domain {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ScaleVariant0DomainRaw`"]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"oneOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"type\": \"null\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"type\": \"array\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/signalRef\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum ScaleVariant0DomainRaw {
-    Variant0,
-    Variant1(::std::vec::Vec<::serde_json::Value>),
-    Variant2(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant0DomainRaw {
-    fn from(value: &ScaleVariant0DomainRaw) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant0DomainRaw {
-    fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
-        Self::Variant1(value)
-    }
-}
-impl ::std::convert::From<SignalRef> for ScaleVariant0DomainRaw {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
-    }
-}
-#[doc = "`ScaleVariant0DomainVariant0Item`"]
+#[doc = "`ScaleVariant0DomainArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88051,37 +87981,79 @@ impl ::std::convert::From<SignalRef> for ScaleVariant0DomainRaw {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ScaleVariant0DomainVariant0Item {
-    Variant0,
-    Variant1(bool),
-    Variant2(::std::string::String),
-    Variant3(f64),
-    Variant4(SignalRef),
-    Variant5(::std::vec::Vec<NumberOrSignal>),
+pub enum ScaleVariant0DomainArrayItem {
+    Null,
+    Boolean(bool),
+    String(::std::string::String),
+    Number(f64),
+    SignalRef(SignalRef),
+    Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant0DomainVariant0Item {
-    fn from(value: &ScaleVariant0DomainVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for ScaleVariant0DomainArrayItem {
+    fn from(value: &ScaleVariant0DomainArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<bool> for ScaleVariant0DomainVariant0Item {
+impl ::std::convert::From<bool> for ScaleVariant0DomainArrayItem {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
-impl ::std::convert::From<f64> for ScaleVariant0DomainVariant0Item {
+impl ::std::convert::From<f64> for ScaleVariant0DomainArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant3(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for ScaleVariant0DomainVariant0Item {
+impl ::std::convert::From<SignalRef> for ScaleVariant0DomainArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant4(value)
+        Self::SignalRef(value)
     }
 }
-impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant0DomainVariant0Item {
+impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant0DomainArrayItem {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
-        Self::Variant5(value)
+        Self::Array(value)
+    }
+}
+#[doc = "`ScaleVariant0DomainRaw`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"null\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"array\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"$ref\": \"#/definitions/signalRef\""]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum ScaleVariant0DomainRaw {
+    Null,
+    Array(::std::vec::Vec<::serde_json::Value>),
+    SignalRef(SignalRef),
+}
+impl ::std::convert::From<&Self> for ScaleVariant0DomainRaw {
+    fn from(value: &ScaleVariant0DomainRaw) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant0DomainRaw {
+    fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
+        Self::Array(value)
+    }
+}
+impl ::std::convert::From<SignalRef> for ScaleVariant0DomainRaw {
+    fn from(value: SignalRef) -> Self {
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant0Type`"]
@@ -88203,75 +88175,31 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant0Type {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant10Domain {
-    Variant0(::std::vec::Vec<ScaleVariant10DomainVariant0Item>),
-    Variant1(ScaleData),
-    Variant2(SignalRef),
+    Array(::std::vec::Vec<ScaleVariant10DomainArrayItem>),
+    ScaleData(ScaleData),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant10Domain {
     fn from(value: &ScaleVariant10Domain) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ScaleVariant10DomainVariant0Item>>
-    for ScaleVariant10Domain
-{
-    fn from(value: ::std::vec::Vec<ScaleVariant10DomainVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<ScaleVariant10DomainArrayItem>> for ScaleVariant10Domain {
+    fn from(value: ::std::vec::Vec<ScaleVariant10DomainArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<ScaleData> for ScaleVariant10Domain {
     fn from(value: ScaleData) -> Self {
-        Self::Variant1(value)
+        Self::ScaleData(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant10Domain {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ScaleVariant10DomainRaw`"]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"oneOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"type\": \"null\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"type\": \"array\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/signalRef\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum ScaleVariant10DomainRaw {
-    Variant0,
-    Variant1(::std::vec::Vec<::serde_json::Value>),
-    Variant2(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant10DomainRaw {
-    fn from(value: &ScaleVariant10DomainRaw) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant10DomainRaw {
-    fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
-        Self::Variant1(value)
-    }
-}
-impl ::std::convert::From<SignalRef> for ScaleVariant10DomainRaw {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
-    }
-}
-#[doc = "`ScaleVariant10DomainVariant0Item`"]
+#[doc = "`ScaleVariant10DomainArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88305,37 +88233,79 @@ impl ::std::convert::From<SignalRef> for ScaleVariant10DomainRaw {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ScaleVariant10DomainVariant0Item {
-    Variant0,
-    Variant1(bool),
-    Variant2(::std::string::String),
-    Variant3(f64),
-    Variant4(SignalRef),
-    Variant5(::std::vec::Vec<NumberOrSignal>),
+pub enum ScaleVariant10DomainArrayItem {
+    Null,
+    Boolean(bool),
+    String(::std::string::String),
+    Number(f64),
+    SignalRef(SignalRef),
+    Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant10DomainVariant0Item {
-    fn from(value: &ScaleVariant10DomainVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for ScaleVariant10DomainArrayItem {
+    fn from(value: &ScaleVariant10DomainArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<bool> for ScaleVariant10DomainVariant0Item {
+impl ::std::convert::From<bool> for ScaleVariant10DomainArrayItem {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
-impl ::std::convert::From<f64> for ScaleVariant10DomainVariant0Item {
+impl ::std::convert::From<f64> for ScaleVariant10DomainArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant3(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for ScaleVariant10DomainVariant0Item {
+impl ::std::convert::From<SignalRef> for ScaleVariant10DomainArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant4(value)
+        Self::SignalRef(value)
     }
 }
-impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant10DomainVariant0Item {
+impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant10DomainArrayItem {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
-        Self::Variant5(value)
+        Self::Array(value)
+    }
+}
+#[doc = "`ScaleVariant10DomainRaw`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"null\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"array\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"$ref\": \"#/definitions/signalRef\""]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum ScaleVariant10DomainRaw {
+    Null,
+    Array(::std::vec::Vec<::serde_json::Value>),
+    SignalRef(SignalRef),
+}
+impl ::std::convert::From<&Self> for ScaleVariant10DomainRaw {
+    fn from(value: &ScaleVariant10DomainRaw) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant10DomainRaw {
+    fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
+        Self::Array(value)
+    }
+}
+impl ::std::convert::From<SignalRef> for ScaleVariant10DomainRaw {
+    fn from(value: SignalRef) -> Self {
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant10Nice`"]
@@ -88361,9 +88331,9 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant10Dom
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant10Nice {
-    Variant0(bool),
-    Variant1(f64),
-    Variant2(SignalRef),
+    Boolean(bool),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant10Nice {
     fn from(value: &ScaleVariant10Nice) -> Self {
@@ -88372,17 +88342,17 @@ impl ::std::convert::From<&Self> for ScaleVariant10Nice {
 }
 impl ::std::convert::From<bool> for ScaleVariant10Nice {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<f64> for ScaleVariant10Nice {
     fn from(value: f64) -> Self {
-        Self::Variant1(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant10Nice {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant10Range`"]
@@ -88666,12 +88636,12 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant10RangeVaria
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant10RangeVariant1Item {
-    Variant0,
-    Variant1(bool),
-    Variant2(::std::string::String),
-    Variant3(f64),
-    Variant4(SignalRef),
-    Variant5(::std::vec::Vec<NumberOrSignal>),
+    Null,
+    Boolean(bool),
+    String(::std::string::String),
+    Number(f64),
+    SignalRef(SignalRef),
+    Array(::std::vec::Vec<NumberOrSignal>),
 }
 impl ::std::convert::From<&Self> for ScaleVariant10RangeVariant1Item {
     fn from(value: &ScaleVariant10RangeVariant1Item) -> Self {
@@ -88680,22 +88650,22 @@ impl ::std::convert::From<&Self> for ScaleVariant10RangeVariant1Item {
 }
 impl ::std::convert::From<bool> for ScaleVariant10RangeVariant1Item {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<f64> for ScaleVariant10RangeVariant1Item {
     fn from(value: f64) -> Self {
-        Self::Variant3(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant10RangeVariant1Item {
     fn from(value: SignalRef) -> Self {
-        Self::Variant4(value)
+        Self::SignalRef(value)
     }
 }
 impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant10RangeVariant1Item {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
-        Self::Variant5(value)
+        Self::Array(value)
     }
 }
 #[doc = "`ScaleVariant10RangeVariant2Extent`"]
@@ -88723,8 +88693,8 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant10Ran
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant10RangeVariant2Extent {
-    Variant0([NumberOrSignal; 2usize]),
-    Variant1(SignalRef),
+    Array([NumberOrSignal; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant10RangeVariant2Extent {
     fn from(value: &ScaleVariant10RangeVariant2Extent) -> Self {
@@ -88733,12 +88703,12 @@ impl ::std::convert::From<&Self> for ScaleVariant10RangeVariant2Extent {
 }
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ScaleVariant10RangeVariant2Extent {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant10RangeVariant2Extent {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant10RangeVariant2Scheme`"]
@@ -88774,28 +88744,28 @@ impl ::std::convert::From<SignalRef> for ScaleVariant10RangeVariant2Extent {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant10RangeVariant2Scheme {
-    Variant0(::std::string::String),
-    Variant1(::std::vec::Vec<ScaleVariant10RangeVariant2SchemeVariant1Item>),
-    Variant2(SignalRef),
+    String(::std::string::String),
+    Array(::std::vec::Vec<ScaleVariant10RangeVariant2SchemeArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant10RangeVariant2Scheme {
     fn from(value: &ScaleVariant10RangeVariant2Scheme) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ScaleVariant10RangeVariant2SchemeVariant1Item>>
+impl ::std::convert::From<::std::vec::Vec<ScaleVariant10RangeVariant2SchemeArrayItem>>
     for ScaleVariant10RangeVariant2Scheme
 {
-    fn from(value: ::std::vec::Vec<ScaleVariant10RangeVariant2SchemeVariant1Item>) -> Self {
-        Self::Variant1(value)
+    fn from(value: ::std::vec::Vec<ScaleVariant10RangeVariant2SchemeArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant10RangeVariant2Scheme {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ScaleVariant10RangeVariant2SchemeVariant1Item`"]
+#[doc = "`ScaleVariant10RangeVariant2SchemeArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -88814,18 +88784,18 @@ impl ::std::convert::From<SignalRef> for ScaleVariant10RangeVariant2Scheme {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ScaleVariant10RangeVariant2SchemeVariant1Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum ScaleVariant10RangeVariant2SchemeArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant10RangeVariant2SchemeVariant1Item {
-    fn from(value: &ScaleVariant10RangeVariant2SchemeVariant1Item) -> Self {
+impl ::std::convert::From<&Self> for ScaleVariant10RangeVariant2SchemeArrayItem {
+    fn from(value: &ScaleVariant10RangeVariant2SchemeArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for ScaleVariant10RangeVariant2SchemeVariant1Item {
+impl ::std::convert::From<SignalRef> for ScaleVariant10RangeVariant2SchemeArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant10Type`"]
@@ -88947,75 +88917,31 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant10Type {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant11Domain {
-    Variant0(::std::vec::Vec<ScaleVariant11DomainVariant0Item>),
-    Variant1(ScaleData),
-    Variant2(SignalRef),
+    Array(::std::vec::Vec<ScaleVariant11DomainArrayItem>),
+    ScaleData(ScaleData),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant11Domain {
     fn from(value: &ScaleVariant11Domain) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ScaleVariant11DomainVariant0Item>>
-    for ScaleVariant11Domain
-{
-    fn from(value: ::std::vec::Vec<ScaleVariant11DomainVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<ScaleVariant11DomainArrayItem>> for ScaleVariant11Domain {
+    fn from(value: ::std::vec::Vec<ScaleVariant11DomainArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<ScaleData> for ScaleVariant11Domain {
     fn from(value: ScaleData) -> Self {
-        Self::Variant1(value)
+        Self::ScaleData(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant11Domain {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ScaleVariant11DomainRaw`"]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"oneOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"type\": \"null\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"type\": \"array\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/signalRef\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum ScaleVariant11DomainRaw {
-    Variant0,
-    Variant1(::std::vec::Vec<::serde_json::Value>),
-    Variant2(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant11DomainRaw {
-    fn from(value: &ScaleVariant11DomainRaw) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant11DomainRaw {
-    fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
-        Self::Variant1(value)
-    }
-}
-impl ::std::convert::From<SignalRef> for ScaleVariant11DomainRaw {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
-    }
-}
-#[doc = "`ScaleVariant11DomainVariant0Item`"]
+#[doc = "`ScaleVariant11DomainArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89049,37 +88975,79 @@ impl ::std::convert::From<SignalRef> for ScaleVariant11DomainRaw {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ScaleVariant11DomainVariant0Item {
-    Variant0,
-    Variant1(bool),
-    Variant2(::std::string::String),
-    Variant3(f64),
-    Variant4(SignalRef),
-    Variant5(::std::vec::Vec<NumberOrSignal>),
+pub enum ScaleVariant11DomainArrayItem {
+    Null,
+    Boolean(bool),
+    String(::std::string::String),
+    Number(f64),
+    SignalRef(SignalRef),
+    Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant11DomainVariant0Item {
-    fn from(value: &ScaleVariant11DomainVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for ScaleVariant11DomainArrayItem {
+    fn from(value: &ScaleVariant11DomainArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<bool> for ScaleVariant11DomainVariant0Item {
+impl ::std::convert::From<bool> for ScaleVariant11DomainArrayItem {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
-impl ::std::convert::From<f64> for ScaleVariant11DomainVariant0Item {
+impl ::std::convert::From<f64> for ScaleVariant11DomainArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant3(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for ScaleVariant11DomainVariant0Item {
+impl ::std::convert::From<SignalRef> for ScaleVariant11DomainArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant4(value)
+        Self::SignalRef(value)
     }
 }
-impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant11DomainVariant0Item {
+impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant11DomainArrayItem {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
-        Self::Variant5(value)
+        Self::Array(value)
+    }
+}
+#[doc = "`ScaleVariant11DomainRaw`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"null\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"array\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"$ref\": \"#/definitions/signalRef\""]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum ScaleVariant11DomainRaw {
+    Null,
+    Array(::std::vec::Vec<::serde_json::Value>),
+    SignalRef(SignalRef),
+}
+impl ::std::convert::From<&Self> for ScaleVariant11DomainRaw {
+    fn from(value: &ScaleVariant11DomainRaw) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant11DomainRaw {
+    fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
+        Self::Array(value)
+    }
+}
+impl ::std::convert::From<SignalRef> for ScaleVariant11DomainRaw {
+    fn from(value: SignalRef) -> Self {
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant11Nice`"]
@@ -89105,9 +89073,9 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant11Dom
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant11Nice {
-    Variant0(bool),
-    Variant1(f64),
-    Variant2(SignalRef),
+    Boolean(bool),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant11Nice {
     fn from(value: &ScaleVariant11Nice) -> Self {
@@ -89116,17 +89084,17 @@ impl ::std::convert::From<&Self> for ScaleVariant11Nice {
 }
 impl ::std::convert::From<bool> for ScaleVariant11Nice {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<f64> for ScaleVariant11Nice {
     fn from(value: f64) -> Self {
-        Self::Variant1(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant11Nice {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant11Range`"]
@@ -89410,12 +89378,12 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant11RangeVaria
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant11RangeVariant1Item {
-    Variant0,
-    Variant1(bool),
-    Variant2(::std::string::String),
-    Variant3(f64),
-    Variant4(SignalRef),
-    Variant5(::std::vec::Vec<NumberOrSignal>),
+    Null,
+    Boolean(bool),
+    String(::std::string::String),
+    Number(f64),
+    SignalRef(SignalRef),
+    Array(::std::vec::Vec<NumberOrSignal>),
 }
 impl ::std::convert::From<&Self> for ScaleVariant11RangeVariant1Item {
     fn from(value: &ScaleVariant11RangeVariant1Item) -> Self {
@@ -89424,22 +89392,22 @@ impl ::std::convert::From<&Self> for ScaleVariant11RangeVariant1Item {
 }
 impl ::std::convert::From<bool> for ScaleVariant11RangeVariant1Item {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<f64> for ScaleVariant11RangeVariant1Item {
     fn from(value: f64) -> Self {
-        Self::Variant3(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant11RangeVariant1Item {
     fn from(value: SignalRef) -> Self {
-        Self::Variant4(value)
+        Self::SignalRef(value)
     }
 }
 impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant11RangeVariant1Item {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
-        Self::Variant5(value)
+        Self::Array(value)
     }
 }
 #[doc = "`ScaleVariant11RangeVariant2Extent`"]
@@ -89467,8 +89435,8 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant11Ran
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant11RangeVariant2Extent {
-    Variant0([NumberOrSignal; 2usize]),
-    Variant1(SignalRef),
+    Array([NumberOrSignal; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant11RangeVariant2Extent {
     fn from(value: &ScaleVariant11RangeVariant2Extent) -> Self {
@@ -89477,12 +89445,12 @@ impl ::std::convert::From<&Self> for ScaleVariant11RangeVariant2Extent {
 }
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ScaleVariant11RangeVariant2Extent {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant11RangeVariant2Extent {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant11RangeVariant2Scheme`"]
@@ -89518,28 +89486,28 @@ impl ::std::convert::From<SignalRef> for ScaleVariant11RangeVariant2Extent {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant11RangeVariant2Scheme {
-    Variant0(::std::string::String),
-    Variant1(::std::vec::Vec<ScaleVariant11RangeVariant2SchemeVariant1Item>),
-    Variant2(SignalRef),
+    String(::std::string::String),
+    Array(::std::vec::Vec<ScaleVariant11RangeVariant2SchemeArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant11RangeVariant2Scheme {
     fn from(value: &ScaleVariant11RangeVariant2Scheme) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ScaleVariant11RangeVariant2SchemeVariant1Item>>
+impl ::std::convert::From<::std::vec::Vec<ScaleVariant11RangeVariant2SchemeArrayItem>>
     for ScaleVariant11RangeVariant2Scheme
 {
-    fn from(value: ::std::vec::Vec<ScaleVariant11RangeVariant2SchemeVariant1Item>) -> Self {
-        Self::Variant1(value)
+    fn from(value: ::std::vec::Vec<ScaleVariant11RangeVariant2SchemeArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant11RangeVariant2Scheme {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ScaleVariant11RangeVariant2SchemeVariant1Item`"]
+#[doc = "`ScaleVariant11RangeVariant2SchemeArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89558,18 +89526,18 @@ impl ::std::convert::From<SignalRef> for ScaleVariant11RangeVariant2Scheme {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ScaleVariant11RangeVariant2SchemeVariant1Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum ScaleVariant11RangeVariant2SchemeArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant11RangeVariant2SchemeVariant1Item {
-    fn from(value: &ScaleVariant11RangeVariant2SchemeVariant1Item) -> Self {
+impl ::std::convert::From<&Self> for ScaleVariant11RangeVariant2SchemeArrayItem {
+    fn from(value: &ScaleVariant11RangeVariant2SchemeArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for ScaleVariant11RangeVariant2SchemeVariant1Item {
+impl ::std::convert::From<SignalRef> for ScaleVariant11RangeVariant2SchemeArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant11Type`"]
@@ -89691,75 +89659,31 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant11Type {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant1Domain {
-    Variant0(::std::vec::Vec<ScaleVariant1DomainVariant0Item>),
-    Variant1(ScaleData),
-    Variant2(SignalRef),
+    Array(::std::vec::Vec<ScaleVariant1DomainArrayItem>),
+    ScaleData(ScaleData),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant1Domain {
     fn from(value: &ScaleVariant1Domain) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ScaleVariant1DomainVariant0Item>>
-    for ScaleVariant1Domain
-{
-    fn from(value: ::std::vec::Vec<ScaleVariant1DomainVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<ScaleVariant1DomainArrayItem>> for ScaleVariant1Domain {
+    fn from(value: ::std::vec::Vec<ScaleVariant1DomainArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<ScaleData> for ScaleVariant1Domain {
     fn from(value: ScaleData) -> Self {
-        Self::Variant1(value)
+        Self::ScaleData(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant1Domain {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ScaleVariant1DomainRaw`"]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"oneOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"type\": \"null\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"type\": \"array\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/signalRef\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum ScaleVariant1DomainRaw {
-    Variant0,
-    Variant1(::std::vec::Vec<::serde_json::Value>),
-    Variant2(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant1DomainRaw {
-    fn from(value: &ScaleVariant1DomainRaw) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant1DomainRaw {
-    fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
-        Self::Variant1(value)
-    }
-}
-impl ::std::convert::From<SignalRef> for ScaleVariant1DomainRaw {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
-    }
-}
-#[doc = "`ScaleVariant1DomainVariant0Item`"]
+#[doc = "`ScaleVariant1DomainArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -89793,37 +89717,79 @@ impl ::std::convert::From<SignalRef> for ScaleVariant1DomainRaw {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ScaleVariant1DomainVariant0Item {
-    Variant0,
-    Variant1(bool),
-    Variant2(::std::string::String),
-    Variant3(f64),
-    Variant4(SignalRef),
-    Variant5(::std::vec::Vec<NumberOrSignal>),
+pub enum ScaleVariant1DomainArrayItem {
+    Null,
+    Boolean(bool),
+    String(::std::string::String),
+    Number(f64),
+    SignalRef(SignalRef),
+    Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant1DomainVariant0Item {
-    fn from(value: &ScaleVariant1DomainVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for ScaleVariant1DomainArrayItem {
+    fn from(value: &ScaleVariant1DomainArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<bool> for ScaleVariant1DomainVariant0Item {
+impl ::std::convert::From<bool> for ScaleVariant1DomainArrayItem {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
-impl ::std::convert::From<f64> for ScaleVariant1DomainVariant0Item {
+impl ::std::convert::From<f64> for ScaleVariant1DomainArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant3(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for ScaleVariant1DomainVariant0Item {
+impl ::std::convert::From<SignalRef> for ScaleVariant1DomainArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant4(value)
+        Self::SignalRef(value)
     }
 }
-impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant1DomainVariant0Item {
+impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant1DomainArrayItem {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
-        Self::Variant5(value)
+        Self::Array(value)
+    }
+}
+#[doc = "`ScaleVariant1DomainRaw`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"null\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"array\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"$ref\": \"#/definitions/signalRef\""]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum ScaleVariant1DomainRaw {
+    Null,
+    Array(::std::vec::Vec<::serde_json::Value>),
+    SignalRef(SignalRef),
+}
+impl ::std::convert::From<&Self> for ScaleVariant1DomainRaw {
+    fn from(value: &ScaleVariant1DomainRaw) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant1DomainRaw {
+    fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
+        Self::Array(value)
+    }
+}
+impl ::std::convert::From<SignalRef> for ScaleVariant1DomainRaw {
+    fn from(value: SignalRef) -> Self {
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant1Range`"]
@@ -90313,12 +90279,12 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant1RangeVarian
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant1RangeVariant1Item {
-    Variant0,
-    Variant1(bool),
-    Variant2(::std::string::String),
-    Variant3(f64),
-    Variant4(SignalRef),
-    Variant5(::std::vec::Vec<NumberOrSignal>),
+    Null,
+    Boolean(bool),
+    String(::std::string::String),
+    Number(f64),
+    SignalRef(SignalRef),
+    Array(::std::vec::Vec<NumberOrSignal>),
 }
 impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant1Item {
     fn from(value: &ScaleVariant1RangeVariant1Item) -> Self {
@@ -90327,22 +90293,22 @@ impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant1Item {
 }
 impl ::std::convert::From<bool> for ScaleVariant1RangeVariant1Item {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<f64> for ScaleVariant1RangeVariant1Item {
     fn from(value: f64) -> Self {
-        Self::Variant3(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant1RangeVariant1Item {
     fn from(value: SignalRef) -> Self {
-        Self::Variant4(value)
+        Self::SignalRef(value)
     }
 }
 impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant1RangeVariant1Item {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
-        Self::Variant5(value)
+        Self::Array(value)
     }
 }
 #[doc = "`ScaleVariant1RangeVariant2Extent`"]
@@ -90370,8 +90336,8 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant1Rang
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant1RangeVariant2Extent {
-    Variant0([NumberOrSignal; 2usize]),
-    Variant1(SignalRef),
+    Array([NumberOrSignal; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant2Extent {
     fn from(value: &ScaleVariant1RangeVariant2Extent) -> Self {
@@ -90380,12 +90346,12 @@ impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant2Extent {
 }
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ScaleVariant1RangeVariant2Extent {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant1RangeVariant2Extent {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant1RangeVariant2Scheme`"]
@@ -90421,28 +90387,28 @@ impl ::std::convert::From<SignalRef> for ScaleVariant1RangeVariant2Extent {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant1RangeVariant2Scheme {
-    Variant0(::std::string::String),
-    Variant1(::std::vec::Vec<ScaleVariant1RangeVariant2SchemeVariant1Item>),
-    Variant2(SignalRef),
+    String(::std::string::String),
+    Array(::std::vec::Vec<ScaleVariant1RangeVariant2SchemeArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant2Scheme {
     fn from(value: &ScaleVariant1RangeVariant2Scheme) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ScaleVariant1RangeVariant2SchemeVariant1Item>>
+impl ::std::convert::From<::std::vec::Vec<ScaleVariant1RangeVariant2SchemeArrayItem>>
     for ScaleVariant1RangeVariant2Scheme
 {
-    fn from(value: ::std::vec::Vec<ScaleVariant1RangeVariant2SchemeVariant1Item>) -> Self {
-        Self::Variant1(value)
+    fn from(value: ::std::vec::Vec<ScaleVariant1RangeVariant2SchemeArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant1RangeVariant2Scheme {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ScaleVariant1RangeVariant2SchemeVariant1Item`"]
+#[doc = "`ScaleVariant1RangeVariant2SchemeArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -90461,18 +90427,18 @@ impl ::std::convert::From<SignalRef> for ScaleVariant1RangeVariant2Scheme {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ScaleVariant1RangeVariant2SchemeVariant1Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum ScaleVariant1RangeVariant2SchemeArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant2SchemeVariant1Item {
-    fn from(value: &ScaleVariant1RangeVariant2SchemeVariant1Item) -> Self {
+impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant2SchemeArrayItem {
+    fn from(value: &ScaleVariant1RangeVariant2SchemeArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for ScaleVariant1RangeVariant2SchemeVariant1Item {
+impl ::std::convert::From<SignalRef> for ScaleVariant1RangeVariant2SchemeArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant1RangeVariant3`"]
@@ -90742,8 +90708,8 @@ impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant3 {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant1RangeVariant3Variant0Sort {
-    Variant0(bool),
-    Variant1 {
+    Boolean(bool),
+    Object {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         field: ::std::option::Option<StringOrSignal>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -90759,7 +90725,7 @@ impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant3Variant0Sort {
 }
 impl ::std::convert::From<bool> for ScaleVariant1RangeVariant3Variant0Sort {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`ScaleVariant1RangeVariant3Variant1Sort`"]
@@ -91049,33 +91015,31 @@ impl ::std::convert::TryFrom<::std::string::String>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ScaleVariant1RangeVariant3Variant2FieldsItem {
-    Variant0 {
+    Object {
         data: ::std::string::String,
         field: StringOrSignal,
     },
-    Variant1(::std::vec::Vec<ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item>),
-    Variant2(SignalRef),
+    Array(::std::vec::Vec<ScaleVariant1RangeVariant3Variant2FieldsItemArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant3Variant2FieldsItem {
     fn from(value: &ScaleVariant1RangeVariant3Variant2FieldsItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item>>
+impl ::std::convert::From<::std::vec::Vec<ScaleVariant1RangeVariant3Variant2FieldsItemArrayItem>>
     for ScaleVariant1RangeVariant3Variant2FieldsItem
 {
-    fn from(
-        value: ::std::vec::Vec<ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item>,
-    ) -> Self {
-        Self::Variant1(value)
+    fn from(value: ::std::vec::Vec<ScaleVariant1RangeVariant3Variant2FieldsItemArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant1RangeVariant3Variant2FieldsItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item`"]
+#[doc = "`ScaleVariant1RangeVariant3Variant2FieldsItemArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -91097,33 +91061,33 @@ impl ::std::convert::From<SignalRef> for ScaleVariant1RangeVariant3Variant2Field
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item {
-    Variant0(::std::string::String),
-    Variant1(f64),
-    Variant2(bool),
+pub enum ScaleVariant1RangeVariant3Variant2FieldsItemArrayItem {
+    String(::std::string::String),
+    Number(f64),
+    Boolean(bool),
 }
-impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item {
-    fn from(value: &ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item) -> Self {
+impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant3Variant2FieldsItemArrayItem {
+    fn from(value: &ScaleVariant1RangeVariant3Variant2FieldsItemArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::fmt::Display for ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item {
+impl ::std::fmt::Display for ScaleVariant1RangeVariant3Variant2FieldsItemArrayItem {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
-            Self::Variant2(x) => x.fmt(f),
+            Self::String(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
-impl ::std::convert::From<f64> for ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item {
+impl ::std::convert::From<f64> for ScaleVariant1RangeVariant3Variant2FieldsItemArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant1(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<bool> for ScaleVariant1RangeVariant3Variant2FieldsItemVariant1Item {
+impl ::std::convert::From<bool> for ScaleVariant1RangeVariant3Variant2FieldsItemArrayItem {
     fn from(value: bool) -> Self {
-        Self::Variant2(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`ScaleVariant1RangeVariant3Variant2Sort`"]
@@ -91483,75 +91447,31 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant1Type {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant2Domain {
-    Variant0(::std::vec::Vec<ScaleVariant2DomainVariant0Item>),
-    Variant1(ScaleData),
-    Variant2(SignalRef),
+    Array(::std::vec::Vec<ScaleVariant2DomainArrayItem>),
+    ScaleData(ScaleData),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant2Domain {
     fn from(value: &ScaleVariant2Domain) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ScaleVariant2DomainVariant0Item>>
-    for ScaleVariant2Domain
-{
-    fn from(value: ::std::vec::Vec<ScaleVariant2DomainVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<ScaleVariant2DomainArrayItem>> for ScaleVariant2Domain {
+    fn from(value: ::std::vec::Vec<ScaleVariant2DomainArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<ScaleData> for ScaleVariant2Domain {
     fn from(value: ScaleData) -> Self {
-        Self::Variant1(value)
+        Self::ScaleData(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant2Domain {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ScaleVariant2DomainRaw`"]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"oneOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"type\": \"null\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"type\": \"array\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/signalRef\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum ScaleVariant2DomainRaw {
-    Variant0,
-    Variant1(::std::vec::Vec<::serde_json::Value>),
-    Variant2(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant2DomainRaw {
-    fn from(value: &ScaleVariant2DomainRaw) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant2DomainRaw {
-    fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
-        Self::Variant1(value)
-    }
-}
-impl ::std::convert::From<SignalRef> for ScaleVariant2DomainRaw {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
-    }
-}
-#[doc = "`ScaleVariant2DomainVariant0Item`"]
+#[doc = "`ScaleVariant2DomainArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -91585,37 +91505,79 @@ impl ::std::convert::From<SignalRef> for ScaleVariant2DomainRaw {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ScaleVariant2DomainVariant0Item {
-    Variant0,
-    Variant1(bool),
-    Variant2(::std::string::String),
-    Variant3(f64),
-    Variant4(SignalRef),
-    Variant5(::std::vec::Vec<NumberOrSignal>),
+pub enum ScaleVariant2DomainArrayItem {
+    Null,
+    Boolean(bool),
+    String(::std::string::String),
+    Number(f64),
+    SignalRef(SignalRef),
+    Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant2DomainVariant0Item {
-    fn from(value: &ScaleVariant2DomainVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for ScaleVariant2DomainArrayItem {
+    fn from(value: &ScaleVariant2DomainArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<bool> for ScaleVariant2DomainVariant0Item {
+impl ::std::convert::From<bool> for ScaleVariant2DomainArrayItem {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
-impl ::std::convert::From<f64> for ScaleVariant2DomainVariant0Item {
+impl ::std::convert::From<f64> for ScaleVariant2DomainArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant3(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for ScaleVariant2DomainVariant0Item {
+impl ::std::convert::From<SignalRef> for ScaleVariant2DomainArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant4(value)
+        Self::SignalRef(value)
     }
 }
-impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant2DomainVariant0Item {
+impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant2DomainArrayItem {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
-        Self::Variant5(value)
+        Self::Array(value)
+    }
+}
+#[doc = "`ScaleVariant2DomainRaw`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"null\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"array\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"$ref\": \"#/definitions/signalRef\""]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum ScaleVariant2DomainRaw {
+    Null,
+    Array(::std::vec::Vec<::serde_json::Value>),
+    SignalRef(SignalRef),
+}
+impl ::std::convert::From<&Self> for ScaleVariant2DomainRaw {
+    fn from(value: &ScaleVariant2DomainRaw) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant2DomainRaw {
+    fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
+        Self::Array(value)
+    }
+}
+impl ::std::convert::From<SignalRef> for ScaleVariant2DomainRaw {
+    fn from(value: SignalRef) -> Self {
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant2Range`"]
@@ -91853,12 +91815,12 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant2RangeVarian
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant2RangeVariant1Item {
-    Variant0,
-    Variant1(bool),
-    Variant2(::std::string::String),
-    Variant3(f64),
-    Variant4(SignalRef),
-    Variant5(::std::vec::Vec<NumberOrSignal>),
+    Null,
+    Boolean(bool),
+    String(::std::string::String),
+    Number(f64),
+    SignalRef(SignalRef),
+    Array(::std::vec::Vec<NumberOrSignal>),
 }
 impl ::std::convert::From<&Self> for ScaleVariant2RangeVariant1Item {
     fn from(value: &ScaleVariant2RangeVariant1Item) -> Self {
@@ -91867,22 +91829,22 @@ impl ::std::convert::From<&Self> for ScaleVariant2RangeVariant1Item {
 }
 impl ::std::convert::From<bool> for ScaleVariant2RangeVariant1Item {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<f64> for ScaleVariant2RangeVariant1Item {
     fn from(value: f64) -> Self {
-        Self::Variant3(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant2RangeVariant1Item {
     fn from(value: SignalRef) -> Self {
-        Self::Variant4(value)
+        Self::SignalRef(value)
     }
 }
 impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant2RangeVariant1Item {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
-        Self::Variant5(value)
+        Self::Array(value)
     }
 }
 #[doc = "`ScaleVariant2Type`"]
@@ -92004,75 +91966,31 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant2Type {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant3Domain {
-    Variant0(::std::vec::Vec<ScaleVariant3DomainVariant0Item>),
-    Variant1(ScaleData),
-    Variant2(SignalRef),
+    Array(::std::vec::Vec<ScaleVariant3DomainArrayItem>),
+    ScaleData(ScaleData),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant3Domain {
     fn from(value: &ScaleVariant3Domain) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ScaleVariant3DomainVariant0Item>>
-    for ScaleVariant3Domain
-{
-    fn from(value: ::std::vec::Vec<ScaleVariant3DomainVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<ScaleVariant3DomainArrayItem>> for ScaleVariant3Domain {
+    fn from(value: ::std::vec::Vec<ScaleVariant3DomainArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<ScaleData> for ScaleVariant3Domain {
     fn from(value: ScaleData) -> Self {
-        Self::Variant1(value)
+        Self::ScaleData(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant3Domain {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ScaleVariant3DomainRaw`"]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"oneOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"type\": \"null\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"type\": \"array\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/signalRef\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum ScaleVariant3DomainRaw {
-    Variant0,
-    Variant1(::std::vec::Vec<::serde_json::Value>),
-    Variant2(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant3DomainRaw {
-    fn from(value: &ScaleVariant3DomainRaw) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant3DomainRaw {
-    fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
-        Self::Variant1(value)
-    }
-}
-impl ::std::convert::From<SignalRef> for ScaleVariant3DomainRaw {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
-    }
-}
-#[doc = "`ScaleVariant3DomainVariant0Item`"]
+#[doc = "`ScaleVariant3DomainArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92106,37 +92024,79 @@ impl ::std::convert::From<SignalRef> for ScaleVariant3DomainRaw {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ScaleVariant3DomainVariant0Item {
-    Variant0,
-    Variant1(bool),
-    Variant2(::std::string::String),
-    Variant3(f64),
-    Variant4(SignalRef),
-    Variant5(::std::vec::Vec<NumberOrSignal>),
+pub enum ScaleVariant3DomainArrayItem {
+    Null,
+    Boolean(bool),
+    String(::std::string::String),
+    Number(f64),
+    SignalRef(SignalRef),
+    Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant3DomainVariant0Item {
-    fn from(value: &ScaleVariant3DomainVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for ScaleVariant3DomainArrayItem {
+    fn from(value: &ScaleVariant3DomainArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<bool> for ScaleVariant3DomainVariant0Item {
+impl ::std::convert::From<bool> for ScaleVariant3DomainArrayItem {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
-impl ::std::convert::From<f64> for ScaleVariant3DomainVariant0Item {
+impl ::std::convert::From<f64> for ScaleVariant3DomainArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant3(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for ScaleVariant3DomainVariant0Item {
+impl ::std::convert::From<SignalRef> for ScaleVariant3DomainArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant4(value)
+        Self::SignalRef(value)
     }
 }
-impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant3DomainVariant0Item {
+impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant3DomainArrayItem {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
-        Self::Variant5(value)
+        Self::Array(value)
+    }
+}
+#[doc = "`ScaleVariant3DomainRaw`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"null\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"array\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"$ref\": \"#/definitions/signalRef\""]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum ScaleVariant3DomainRaw {
+    Null,
+    Array(::std::vec::Vec<::serde_json::Value>),
+    SignalRef(SignalRef),
+}
+impl ::std::convert::From<&Self> for ScaleVariant3DomainRaw {
+    fn from(value: &ScaleVariant3DomainRaw) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant3DomainRaw {
+    fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
+        Self::Array(value)
+    }
+}
+impl ::std::convert::From<SignalRef> for ScaleVariant3DomainRaw {
+    fn from(value: SignalRef) -> Self {
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant3Range`"]
@@ -92374,12 +92334,12 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant3RangeVarian
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant3RangeVariant1Item {
-    Variant0,
-    Variant1(bool),
-    Variant2(::std::string::String),
-    Variant3(f64),
-    Variant4(SignalRef),
-    Variant5(::std::vec::Vec<NumberOrSignal>),
+    Null,
+    Boolean(bool),
+    String(::std::string::String),
+    Number(f64),
+    SignalRef(SignalRef),
+    Array(::std::vec::Vec<NumberOrSignal>),
 }
 impl ::std::convert::From<&Self> for ScaleVariant3RangeVariant1Item {
     fn from(value: &ScaleVariant3RangeVariant1Item) -> Self {
@@ -92388,22 +92348,22 @@ impl ::std::convert::From<&Self> for ScaleVariant3RangeVariant1Item {
 }
 impl ::std::convert::From<bool> for ScaleVariant3RangeVariant1Item {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<f64> for ScaleVariant3RangeVariant1Item {
     fn from(value: f64) -> Self {
-        Self::Variant3(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant3RangeVariant1Item {
     fn from(value: SignalRef) -> Self {
-        Self::Variant4(value)
+        Self::SignalRef(value)
     }
 }
 impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant3RangeVariant1Item {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
-        Self::Variant5(value)
+        Self::Array(value)
     }
 }
 #[doc = "`ScaleVariant3Type`"]
@@ -92525,75 +92485,31 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant3Type {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant4Domain {
-    Variant0(::std::vec::Vec<ScaleVariant4DomainVariant0Item>),
-    Variant1(ScaleData),
-    Variant2(SignalRef),
+    Array(::std::vec::Vec<ScaleVariant4DomainArrayItem>),
+    ScaleData(ScaleData),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant4Domain {
     fn from(value: &ScaleVariant4Domain) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ScaleVariant4DomainVariant0Item>>
-    for ScaleVariant4Domain
-{
-    fn from(value: ::std::vec::Vec<ScaleVariant4DomainVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<ScaleVariant4DomainArrayItem>> for ScaleVariant4Domain {
+    fn from(value: ::std::vec::Vec<ScaleVariant4DomainArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<ScaleData> for ScaleVariant4Domain {
     fn from(value: ScaleData) -> Self {
-        Self::Variant1(value)
+        Self::ScaleData(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant4Domain {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ScaleVariant4DomainRaw`"]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"oneOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"type\": \"null\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"type\": \"array\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/signalRef\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum ScaleVariant4DomainRaw {
-    Variant0,
-    Variant1(::std::vec::Vec<::serde_json::Value>),
-    Variant2(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant4DomainRaw {
-    fn from(value: &ScaleVariant4DomainRaw) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant4DomainRaw {
-    fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
-        Self::Variant1(value)
-    }
-}
-impl ::std::convert::From<SignalRef> for ScaleVariant4DomainRaw {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
-    }
-}
-#[doc = "`ScaleVariant4DomainVariant0Item`"]
+#[doc = "`ScaleVariant4DomainArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -92627,37 +92543,79 @@ impl ::std::convert::From<SignalRef> for ScaleVariant4DomainRaw {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ScaleVariant4DomainVariant0Item {
-    Variant0,
-    Variant1(bool),
-    Variant2(::std::string::String),
-    Variant3(f64),
-    Variant4(SignalRef),
-    Variant5(::std::vec::Vec<NumberOrSignal>),
+pub enum ScaleVariant4DomainArrayItem {
+    Null,
+    Boolean(bool),
+    String(::std::string::String),
+    Number(f64),
+    SignalRef(SignalRef),
+    Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant4DomainVariant0Item {
-    fn from(value: &ScaleVariant4DomainVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for ScaleVariant4DomainArrayItem {
+    fn from(value: &ScaleVariant4DomainArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<bool> for ScaleVariant4DomainVariant0Item {
+impl ::std::convert::From<bool> for ScaleVariant4DomainArrayItem {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
-impl ::std::convert::From<f64> for ScaleVariant4DomainVariant0Item {
+impl ::std::convert::From<f64> for ScaleVariant4DomainArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant3(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for ScaleVariant4DomainVariant0Item {
+impl ::std::convert::From<SignalRef> for ScaleVariant4DomainArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant4(value)
+        Self::SignalRef(value)
     }
 }
-impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant4DomainVariant0Item {
+impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant4DomainArrayItem {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
-        Self::Variant5(value)
+        Self::Array(value)
+    }
+}
+#[doc = "`ScaleVariant4DomainRaw`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"null\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"array\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"$ref\": \"#/definitions/signalRef\""]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum ScaleVariant4DomainRaw {
+    Null,
+    Array(::std::vec::Vec<::serde_json::Value>),
+    SignalRef(SignalRef),
+}
+impl ::std::convert::From<&Self> for ScaleVariant4DomainRaw {
+    fn from(value: &ScaleVariant4DomainRaw) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant4DomainRaw {
+    fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
+        Self::Array(value)
+    }
+}
+impl ::std::convert::From<SignalRef> for ScaleVariant4DomainRaw {
+    fn from(value: SignalRef) -> Self {
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant4Nice`"]
@@ -92683,9 +92641,9 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant4Doma
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant4Nice {
-    Variant0(bool),
-    Variant1(f64),
-    Variant2(SignalRef),
+    Boolean(bool),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant4Nice {
     fn from(value: &ScaleVariant4Nice) -> Self {
@@ -92694,17 +92652,17 @@ impl ::std::convert::From<&Self> for ScaleVariant4Nice {
 }
 impl ::std::convert::From<bool> for ScaleVariant4Nice {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<f64> for ScaleVariant4Nice {
     fn from(value: f64) -> Self {
-        Self::Variant1(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant4Nice {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant4Range`"]
@@ -92986,12 +92944,12 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant4RangeVarian
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant4RangeVariant1Item {
-    Variant0,
-    Variant1(bool),
-    Variant2(::std::string::String),
-    Variant3(f64),
-    Variant4(SignalRef),
-    Variant5(::std::vec::Vec<NumberOrSignal>),
+    Null,
+    Boolean(bool),
+    String(::std::string::String),
+    Number(f64),
+    SignalRef(SignalRef),
+    Array(::std::vec::Vec<NumberOrSignal>),
 }
 impl ::std::convert::From<&Self> for ScaleVariant4RangeVariant1Item {
     fn from(value: &ScaleVariant4RangeVariant1Item) -> Self {
@@ -93000,22 +92958,22 @@ impl ::std::convert::From<&Self> for ScaleVariant4RangeVariant1Item {
 }
 impl ::std::convert::From<bool> for ScaleVariant4RangeVariant1Item {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<f64> for ScaleVariant4RangeVariant1Item {
     fn from(value: f64) -> Self {
-        Self::Variant3(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant4RangeVariant1Item {
     fn from(value: SignalRef) -> Self {
-        Self::Variant4(value)
+        Self::SignalRef(value)
     }
 }
 impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant4RangeVariant1Item {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
-        Self::Variant5(value)
+        Self::Array(value)
     }
 }
 #[doc = "`ScaleVariant4RangeVariant2Extent`"]
@@ -93043,8 +93001,8 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant4Rang
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant4RangeVariant2Extent {
-    Variant0([NumberOrSignal; 2usize]),
-    Variant1(SignalRef),
+    Array([NumberOrSignal; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant4RangeVariant2Extent {
     fn from(value: &ScaleVariant4RangeVariant2Extent) -> Self {
@@ -93053,12 +93011,12 @@ impl ::std::convert::From<&Self> for ScaleVariant4RangeVariant2Extent {
 }
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ScaleVariant4RangeVariant2Extent {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant4RangeVariant2Extent {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant4RangeVariant2Scheme`"]
@@ -93094,28 +93052,28 @@ impl ::std::convert::From<SignalRef> for ScaleVariant4RangeVariant2Extent {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant4RangeVariant2Scheme {
-    Variant0(::std::string::String),
-    Variant1(::std::vec::Vec<ScaleVariant4RangeVariant2SchemeVariant1Item>),
-    Variant2(SignalRef),
+    String(::std::string::String),
+    Array(::std::vec::Vec<ScaleVariant4RangeVariant2SchemeArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant4RangeVariant2Scheme {
     fn from(value: &ScaleVariant4RangeVariant2Scheme) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ScaleVariant4RangeVariant2SchemeVariant1Item>>
+impl ::std::convert::From<::std::vec::Vec<ScaleVariant4RangeVariant2SchemeArrayItem>>
     for ScaleVariant4RangeVariant2Scheme
 {
-    fn from(value: ::std::vec::Vec<ScaleVariant4RangeVariant2SchemeVariant1Item>) -> Self {
-        Self::Variant1(value)
+    fn from(value: ::std::vec::Vec<ScaleVariant4RangeVariant2SchemeArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant4RangeVariant2Scheme {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ScaleVariant4RangeVariant2SchemeVariant1Item`"]
+#[doc = "`ScaleVariant4RangeVariant2SchemeArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93134,18 +93092,18 @@ impl ::std::convert::From<SignalRef> for ScaleVariant4RangeVariant2Scheme {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ScaleVariant4RangeVariant2SchemeVariant1Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum ScaleVariant4RangeVariant2SchemeArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant4RangeVariant2SchemeVariant1Item {
-    fn from(value: &ScaleVariant4RangeVariant2SchemeVariant1Item) -> Self {
+impl ::std::convert::From<&Self> for ScaleVariant4RangeVariant2SchemeArrayItem {
+    fn from(value: &ScaleVariant4RangeVariant2SchemeArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for ScaleVariant4RangeVariant2SchemeVariant1Item {
+impl ::std::convert::From<SignalRef> for ScaleVariant4RangeVariant2SchemeArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant4Type`"]
@@ -93272,75 +93230,31 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant4Type {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant5Domain {
-    Variant0(::std::vec::Vec<ScaleVariant5DomainVariant0Item>),
-    Variant1(ScaleData),
-    Variant2(SignalRef),
+    Array(::std::vec::Vec<ScaleVariant5DomainArrayItem>),
+    ScaleData(ScaleData),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant5Domain {
     fn from(value: &ScaleVariant5Domain) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ScaleVariant5DomainVariant0Item>>
-    for ScaleVariant5Domain
-{
-    fn from(value: ::std::vec::Vec<ScaleVariant5DomainVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<ScaleVariant5DomainArrayItem>> for ScaleVariant5Domain {
+    fn from(value: ::std::vec::Vec<ScaleVariant5DomainArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<ScaleData> for ScaleVariant5Domain {
     fn from(value: ScaleData) -> Self {
-        Self::Variant1(value)
+        Self::ScaleData(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant5Domain {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ScaleVariant5DomainRaw`"]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"oneOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"type\": \"null\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"type\": \"array\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/signalRef\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum ScaleVariant5DomainRaw {
-    Variant0,
-    Variant1(::std::vec::Vec<::serde_json::Value>),
-    Variant2(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant5DomainRaw {
-    fn from(value: &ScaleVariant5DomainRaw) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant5DomainRaw {
-    fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
-        Self::Variant1(value)
-    }
-}
-impl ::std::convert::From<SignalRef> for ScaleVariant5DomainRaw {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
-    }
-}
-#[doc = "`ScaleVariant5DomainVariant0Item`"]
+#[doc = "`ScaleVariant5DomainArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93374,37 +93288,79 @@ impl ::std::convert::From<SignalRef> for ScaleVariant5DomainRaw {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ScaleVariant5DomainVariant0Item {
-    Variant0,
-    Variant1(bool),
-    Variant2(::std::string::String),
-    Variant3(f64),
-    Variant4(SignalRef),
-    Variant5(::std::vec::Vec<NumberOrSignal>),
+pub enum ScaleVariant5DomainArrayItem {
+    Null,
+    Boolean(bool),
+    String(::std::string::String),
+    Number(f64),
+    SignalRef(SignalRef),
+    Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant5DomainVariant0Item {
-    fn from(value: &ScaleVariant5DomainVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for ScaleVariant5DomainArrayItem {
+    fn from(value: &ScaleVariant5DomainArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<bool> for ScaleVariant5DomainVariant0Item {
+impl ::std::convert::From<bool> for ScaleVariant5DomainArrayItem {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
-impl ::std::convert::From<f64> for ScaleVariant5DomainVariant0Item {
+impl ::std::convert::From<f64> for ScaleVariant5DomainArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant3(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for ScaleVariant5DomainVariant0Item {
+impl ::std::convert::From<SignalRef> for ScaleVariant5DomainArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant4(value)
+        Self::SignalRef(value)
     }
 }
-impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant5DomainVariant0Item {
+impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant5DomainArrayItem {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
-        Self::Variant5(value)
+        Self::Array(value)
+    }
+}
+#[doc = "`ScaleVariant5DomainRaw`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"null\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"array\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"$ref\": \"#/definitions/signalRef\""]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum ScaleVariant5DomainRaw {
+    Null,
+    Array(::std::vec::Vec<::serde_json::Value>),
+    SignalRef(SignalRef),
+}
+impl ::std::convert::From<&Self> for ScaleVariant5DomainRaw {
+    fn from(value: &ScaleVariant5DomainRaw) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant5DomainRaw {
+    fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
+        Self::Array(value)
+    }
+}
+impl ::std::convert::From<SignalRef> for ScaleVariant5DomainRaw {
+    fn from(value: SignalRef) -> Self {
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant5Range`"]
@@ -93686,12 +93642,12 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant5RangeVarian
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant5RangeVariant1Item {
-    Variant0,
-    Variant1(bool),
-    Variant2(::std::string::String),
-    Variant3(f64),
-    Variant4(SignalRef),
-    Variant5(::std::vec::Vec<NumberOrSignal>),
+    Null,
+    Boolean(bool),
+    String(::std::string::String),
+    Number(f64),
+    SignalRef(SignalRef),
+    Array(::std::vec::Vec<NumberOrSignal>),
 }
 impl ::std::convert::From<&Self> for ScaleVariant5RangeVariant1Item {
     fn from(value: &ScaleVariant5RangeVariant1Item) -> Self {
@@ -93700,22 +93656,22 @@ impl ::std::convert::From<&Self> for ScaleVariant5RangeVariant1Item {
 }
 impl ::std::convert::From<bool> for ScaleVariant5RangeVariant1Item {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<f64> for ScaleVariant5RangeVariant1Item {
     fn from(value: f64) -> Self {
-        Self::Variant3(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant5RangeVariant1Item {
     fn from(value: SignalRef) -> Self {
-        Self::Variant4(value)
+        Self::SignalRef(value)
     }
 }
 impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant5RangeVariant1Item {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
-        Self::Variant5(value)
+        Self::Array(value)
     }
 }
 #[doc = "`ScaleVariant5RangeVariant2Extent`"]
@@ -93743,8 +93699,8 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant5Rang
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant5RangeVariant2Extent {
-    Variant0([NumberOrSignal; 2usize]),
-    Variant1(SignalRef),
+    Array([NumberOrSignal; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant5RangeVariant2Extent {
     fn from(value: &ScaleVariant5RangeVariant2Extent) -> Self {
@@ -93753,12 +93709,12 @@ impl ::std::convert::From<&Self> for ScaleVariant5RangeVariant2Extent {
 }
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ScaleVariant5RangeVariant2Extent {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant5RangeVariant2Extent {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant5RangeVariant2Scheme`"]
@@ -93794,28 +93750,28 @@ impl ::std::convert::From<SignalRef> for ScaleVariant5RangeVariant2Extent {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant5RangeVariant2Scheme {
-    Variant0(::std::string::String),
-    Variant1(::std::vec::Vec<ScaleVariant5RangeVariant2SchemeVariant1Item>),
-    Variant2(SignalRef),
+    String(::std::string::String),
+    Array(::std::vec::Vec<ScaleVariant5RangeVariant2SchemeArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant5RangeVariant2Scheme {
     fn from(value: &ScaleVariant5RangeVariant2Scheme) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ScaleVariant5RangeVariant2SchemeVariant1Item>>
+impl ::std::convert::From<::std::vec::Vec<ScaleVariant5RangeVariant2SchemeArrayItem>>
     for ScaleVariant5RangeVariant2Scheme
 {
-    fn from(value: ::std::vec::Vec<ScaleVariant5RangeVariant2SchemeVariant1Item>) -> Self {
-        Self::Variant1(value)
+    fn from(value: ::std::vec::Vec<ScaleVariant5RangeVariant2SchemeArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant5RangeVariant2Scheme {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ScaleVariant5RangeVariant2SchemeVariant1Item`"]
+#[doc = "`ScaleVariant5RangeVariant2SchemeArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -93834,18 +93790,18 @@ impl ::std::convert::From<SignalRef> for ScaleVariant5RangeVariant2Scheme {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ScaleVariant5RangeVariant2SchemeVariant1Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum ScaleVariant5RangeVariant2SchemeArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant5RangeVariant2SchemeVariant1Item {
-    fn from(value: &ScaleVariant5RangeVariant2SchemeVariant1Item) -> Self {
+impl ::std::convert::From<&Self> for ScaleVariant5RangeVariant2SchemeArrayItem {
+    fn from(value: &ScaleVariant5RangeVariant2SchemeArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for ScaleVariant5RangeVariant2SchemeVariant1Item {
+impl ::std::convert::From<SignalRef> for ScaleVariant5RangeVariant2SchemeArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant5Type`"]
@@ -93967,75 +93923,31 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant5Type {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant6Domain {
-    Variant0(::std::vec::Vec<ScaleVariant6DomainVariant0Item>),
-    Variant1(ScaleData),
-    Variant2(SignalRef),
+    Array(::std::vec::Vec<ScaleVariant6DomainArrayItem>),
+    ScaleData(ScaleData),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant6Domain {
     fn from(value: &ScaleVariant6Domain) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ScaleVariant6DomainVariant0Item>>
-    for ScaleVariant6Domain
-{
-    fn from(value: ::std::vec::Vec<ScaleVariant6DomainVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<ScaleVariant6DomainArrayItem>> for ScaleVariant6Domain {
+    fn from(value: ::std::vec::Vec<ScaleVariant6DomainArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<ScaleData> for ScaleVariant6Domain {
     fn from(value: ScaleData) -> Self {
-        Self::Variant1(value)
+        Self::ScaleData(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant6Domain {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ScaleVariant6DomainRaw`"]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"oneOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"type\": \"null\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"type\": \"array\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/signalRef\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum ScaleVariant6DomainRaw {
-    Variant0,
-    Variant1(::std::vec::Vec<::serde_json::Value>),
-    Variant2(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant6DomainRaw {
-    fn from(value: &ScaleVariant6DomainRaw) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant6DomainRaw {
-    fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
-        Self::Variant1(value)
-    }
-}
-impl ::std::convert::From<SignalRef> for ScaleVariant6DomainRaw {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
-    }
-}
-#[doc = "`ScaleVariant6DomainVariant0Item`"]
+#[doc = "`ScaleVariant6DomainArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94069,37 +93981,79 @@ impl ::std::convert::From<SignalRef> for ScaleVariant6DomainRaw {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ScaleVariant6DomainVariant0Item {
-    Variant0,
-    Variant1(bool),
-    Variant2(::std::string::String),
-    Variant3(f64),
-    Variant4(SignalRef),
-    Variant5(::std::vec::Vec<NumberOrSignal>),
+pub enum ScaleVariant6DomainArrayItem {
+    Null,
+    Boolean(bool),
+    String(::std::string::String),
+    Number(f64),
+    SignalRef(SignalRef),
+    Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant6DomainVariant0Item {
-    fn from(value: &ScaleVariant6DomainVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for ScaleVariant6DomainArrayItem {
+    fn from(value: &ScaleVariant6DomainArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<bool> for ScaleVariant6DomainVariant0Item {
+impl ::std::convert::From<bool> for ScaleVariant6DomainArrayItem {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
-impl ::std::convert::From<f64> for ScaleVariant6DomainVariant0Item {
+impl ::std::convert::From<f64> for ScaleVariant6DomainArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant3(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for ScaleVariant6DomainVariant0Item {
+impl ::std::convert::From<SignalRef> for ScaleVariant6DomainArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant4(value)
+        Self::SignalRef(value)
     }
 }
-impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant6DomainVariant0Item {
+impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant6DomainArrayItem {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
-        Self::Variant5(value)
+        Self::Array(value)
+    }
+}
+#[doc = "`ScaleVariant6DomainRaw`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"null\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"array\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"$ref\": \"#/definitions/signalRef\""]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum ScaleVariant6DomainRaw {
+    Null,
+    Array(::std::vec::Vec<::serde_json::Value>),
+    SignalRef(SignalRef),
+}
+impl ::std::convert::From<&Self> for ScaleVariant6DomainRaw {
+    fn from(value: &ScaleVariant6DomainRaw) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant6DomainRaw {
+    fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
+        Self::Array(value)
+    }
+}
+impl ::std::convert::From<SignalRef> for ScaleVariant6DomainRaw {
+    fn from(value: SignalRef) -> Self {
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant6Range`"]
@@ -94381,12 +94335,12 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant6RangeVarian
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant6RangeVariant1Item {
-    Variant0,
-    Variant1(bool),
-    Variant2(::std::string::String),
-    Variant3(f64),
-    Variant4(SignalRef),
-    Variant5(::std::vec::Vec<NumberOrSignal>),
+    Null,
+    Boolean(bool),
+    String(::std::string::String),
+    Number(f64),
+    SignalRef(SignalRef),
+    Array(::std::vec::Vec<NumberOrSignal>),
 }
 impl ::std::convert::From<&Self> for ScaleVariant6RangeVariant1Item {
     fn from(value: &ScaleVariant6RangeVariant1Item) -> Self {
@@ -94395,22 +94349,22 @@ impl ::std::convert::From<&Self> for ScaleVariant6RangeVariant1Item {
 }
 impl ::std::convert::From<bool> for ScaleVariant6RangeVariant1Item {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<f64> for ScaleVariant6RangeVariant1Item {
     fn from(value: f64) -> Self {
-        Self::Variant3(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant6RangeVariant1Item {
     fn from(value: SignalRef) -> Self {
-        Self::Variant4(value)
+        Self::SignalRef(value)
     }
 }
 impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant6RangeVariant1Item {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
-        Self::Variant5(value)
+        Self::Array(value)
     }
 }
 #[doc = "`ScaleVariant6RangeVariant2Extent`"]
@@ -94438,8 +94392,8 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant6Rang
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant6RangeVariant2Extent {
-    Variant0([NumberOrSignal; 2usize]),
-    Variant1(SignalRef),
+    Array([NumberOrSignal; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant6RangeVariant2Extent {
     fn from(value: &ScaleVariant6RangeVariant2Extent) -> Self {
@@ -94448,12 +94402,12 @@ impl ::std::convert::From<&Self> for ScaleVariant6RangeVariant2Extent {
 }
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ScaleVariant6RangeVariant2Extent {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant6RangeVariant2Extent {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant6RangeVariant2Scheme`"]
@@ -94489,28 +94443,28 @@ impl ::std::convert::From<SignalRef> for ScaleVariant6RangeVariant2Extent {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant6RangeVariant2Scheme {
-    Variant0(::std::string::String),
-    Variant1(::std::vec::Vec<ScaleVariant6RangeVariant2SchemeVariant1Item>),
-    Variant2(SignalRef),
+    String(::std::string::String),
+    Array(::std::vec::Vec<ScaleVariant6RangeVariant2SchemeArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant6RangeVariant2Scheme {
     fn from(value: &ScaleVariant6RangeVariant2Scheme) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ScaleVariant6RangeVariant2SchemeVariant1Item>>
+impl ::std::convert::From<::std::vec::Vec<ScaleVariant6RangeVariant2SchemeArrayItem>>
     for ScaleVariant6RangeVariant2Scheme
 {
-    fn from(value: ::std::vec::Vec<ScaleVariant6RangeVariant2SchemeVariant1Item>) -> Self {
-        Self::Variant1(value)
+    fn from(value: ::std::vec::Vec<ScaleVariant6RangeVariant2SchemeArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant6RangeVariant2Scheme {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ScaleVariant6RangeVariant2SchemeVariant1Item`"]
+#[doc = "`ScaleVariant6RangeVariant2SchemeArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94529,18 +94483,18 @@ impl ::std::convert::From<SignalRef> for ScaleVariant6RangeVariant2Scheme {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ScaleVariant6RangeVariant2SchemeVariant1Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum ScaleVariant6RangeVariant2SchemeArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant6RangeVariant2SchemeVariant1Item {
-    fn from(value: &ScaleVariant6RangeVariant2SchemeVariant1Item) -> Self {
+impl ::std::convert::From<&Self> for ScaleVariant6RangeVariant2SchemeArrayItem {
+    fn from(value: &ScaleVariant6RangeVariant2SchemeArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for ScaleVariant6RangeVariant2SchemeVariant1Item {
+impl ::std::convert::From<SignalRef> for ScaleVariant6RangeVariant2SchemeArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant6Type`"]
@@ -94662,75 +94616,31 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant6Type {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant7Domain {
-    Variant0(::std::vec::Vec<ScaleVariant7DomainVariant0Item>),
-    Variant1(ScaleData),
-    Variant2(SignalRef),
+    Array(::std::vec::Vec<ScaleVariant7DomainArrayItem>),
+    ScaleData(ScaleData),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant7Domain {
     fn from(value: &ScaleVariant7Domain) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ScaleVariant7DomainVariant0Item>>
-    for ScaleVariant7Domain
-{
-    fn from(value: ::std::vec::Vec<ScaleVariant7DomainVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<ScaleVariant7DomainArrayItem>> for ScaleVariant7Domain {
+    fn from(value: ::std::vec::Vec<ScaleVariant7DomainArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<ScaleData> for ScaleVariant7Domain {
     fn from(value: ScaleData) -> Self {
-        Self::Variant1(value)
+        Self::ScaleData(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant7Domain {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ScaleVariant7DomainRaw`"]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"oneOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"type\": \"null\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"type\": \"array\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/signalRef\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum ScaleVariant7DomainRaw {
-    Variant0,
-    Variant1(::std::vec::Vec<::serde_json::Value>),
-    Variant2(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant7DomainRaw {
-    fn from(value: &ScaleVariant7DomainRaw) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant7DomainRaw {
-    fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
-        Self::Variant1(value)
-    }
-}
-impl ::std::convert::From<SignalRef> for ScaleVariant7DomainRaw {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
-    }
-}
-#[doc = "`ScaleVariant7DomainVariant0Item`"]
+#[doc = "`ScaleVariant7DomainArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -94764,37 +94674,79 @@ impl ::std::convert::From<SignalRef> for ScaleVariant7DomainRaw {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ScaleVariant7DomainVariant0Item {
-    Variant0,
-    Variant1(bool),
-    Variant2(::std::string::String),
-    Variant3(f64),
-    Variant4(SignalRef),
-    Variant5(::std::vec::Vec<NumberOrSignal>),
+pub enum ScaleVariant7DomainArrayItem {
+    Null,
+    Boolean(bool),
+    String(::std::string::String),
+    Number(f64),
+    SignalRef(SignalRef),
+    Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant7DomainVariant0Item {
-    fn from(value: &ScaleVariant7DomainVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for ScaleVariant7DomainArrayItem {
+    fn from(value: &ScaleVariant7DomainArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<bool> for ScaleVariant7DomainVariant0Item {
+impl ::std::convert::From<bool> for ScaleVariant7DomainArrayItem {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
-impl ::std::convert::From<f64> for ScaleVariant7DomainVariant0Item {
+impl ::std::convert::From<f64> for ScaleVariant7DomainArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant3(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for ScaleVariant7DomainVariant0Item {
+impl ::std::convert::From<SignalRef> for ScaleVariant7DomainArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant4(value)
+        Self::SignalRef(value)
     }
 }
-impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant7DomainVariant0Item {
+impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant7DomainArrayItem {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
-        Self::Variant5(value)
+        Self::Array(value)
+    }
+}
+#[doc = "`ScaleVariant7DomainRaw`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"null\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"array\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"$ref\": \"#/definitions/signalRef\""]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum ScaleVariant7DomainRaw {
+    Null,
+    Array(::std::vec::Vec<::serde_json::Value>),
+    SignalRef(SignalRef),
+}
+impl ::std::convert::From<&Self> for ScaleVariant7DomainRaw {
+    fn from(value: &ScaleVariant7DomainRaw) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant7DomainRaw {
+    fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
+        Self::Array(value)
+    }
+}
+impl ::std::convert::From<SignalRef> for ScaleVariant7DomainRaw {
+    fn from(value: SignalRef) -> Self {
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant7Nice`"]
@@ -95420,12 +95372,12 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant7RangeVarian
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant7RangeVariant1Item {
-    Variant0,
-    Variant1(bool),
-    Variant2(::std::string::String),
-    Variant3(f64),
-    Variant4(SignalRef),
-    Variant5(::std::vec::Vec<NumberOrSignal>),
+    Null,
+    Boolean(bool),
+    String(::std::string::String),
+    Number(f64),
+    SignalRef(SignalRef),
+    Array(::std::vec::Vec<NumberOrSignal>),
 }
 impl ::std::convert::From<&Self> for ScaleVariant7RangeVariant1Item {
     fn from(value: &ScaleVariant7RangeVariant1Item) -> Self {
@@ -95434,22 +95386,22 @@ impl ::std::convert::From<&Self> for ScaleVariant7RangeVariant1Item {
 }
 impl ::std::convert::From<bool> for ScaleVariant7RangeVariant1Item {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<f64> for ScaleVariant7RangeVariant1Item {
     fn from(value: f64) -> Self {
-        Self::Variant3(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant7RangeVariant1Item {
     fn from(value: SignalRef) -> Self {
-        Self::Variant4(value)
+        Self::SignalRef(value)
     }
 }
 impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant7RangeVariant1Item {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
-        Self::Variant5(value)
+        Self::Array(value)
     }
 }
 #[doc = "`ScaleVariant7RangeVariant2Extent`"]
@@ -95477,8 +95429,8 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant7Rang
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant7RangeVariant2Extent {
-    Variant0([NumberOrSignal; 2usize]),
-    Variant1(SignalRef),
+    Array([NumberOrSignal; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant7RangeVariant2Extent {
     fn from(value: &ScaleVariant7RangeVariant2Extent) -> Self {
@@ -95487,12 +95439,12 @@ impl ::std::convert::From<&Self> for ScaleVariant7RangeVariant2Extent {
 }
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ScaleVariant7RangeVariant2Extent {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant7RangeVariant2Extent {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant7RangeVariant2Scheme`"]
@@ -95528,28 +95480,28 @@ impl ::std::convert::From<SignalRef> for ScaleVariant7RangeVariant2Extent {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant7RangeVariant2Scheme {
-    Variant0(::std::string::String),
-    Variant1(::std::vec::Vec<ScaleVariant7RangeVariant2SchemeVariant1Item>),
-    Variant2(SignalRef),
+    String(::std::string::String),
+    Array(::std::vec::Vec<ScaleVariant7RangeVariant2SchemeArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant7RangeVariant2Scheme {
     fn from(value: &ScaleVariant7RangeVariant2Scheme) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ScaleVariant7RangeVariant2SchemeVariant1Item>>
+impl ::std::convert::From<::std::vec::Vec<ScaleVariant7RangeVariant2SchemeArrayItem>>
     for ScaleVariant7RangeVariant2Scheme
 {
-    fn from(value: ::std::vec::Vec<ScaleVariant7RangeVariant2SchemeVariant1Item>) -> Self {
-        Self::Variant1(value)
+    fn from(value: ::std::vec::Vec<ScaleVariant7RangeVariant2SchemeArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant7RangeVariant2Scheme {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ScaleVariant7RangeVariant2SchemeVariant1Item`"]
+#[doc = "`ScaleVariant7RangeVariant2SchemeArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95568,18 +95520,18 @@ impl ::std::convert::From<SignalRef> for ScaleVariant7RangeVariant2Scheme {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ScaleVariant7RangeVariant2SchemeVariant1Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum ScaleVariant7RangeVariant2SchemeArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant7RangeVariant2SchemeVariant1Item {
-    fn from(value: &ScaleVariant7RangeVariant2SchemeVariant1Item) -> Self {
+impl ::std::convert::From<&Self> for ScaleVariant7RangeVariant2SchemeArrayItem {
+    fn from(value: &ScaleVariant7RangeVariant2SchemeArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for ScaleVariant7RangeVariant2SchemeVariant1Item {
+impl ::std::convert::From<SignalRef> for ScaleVariant7RangeVariant2SchemeArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant7Type`"]
@@ -95706,75 +95658,31 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant7Type {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant8Domain {
-    Variant0(::std::vec::Vec<ScaleVariant8DomainVariant0Item>),
-    Variant1(ScaleData),
-    Variant2(SignalRef),
+    Array(::std::vec::Vec<ScaleVariant8DomainArrayItem>),
+    ScaleData(ScaleData),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant8Domain {
     fn from(value: &ScaleVariant8Domain) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ScaleVariant8DomainVariant0Item>>
-    for ScaleVariant8Domain
-{
-    fn from(value: ::std::vec::Vec<ScaleVariant8DomainVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<ScaleVariant8DomainArrayItem>> for ScaleVariant8Domain {
+    fn from(value: ::std::vec::Vec<ScaleVariant8DomainArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<ScaleData> for ScaleVariant8Domain {
     fn from(value: ScaleData) -> Self {
-        Self::Variant1(value)
+        Self::ScaleData(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant8Domain {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ScaleVariant8DomainRaw`"]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"oneOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"type\": \"null\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"type\": \"array\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/signalRef\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum ScaleVariant8DomainRaw {
-    Variant0,
-    Variant1(::std::vec::Vec<::serde_json::Value>),
-    Variant2(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant8DomainRaw {
-    fn from(value: &ScaleVariant8DomainRaw) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant8DomainRaw {
-    fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
-        Self::Variant1(value)
-    }
-}
-impl ::std::convert::From<SignalRef> for ScaleVariant8DomainRaw {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
-    }
-}
-#[doc = "`ScaleVariant8DomainVariant0Item`"]
+#[doc = "`ScaleVariant8DomainArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -95808,37 +95716,79 @@ impl ::std::convert::From<SignalRef> for ScaleVariant8DomainRaw {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ScaleVariant8DomainVariant0Item {
-    Variant0,
-    Variant1(bool),
-    Variant2(::std::string::String),
-    Variant3(f64),
-    Variant4(SignalRef),
-    Variant5(::std::vec::Vec<NumberOrSignal>),
+pub enum ScaleVariant8DomainArrayItem {
+    Null,
+    Boolean(bool),
+    String(::std::string::String),
+    Number(f64),
+    SignalRef(SignalRef),
+    Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant8DomainVariant0Item {
-    fn from(value: &ScaleVariant8DomainVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for ScaleVariant8DomainArrayItem {
+    fn from(value: &ScaleVariant8DomainArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<bool> for ScaleVariant8DomainVariant0Item {
+impl ::std::convert::From<bool> for ScaleVariant8DomainArrayItem {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
-impl ::std::convert::From<f64> for ScaleVariant8DomainVariant0Item {
+impl ::std::convert::From<f64> for ScaleVariant8DomainArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant3(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for ScaleVariant8DomainVariant0Item {
+impl ::std::convert::From<SignalRef> for ScaleVariant8DomainArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant4(value)
+        Self::SignalRef(value)
     }
 }
-impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant8DomainVariant0Item {
+impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant8DomainArrayItem {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
-        Self::Variant5(value)
+        Self::Array(value)
+    }
+}
+#[doc = "`ScaleVariant8DomainRaw`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"null\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"array\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"$ref\": \"#/definitions/signalRef\""]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum ScaleVariant8DomainRaw {
+    Null,
+    Array(::std::vec::Vec<::serde_json::Value>),
+    SignalRef(SignalRef),
+}
+impl ::std::convert::From<&Self> for ScaleVariant8DomainRaw {
+    fn from(value: &ScaleVariant8DomainRaw) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant8DomainRaw {
+    fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
+        Self::Array(value)
+    }
+}
+impl ::std::convert::From<SignalRef> for ScaleVariant8DomainRaw {
+    fn from(value: SignalRef) -> Self {
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant8Nice`"]
@@ -95864,9 +95814,9 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant8Doma
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant8Nice {
-    Variant0(bool),
-    Variant1(f64),
-    Variant2(SignalRef),
+    Boolean(bool),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant8Nice {
     fn from(value: &ScaleVariant8Nice) -> Self {
@@ -95875,17 +95825,17 @@ impl ::std::convert::From<&Self> for ScaleVariant8Nice {
 }
 impl ::std::convert::From<bool> for ScaleVariant8Nice {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<f64> for ScaleVariant8Nice {
     fn from(value: f64) -> Self {
-        Self::Variant1(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant8Nice {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant8Range`"]
@@ -96167,12 +96117,12 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant8RangeVarian
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant8RangeVariant1Item {
-    Variant0,
-    Variant1(bool),
-    Variant2(::std::string::String),
-    Variant3(f64),
-    Variant4(SignalRef),
-    Variant5(::std::vec::Vec<NumberOrSignal>),
+    Null,
+    Boolean(bool),
+    String(::std::string::String),
+    Number(f64),
+    SignalRef(SignalRef),
+    Array(::std::vec::Vec<NumberOrSignal>),
 }
 impl ::std::convert::From<&Self> for ScaleVariant8RangeVariant1Item {
     fn from(value: &ScaleVariant8RangeVariant1Item) -> Self {
@@ -96181,22 +96131,22 @@ impl ::std::convert::From<&Self> for ScaleVariant8RangeVariant1Item {
 }
 impl ::std::convert::From<bool> for ScaleVariant8RangeVariant1Item {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<f64> for ScaleVariant8RangeVariant1Item {
     fn from(value: f64) -> Self {
-        Self::Variant3(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant8RangeVariant1Item {
     fn from(value: SignalRef) -> Self {
-        Self::Variant4(value)
+        Self::SignalRef(value)
     }
 }
 impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant8RangeVariant1Item {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
-        Self::Variant5(value)
+        Self::Array(value)
     }
 }
 #[doc = "`ScaleVariant8RangeVariant2Extent`"]
@@ -96224,8 +96174,8 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant8Rang
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant8RangeVariant2Extent {
-    Variant0([NumberOrSignal; 2usize]),
-    Variant1(SignalRef),
+    Array([NumberOrSignal; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant8RangeVariant2Extent {
     fn from(value: &ScaleVariant8RangeVariant2Extent) -> Self {
@@ -96234,12 +96184,12 @@ impl ::std::convert::From<&Self> for ScaleVariant8RangeVariant2Extent {
 }
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ScaleVariant8RangeVariant2Extent {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant8RangeVariant2Extent {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant8RangeVariant2Scheme`"]
@@ -96275,28 +96225,28 @@ impl ::std::convert::From<SignalRef> for ScaleVariant8RangeVariant2Extent {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant8RangeVariant2Scheme {
-    Variant0(::std::string::String),
-    Variant1(::std::vec::Vec<ScaleVariant8RangeVariant2SchemeVariant1Item>),
-    Variant2(SignalRef),
+    String(::std::string::String),
+    Array(::std::vec::Vec<ScaleVariant8RangeVariant2SchemeArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant8RangeVariant2Scheme {
     fn from(value: &ScaleVariant8RangeVariant2Scheme) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ScaleVariant8RangeVariant2SchemeVariant1Item>>
+impl ::std::convert::From<::std::vec::Vec<ScaleVariant8RangeVariant2SchemeArrayItem>>
     for ScaleVariant8RangeVariant2Scheme
 {
-    fn from(value: ::std::vec::Vec<ScaleVariant8RangeVariant2SchemeVariant1Item>) -> Self {
-        Self::Variant1(value)
+    fn from(value: ::std::vec::Vec<ScaleVariant8RangeVariant2SchemeArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant8RangeVariant2Scheme {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ScaleVariant8RangeVariant2SchemeVariant1Item`"]
+#[doc = "`ScaleVariant8RangeVariant2SchemeArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -96315,18 +96265,18 @@ impl ::std::convert::From<SignalRef> for ScaleVariant8RangeVariant2Scheme {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ScaleVariant8RangeVariant2SchemeVariant1Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum ScaleVariant8RangeVariant2SchemeArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant8RangeVariant2SchemeVariant1Item {
-    fn from(value: &ScaleVariant8RangeVariant2SchemeVariant1Item) -> Self {
+impl ::std::convert::From<&Self> for ScaleVariant8RangeVariant2SchemeArrayItem {
+    fn from(value: &ScaleVariant8RangeVariant2SchemeArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for ScaleVariant8RangeVariant2SchemeVariant1Item {
+impl ::std::convert::From<SignalRef> for ScaleVariant8RangeVariant2SchemeArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant8Type`"]
@@ -96458,75 +96408,31 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant8Type {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant9Domain {
-    Variant0(::std::vec::Vec<ScaleVariant9DomainVariant0Item>),
-    Variant1(ScaleData),
-    Variant2(SignalRef),
+    Array(::std::vec::Vec<ScaleVariant9DomainArrayItem>),
+    ScaleData(ScaleData),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant9Domain {
     fn from(value: &ScaleVariant9Domain) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ScaleVariant9DomainVariant0Item>>
-    for ScaleVariant9Domain
-{
-    fn from(value: ::std::vec::Vec<ScaleVariant9DomainVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<ScaleVariant9DomainArrayItem>> for ScaleVariant9Domain {
+    fn from(value: ::std::vec::Vec<ScaleVariant9DomainArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<ScaleData> for ScaleVariant9Domain {
     fn from(value: ScaleData) -> Self {
-        Self::Variant1(value)
+        Self::ScaleData(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant9Domain {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ScaleVariant9DomainRaw`"]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"oneOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"type\": \"null\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"type\": \"array\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/signalRef\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum ScaleVariant9DomainRaw {
-    Variant0,
-    Variant1(::std::vec::Vec<::serde_json::Value>),
-    Variant2(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant9DomainRaw {
-    fn from(value: &ScaleVariant9DomainRaw) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant9DomainRaw {
-    fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
-        Self::Variant1(value)
-    }
-}
-impl ::std::convert::From<SignalRef> for ScaleVariant9DomainRaw {
-    fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
-    }
-}
-#[doc = "`ScaleVariant9DomainVariant0Item`"]
+#[doc = "`ScaleVariant9DomainArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -96560,37 +96466,79 @@ impl ::std::convert::From<SignalRef> for ScaleVariant9DomainRaw {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ScaleVariant9DomainVariant0Item {
-    Variant0,
-    Variant1(bool),
-    Variant2(::std::string::String),
-    Variant3(f64),
-    Variant4(SignalRef),
-    Variant5(::std::vec::Vec<NumberOrSignal>),
+pub enum ScaleVariant9DomainArrayItem {
+    Null,
+    Boolean(bool),
+    String(::std::string::String),
+    Number(f64),
+    SignalRef(SignalRef),
+    Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant9DomainVariant0Item {
-    fn from(value: &ScaleVariant9DomainVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for ScaleVariant9DomainArrayItem {
+    fn from(value: &ScaleVariant9DomainArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<bool> for ScaleVariant9DomainVariant0Item {
+impl ::std::convert::From<bool> for ScaleVariant9DomainArrayItem {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
-impl ::std::convert::From<f64> for ScaleVariant9DomainVariant0Item {
+impl ::std::convert::From<f64> for ScaleVariant9DomainArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant3(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for ScaleVariant9DomainVariant0Item {
+impl ::std::convert::From<SignalRef> for ScaleVariant9DomainArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant4(value)
+        Self::SignalRef(value)
     }
 }
-impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant9DomainVariant0Item {
+impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant9DomainArrayItem {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
-        Self::Variant5(value)
+        Self::Array(value)
+    }
+}
+#[doc = "`ScaleVariant9DomainRaw`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"null\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"array\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"$ref\": \"#/definitions/signalRef\""]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum ScaleVariant9DomainRaw {
+    Null,
+    Array(::std::vec::Vec<::serde_json::Value>),
+    SignalRef(SignalRef),
+}
+impl ::std::convert::From<&Self> for ScaleVariant9DomainRaw {
+    fn from(value: &ScaleVariant9DomainRaw) -> Self {
+        value.clone()
+    }
+}
+impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant9DomainRaw {
+    fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
+        Self::Array(value)
+    }
+}
+impl ::std::convert::From<SignalRef> for ScaleVariant9DomainRaw {
+    fn from(value: SignalRef) -> Self {
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant9Nice`"]
@@ -96616,9 +96564,9 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant9Doma
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant9Nice {
-    Variant0(bool),
-    Variant1(f64),
-    Variant2(SignalRef),
+    Boolean(bool),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant9Nice {
     fn from(value: &ScaleVariant9Nice) -> Self {
@@ -96627,17 +96575,17 @@ impl ::std::convert::From<&Self> for ScaleVariant9Nice {
 }
 impl ::std::convert::From<bool> for ScaleVariant9Nice {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<f64> for ScaleVariant9Nice {
     fn from(value: f64) -> Self {
-        Self::Variant1(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant9Nice {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant9Range`"]
@@ -96919,12 +96867,12 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant9RangeVarian
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant9RangeVariant1Item {
-    Variant0,
-    Variant1(bool),
-    Variant2(::std::string::String),
-    Variant3(f64),
-    Variant4(SignalRef),
-    Variant5(::std::vec::Vec<NumberOrSignal>),
+    Null,
+    Boolean(bool),
+    String(::std::string::String),
+    Number(f64),
+    SignalRef(SignalRef),
+    Array(::std::vec::Vec<NumberOrSignal>),
 }
 impl ::std::convert::From<&Self> for ScaleVariant9RangeVariant1Item {
     fn from(value: &ScaleVariant9RangeVariant1Item) -> Self {
@@ -96933,22 +96881,22 @@ impl ::std::convert::From<&Self> for ScaleVariant9RangeVariant1Item {
 }
 impl ::std::convert::From<bool> for ScaleVariant9RangeVariant1Item {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<f64> for ScaleVariant9RangeVariant1Item {
     fn from(value: f64) -> Self {
-        Self::Variant3(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant9RangeVariant1Item {
     fn from(value: SignalRef) -> Self {
-        Self::Variant4(value)
+        Self::SignalRef(value)
     }
 }
 impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant9RangeVariant1Item {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
-        Self::Variant5(value)
+        Self::Array(value)
     }
 }
 #[doc = "`ScaleVariant9RangeVariant2Extent`"]
@@ -96976,8 +96924,8 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant9Rang
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant9RangeVariant2Extent {
-    Variant0([NumberOrSignal; 2usize]),
-    Variant1(SignalRef),
+    Array([NumberOrSignal; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant9RangeVariant2Extent {
     fn from(value: &ScaleVariant9RangeVariant2Extent) -> Self {
@@ -96986,12 +96934,12 @@ impl ::std::convert::From<&Self> for ScaleVariant9RangeVariant2Extent {
 }
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ScaleVariant9RangeVariant2Extent {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant9RangeVariant2Extent {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant9RangeVariant2Scheme`"]
@@ -97027,28 +96975,28 @@ impl ::std::convert::From<SignalRef> for ScaleVariant9RangeVariant2Extent {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum ScaleVariant9RangeVariant2Scheme {
-    Variant0(::std::string::String),
-    Variant1(::std::vec::Vec<ScaleVariant9RangeVariant2SchemeVariant1Item>),
-    Variant2(SignalRef),
+    String(::std::string::String),
+    Array(::std::vec::Vec<ScaleVariant9RangeVariant2SchemeArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for ScaleVariant9RangeVariant2Scheme {
     fn from(value: &ScaleVariant9RangeVariant2Scheme) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<ScaleVariant9RangeVariant2SchemeVariant1Item>>
+impl ::std::convert::From<::std::vec::Vec<ScaleVariant9RangeVariant2SchemeArrayItem>>
     for ScaleVariant9RangeVariant2Scheme
 {
-    fn from(value: ::std::vec::Vec<ScaleVariant9RangeVariant2SchemeVariant1Item>) -> Self {
-        Self::Variant1(value)
+    fn from(value: ::std::vec::Vec<ScaleVariant9RangeVariant2SchemeArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant9RangeVariant2Scheme {
     fn from(value: SignalRef) -> Self {
-        Self::Variant2(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`ScaleVariant9RangeVariant2SchemeVariant1Item`"]
+#[doc = "`ScaleVariant9RangeVariant2SchemeArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -97067,18 +97015,18 @@ impl ::std::convert::From<SignalRef> for ScaleVariant9RangeVariant2Scheme {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ScaleVariant9RangeVariant2SchemeVariant1Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum ScaleVariant9RangeVariant2SchemeArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant9RangeVariant2SchemeVariant1Item {
-    fn from(value: &ScaleVariant9RangeVariant2SchemeVariant1Item) -> Self {
+impl ::std::convert::From<&Self> for ScaleVariant9RangeVariant2SchemeArrayItem {
+    fn from(value: &ScaleVariant9RangeVariant2SchemeArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for ScaleVariant9RangeVariant2SchemeVariant1Item {
+impl ::std::convert::From<SignalRef> for ScaleVariant9RangeVariant2SchemeArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`ScaleVariant9Type`"]
@@ -97473,8 +97421,8 @@ impl ::std::convert::From<&SequenceTransform> for SequenceTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum SequenceTransformAs {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for SequenceTransformAs {
     fn from(value: &SequenceTransformAs) -> Self {
@@ -97483,12 +97431,12 @@ impl ::std::convert::From<&Self> for SequenceTransformAs {
 }
 impl ::std::default::Default for SequenceTransformAs {
     fn default() -> Self {
-        SequenceTransformAs::Variant0("data".to_string())
+        SequenceTransformAs::String("data".to_string())
     }
 }
 impl ::std::convert::From<SignalRef> for SequenceTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`SequenceTransformStart`"]
@@ -97511,8 +97459,8 @@ impl ::std::convert::From<SignalRef> for SequenceTransformAs {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum SequenceTransformStart {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for SequenceTransformStart {
     fn from(value: &SequenceTransformStart) -> Self {
@@ -97521,12 +97469,12 @@ impl ::std::convert::From<&Self> for SequenceTransformStart {
 }
 impl ::std::convert::From<f64> for SequenceTransformStart {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for SequenceTransformStart {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`SequenceTransformStep`"]
@@ -97550,8 +97498,8 @@ impl ::std::convert::From<SignalRef> for SequenceTransformStart {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum SequenceTransformStep {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for SequenceTransformStep {
     fn from(value: &SequenceTransformStep) -> Self {
@@ -97560,17 +97508,17 @@ impl ::std::convert::From<&Self> for SequenceTransformStep {
 }
 impl ::std::default::Default for SequenceTransformStep {
     fn default() -> Self {
-        SequenceTransformStep::Variant0(1_f64)
+        SequenceTransformStep::Number(1_f64)
     }
 }
 impl ::std::convert::From<f64> for SequenceTransformStep {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for SequenceTransformStep {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`SequenceTransformStop`"]
@@ -97593,8 +97541,8 @@ impl ::std::convert::From<SignalRef> for SequenceTransformStep {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum SequenceTransformStop {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for SequenceTransformStop {
     fn from(value: &SequenceTransformStop) -> Self {
@@ -97603,12 +97551,12 @@ impl ::std::convert::From<&Self> for SequenceTransformStop {
 }
 impl ::std::convert::From<f64> for SequenceTransformStop {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for SequenceTransformStop {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`SequenceTransformType`"]
@@ -98259,8 +98207,8 @@ impl ::std::convert::From<&StackTransform> for StackTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum StackTransformAs {
-    Variant0([StackTransformAsVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([StackTransformAsArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for StackTransformAs {
     fn from(value: &StackTransformAs) -> Self {
@@ -98269,23 +98217,23 @@ impl ::std::convert::From<&Self> for StackTransformAs {
 }
 impl ::std::default::Default for StackTransformAs {
     fn default() -> Self {
-        StackTransformAs::Variant0([
-            StackTransformAsVariant0Item::Variant0("y0".to_string()),
-            StackTransformAsVariant0Item::Variant0("y1".to_string()),
+        StackTransformAs::Array([
+            StackTransformAsArrayItem::String("y0".to_string()),
+            StackTransformAsArrayItem::String("y1".to_string()),
         ])
     }
 }
-impl ::std::convert::From<[StackTransformAsVariant0Item; 2usize]> for StackTransformAs {
-    fn from(value: [StackTransformAsVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[StackTransformAsArrayItem; 2usize]> for StackTransformAs {
+    fn from(value: [StackTransformAsArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for StackTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`StackTransformAsVariant0Item`"]
+#[doc = "`StackTransformAsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -98304,18 +98252,18 @@ impl ::std::convert::From<SignalRef> for StackTransformAs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum StackTransformAsVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum StackTransformAsArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for StackTransformAsVariant0Item {
-    fn from(value: &StackTransformAsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for StackTransformAsArrayItem {
+    fn from(value: &StackTransformAsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for StackTransformAsVariant0Item {
+impl ::std::convert::From<SignalRef> for StackTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`StackTransformField`"]
@@ -98398,27 +98346,27 @@ impl ::std::convert::From<Expr> for StackTransformField {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum StackTransformGroupby {
-    Variant0(::std::vec::Vec<StackTransformGroupbyVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<StackTransformGroupbyArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for StackTransformGroupby {
     fn from(value: &StackTransformGroupby) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<StackTransformGroupbyVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<StackTransformGroupbyArrayItem>>
     for StackTransformGroupby
 {
-    fn from(value: ::std::vec::Vec<StackTransformGroupbyVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<StackTransformGroupbyArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for StackTransformGroupby {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`StackTransformGroupbyVariant0Item`"]
+#[doc = "`StackTransformGroupbyArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -98440,27 +98388,27 @@ impl ::std::convert::From<SignalRef> for StackTransformGroupby {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum StackTransformGroupbyVariant0Item {
+pub enum StackTransformGroupbyArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for StackTransformGroupbyVariant0Item {
-    fn from(value: &StackTransformGroupbyVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for StackTransformGroupbyArrayItem {
+    fn from(value: &StackTransformGroupbyArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<ScaleField> for StackTransformGroupbyVariant0Item {
+impl ::std::convert::From<ScaleField> for StackTransformGroupbyArrayItem {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
     }
 }
-impl ::std::convert::From<ParamField> for StackTransformGroupbyVariant0Item {
+impl ::std::convert::From<ParamField> for StackTransformGroupbyArrayItem {
     fn from(value: ParamField) -> Self {
         Self::ParamField(value)
     }
 }
-impl ::std::convert::From<Expr> for StackTransformGroupbyVariant0Item {
+impl ::std::convert::From<Expr> for StackTransformGroupbyArrayItem {
     fn from(value: Expr) -> Self {
         Self::Expr(value)
     }
@@ -99082,8 +99030,8 @@ impl ::std::convert::From<&Self> for Stream {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum StreamVariant0Filter {
-    Variant0(ExprString),
-    Variant1(::std::vec::Vec<ExprString>),
+    ExprString(ExprString),
+    Array(::std::vec::Vec<ExprString>),
 }
 impl ::std::convert::From<&Self> for StreamVariant0Filter {
     fn from(value: &StreamVariant0Filter) -> Self {
@@ -99092,12 +99040,12 @@ impl ::std::convert::From<&Self> for StreamVariant0Filter {
 }
 impl ::std::convert::From<ExprString> for StreamVariant0Filter {
     fn from(value: ExprString) -> Self {
-        Self::Variant0(value)
+        Self::ExprString(value)
     }
 }
 impl ::std::convert::From<::std::vec::Vec<ExprString>> for StreamVariant0Filter {
     fn from(value: ::std::vec::Vec<ExprString>) -> Self {
-        Self::Variant1(value)
+        Self::Array(value)
     }
 }
 #[doc = "`StreamVariant1Filter`"]
@@ -99124,8 +99072,8 @@ impl ::std::convert::From<::std::vec::Vec<ExprString>> for StreamVariant0Filter 
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum StreamVariant1Filter {
-    Variant0(ExprString),
-    Variant1(::std::vec::Vec<ExprString>),
+    ExprString(ExprString),
+    Array(::std::vec::Vec<ExprString>),
 }
 impl ::std::convert::From<&Self> for StreamVariant1Filter {
     fn from(value: &StreamVariant1Filter) -> Self {
@@ -99134,12 +99082,12 @@ impl ::std::convert::From<&Self> for StreamVariant1Filter {
 }
 impl ::std::convert::From<ExprString> for StreamVariant1Filter {
     fn from(value: ExprString) -> Self {
-        Self::Variant0(value)
+        Self::ExprString(value)
     }
 }
 impl ::std::convert::From<::std::vec::Vec<ExprString>> for StreamVariant1Filter {
     fn from(value: ::std::vec::Vec<ExprString>) -> Self {
-        Self::Variant1(value)
+        Self::Array(value)
     }
 }
 #[doc = "`StreamVariant2Filter`"]
@@ -99166,8 +99114,8 @@ impl ::std::convert::From<::std::vec::Vec<ExprString>> for StreamVariant1Filter 
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum StreamVariant2Filter {
-    Variant0(ExprString),
-    Variant1(::std::vec::Vec<ExprString>),
+    ExprString(ExprString),
+    Array(::std::vec::Vec<ExprString>),
 }
 impl ::std::convert::From<&Self> for StreamVariant2Filter {
     fn from(value: &StreamVariant2Filter) -> Self {
@@ -99176,12 +99124,12 @@ impl ::std::convert::From<&Self> for StreamVariant2Filter {
 }
 impl ::std::convert::From<ExprString> for StreamVariant2Filter {
     fn from(value: ExprString) -> Self {
-        Self::Variant0(value)
+        Self::ExprString(value)
     }
 }
 impl ::std::convert::From<::std::vec::Vec<ExprString>> for StreamVariant2Filter {
     fn from(value: ::std::vec::Vec<ExprString>) -> Self {
-        Self::Variant1(value)
+        Self::Array(value)
     }
 }
 #[doc = "`StringModifiers`"]
@@ -99236,8 +99184,8 @@ impl ::std::default::Default for StringModifiers {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum StringOrSignal {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for StringOrSignal {
     fn from(value: &StringOrSignal) -> Self {
@@ -99246,7 +99194,7 @@ impl ::std::convert::From<&Self> for StringOrSignal {
 }
 impl ::std::convert::From<SignalRef> for StringOrSignal {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`StringValue`"]
@@ -99723,8 +99671,8 @@ impl ::std::convert::From<&Self> for StringValueVariant0ItemVariant0 {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum StringValueVariant0ItemVariant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for StringValueVariant0ItemVariant0Variant3Range {
     fn from(value: &StringValueVariant0ItemVariant0Variant3Range) -> Self {
@@ -99735,9 +99683,9 @@ impl ::std::str::FromStr for StringValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -99772,19 +99720,19 @@ impl ::std::convert::TryFrom<::std::string::String>
 impl ::std::fmt::Display for StringValueVariant0ItemVariant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for StringValueVariant0ItemVariant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for StringValueVariant0ItemVariant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`StringValueVariant0ItemVariant1`"]
@@ -100269,8 +100217,8 @@ impl ::std::convert::From<&Self> for StringValueVariant1Variant0 {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum StringValueVariant1Variant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for StringValueVariant1Variant0Variant3Range {
     fn from(value: &StringValueVariant1Variant0Variant3Range) -> Self {
@@ -100281,9 +100229,9 @@ impl ::std::str::FromStr for StringValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -100314,19 +100262,19 @@ impl ::std::convert::TryFrom<::std::string::String> for StringValueVariant1Varia
 impl ::std::fmt::Display for StringValueVariant1Variant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for StringValueVariant1Variant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for StringValueVariant1Variant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`StringValueVariant1Variant1`"]
@@ -101126,8 +101074,8 @@ impl ::std::convert::TryFrom<::std::string::String>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum StrokeCapValueVariant0ItemVariant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for StrokeCapValueVariant0ItemVariant0Variant3Range {
     fn from(value: &StrokeCapValueVariant0ItemVariant0Variant3Range) -> Self {
@@ -101138,9 +101086,9 @@ impl ::std::str::FromStr for StrokeCapValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -101175,19 +101123,19 @@ impl ::std::convert::TryFrom<::std::string::String>
 impl ::std::fmt::Display for StrokeCapValueVariant0ItemVariant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for StrokeCapValueVariant0ItemVariant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for StrokeCapValueVariant0ItemVariant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`StrokeCapValueVariant0ItemVariant1`"]
@@ -101773,8 +101721,8 @@ impl ::std::convert::TryFrom<::std::string::String>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum StrokeCapValueVariant1Variant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for StrokeCapValueVariant1Variant0Variant3Range {
     fn from(value: &StrokeCapValueVariant1Variant0Variant3Range) -> Self {
@@ -101785,9 +101733,9 @@ impl ::std::str::FromStr for StrokeCapValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -101822,19 +101770,19 @@ impl ::std::convert::TryFrom<::std::string::String>
 impl ::std::fmt::Display for StrokeCapValueVariant1Variant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for StrokeCapValueVariant1Variant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for StrokeCapValueVariant1Variant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`StrokeCapValueVariant1Variant1`"]
@@ -102642,8 +102590,8 @@ impl ::std::convert::TryFrom<::std::string::String>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum StrokeJoinValueVariant0ItemVariant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for StrokeJoinValueVariant0ItemVariant0Variant3Range {
     fn from(value: &StrokeJoinValueVariant0ItemVariant0Variant3Range) -> Self {
@@ -102654,9 +102602,9 @@ impl ::std::str::FromStr for StrokeJoinValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -102691,19 +102639,19 @@ impl ::std::convert::TryFrom<::std::string::String>
 impl ::std::fmt::Display for StrokeJoinValueVariant0ItemVariant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for StrokeJoinValueVariant0ItemVariant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for StrokeJoinValueVariant0ItemVariant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`StrokeJoinValueVariant0ItemVariant1`"]
@@ -103289,8 +103237,8 @@ impl ::std::convert::TryFrom<::std::string::String>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum StrokeJoinValueVariant1Variant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for StrokeJoinValueVariant1Variant0Variant3Range {
     fn from(value: &StrokeJoinValueVariant1Variant0Variant3Range) -> Self {
@@ -103301,9 +103249,9 @@ impl ::std::str::FromStr for StrokeJoinValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -103338,19 +103286,19 @@ impl ::std::convert::TryFrom<::std::string::String>
 impl ::std::fmt::Display for StrokeJoinValueVariant1Variant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for StrokeJoinValueVariant1Variant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for StrokeJoinValueVariant1Variant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`StrokeJoinValueVariant1Variant1`"]
@@ -103606,8 +103554,8 @@ impl ::std::convert::From<&Self> for StrokeJoinValueVariant1Variant2 {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum Style {
-    Variant0(::std::string::String),
-    Variant1(::std::vec::Vec<::std::string::String>),
+    String(::std::string::String),
+    Array(::std::vec::Vec<::std::string::String>),
 }
 impl ::std::convert::From<&Self> for Style {
     fn from(value: &Style) -> Self {
@@ -103616,7 +103564,7 @@ impl ::std::convert::From<&Self> for Style {
 }
 impl ::std::convert::From<::std::vec::Vec<::std::string::String>> for Style {
     fn from(value: ::std::vec::Vec<::std::string::String>) -> Self {
-        Self::Variant1(value)
+        Self::Array(value)
     }
 }
 #[doc = "`TextOrSignal`"]
@@ -103690,8 +103638,8 @@ impl ::std::convert::From<SignalRef> for TextOrSignal {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum TextOrSignalVariant0 {
-    Variant0(::std::string::String),
-    Variant1(::std::vec::Vec<::std::string::String>),
+    String(::std::string::String),
+    Array(::std::vec::Vec<::std::string::String>),
 }
 impl ::std::convert::From<&Self> for TextOrSignalVariant0 {
     fn from(value: &TextOrSignalVariant0) -> Self {
@@ -103700,7 +103648,7 @@ impl ::std::convert::From<&Self> for TextOrSignalVariant0 {
 }
 impl ::std::convert::From<::std::vec::Vec<::std::string::String>> for TextOrSignalVariant0 {
     fn from(value: ::std::vec::Vec<::std::string::String>) -> Self {
-        Self::Variant1(value)
+        Self::Array(value)
     }
 }
 #[doc = "`TextValue`"]
@@ -104220,8 +104168,8 @@ impl ::std::convert::From<&Self> for TextValueVariant0ItemVariant0 {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum TextValueVariant0ItemVariant0Variant1Value {
-    Variant0(::std::string::String),
-    Variant1(::std::vec::Vec<::std::string::String>),
+    String(::std::string::String),
+    Array(::std::vec::Vec<::std::string::String>),
 }
 impl ::std::convert::From<&Self> for TextValueVariant0ItemVariant0Variant1Value {
     fn from(value: &TextValueVariant0ItemVariant0Variant1Value) -> Self {
@@ -104232,7 +104180,7 @@ impl ::std::convert::From<::std::vec::Vec<::std::string::String>>
     for TextValueVariant0ItemVariant0Variant1Value
 {
     fn from(value: ::std::vec::Vec<::std::string::String>) -> Self {
-        Self::Variant1(value)
+        Self::Array(value)
     }
 }
 #[doc = "`TextValueVariant0ItemVariant0Variant3Range`"]
@@ -104255,8 +104203,8 @@ impl ::std::convert::From<::std::vec::Vec<::std::string::String>>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum TextValueVariant0ItemVariant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for TextValueVariant0ItemVariant0Variant3Range {
     fn from(value: &TextValueVariant0ItemVariant0Variant3Range) -> Self {
@@ -104267,9 +104215,9 @@ impl ::std::str::FromStr for TextValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -104302,19 +104250,19 @@ impl ::std::convert::TryFrom<::std::string::String> for TextValueVariant0ItemVar
 impl ::std::fmt::Display for TextValueVariant0ItemVariant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for TextValueVariant0ItemVariant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for TextValueVariant0ItemVariant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`TextValueVariant0ItemVariant1`"]
@@ -104842,8 +104790,8 @@ impl ::std::convert::From<&Self> for TextValueVariant1Variant0 {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum TextValueVariant1Variant0Variant1Value {
-    Variant0(::std::string::String),
-    Variant1(::std::vec::Vec<::std::string::String>),
+    String(::std::string::String),
+    Array(::std::vec::Vec<::std::string::String>),
 }
 impl ::std::convert::From<&Self> for TextValueVariant1Variant0Variant1Value {
     fn from(value: &TextValueVariant1Variant0Variant1Value) -> Self {
@@ -104854,7 +104802,7 @@ impl ::std::convert::From<::std::vec::Vec<::std::string::String>>
     for TextValueVariant1Variant0Variant1Value
 {
     fn from(value: ::std::vec::Vec<::std::string::String>) -> Self {
-        Self::Variant1(value)
+        Self::Array(value)
     }
 }
 #[doc = "`TextValueVariant1Variant0Variant3Range`"]
@@ -104877,8 +104825,8 @@ impl ::std::convert::From<::std::vec::Vec<::std::string::String>>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum TextValueVariant1Variant0Variant3Range {
-    Variant0(f64),
-    Variant1(bool),
+    Number(f64),
+    Boolean(bool),
 }
 impl ::std::convert::From<&Self> for TextValueVariant1Variant0Variant3Range {
     fn from(value: &TextValueVariant1Variant0Variant3Range) -> Self {
@@ -104889,9 +104837,9 @@ impl ::std::str::FromStr for TextValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Number(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::Boolean(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -104922,19 +104870,19 @@ impl ::std::convert::TryFrom<::std::string::String> for TextValueVariant1Variant
 impl ::std::fmt::Display for TextValueVariant1Variant0Variant3Range {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<f64> for TextValueVariant1Variant0Variant3Range {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<bool> for TextValueVariant1Variant0Variant3Range {
     fn from(value: bool) -> Self {
-        Self::Variant1(value)
+        Self::Boolean(value)
     }
 }
 #[doc = "`TextValueVariant1Variant1`"]
@@ -105874,8 +105822,8 @@ impl ::std::convert::From<&TimeunitTransform> for TimeunitTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum TimeunitTransformAs {
-    Variant0([TimeunitTransformAsVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([TimeunitTransformAsArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for TimeunitTransformAs {
     fn from(value: &TimeunitTransformAs) -> Self {
@@ -105884,23 +105832,23 @@ impl ::std::convert::From<&Self> for TimeunitTransformAs {
 }
 impl ::std::default::Default for TimeunitTransformAs {
     fn default() -> Self {
-        TimeunitTransformAs::Variant0([
-            TimeunitTransformAsVariant0Item::Variant0("unit0".to_string()),
-            TimeunitTransformAsVariant0Item::Variant0("unit1".to_string()),
+        TimeunitTransformAs::Array([
+            TimeunitTransformAsArrayItem::String("unit0".to_string()),
+            TimeunitTransformAsArrayItem::String("unit1".to_string()),
         ])
     }
 }
-impl ::std::convert::From<[TimeunitTransformAsVariant0Item; 2usize]> for TimeunitTransformAs {
-    fn from(value: [TimeunitTransformAsVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[TimeunitTransformAsArrayItem; 2usize]> for TimeunitTransformAs {
+    fn from(value: [TimeunitTransformAsArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for TimeunitTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`TimeunitTransformAsVariant0Item`"]
+#[doc = "`TimeunitTransformAsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -105919,18 +105867,18 @@ impl ::std::convert::From<SignalRef> for TimeunitTransformAs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TimeunitTransformAsVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum TimeunitTransformAsArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for TimeunitTransformAsVariant0Item {
-    fn from(value: &TimeunitTransformAsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for TimeunitTransformAsArrayItem {
+    fn from(value: &TimeunitTransformAsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for TimeunitTransformAsVariant0Item {
+impl ::std::convert::From<SignalRef> for TimeunitTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`TimeunitTransformExtent`"]
@@ -105963,27 +105911,27 @@ impl ::std::convert::From<SignalRef> for TimeunitTransformAsVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum TimeunitTransformExtent {
-    Variant0(::std::vec::Vec<TimeunitTransformExtentVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<TimeunitTransformExtentArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for TimeunitTransformExtent {
     fn from(value: &TimeunitTransformExtent) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<TimeunitTransformExtentVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<TimeunitTransformExtentArrayItem>>
     for TimeunitTransformExtent
 {
-    fn from(value: ::std::vec::Vec<TimeunitTransformExtentVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<TimeunitTransformExtentArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for TimeunitTransformExtent {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`TimeunitTransformExtentVariant0Item`"]
+#[doc = "`TimeunitTransformExtentArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -106002,23 +105950,23 @@ impl ::std::convert::From<SignalRef> for TimeunitTransformExtent {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TimeunitTransformExtentVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum TimeunitTransformExtentArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for TimeunitTransformExtentVariant0Item {
-    fn from(value: &TimeunitTransformExtentVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for TimeunitTransformExtentArrayItem {
+    fn from(value: &TimeunitTransformExtentArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for TimeunitTransformExtentVariant0Item {
+impl ::std::convert::From<f64> for TimeunitTransformExtentArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for TimeunitTransformExtentVariant0Item {
+impl ::std::convert::From<SignalRef> for TimeunitTransformExtentArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`TimeunitTransformField`"]
@@ -106089,8 +106037,8 @@ impl ::std::convert::From<Expr> for TimeunitTransformField {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum TimeunitTransformInterval {
-    Variant0(bool),
-    Variant1(SignalRef),
+    Boolean(bool),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for TimeunitTransformInterval {
     fn from(value: &TimeunitTransformInterval) -> Self {
@@ -106099,17 +106047,17 @@ impl ::std::convert::From<&Self> for TimeunitTransformInterval {
 }
 impl ::std::default::Default for TimeunitTransformInterval {
     fn default() -> Self {
-        TimeunitTransformInterval::Variant0(true)
+        TimeunitTransformInterval::Boolean(true)
     }
 }
 impl ::std::convert::From<bool> for TimeunitTransformInterval {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<SignalRef> for TimeunitTransformInterval {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`TimeunitTransformMaxbins`"]
@@ -106133,8 +106081,8 @@ impl ::std::convert::From<SignalRef> for TimeunitTransformInterval {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum TimeunitTransformMaxbins {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for TimeunitTransformMaxbins {
     fn from(value: &TimeunitTransformMaxbins) -> Self {
@@ -106143,17 +106091,17 @@ impl ::std::convert::From<&Self> for TimeunitTransformMaxbins {
 }
 impl ::std::default::Default for TimeunitTransformMaxbins {
     fn default() -> Self {
-        TimeunitTransformMaxbins::Variant0(40_f64)
+        TimeunitTransformMaxbins::Number(40_f64)
     }
 }
 impl ::std::convert::From<f64> for TimeunitTransformMaxbins {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for TimeunitTransformMaxbins {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`TimeunitTransformStep`"]
@@ -106177,8 +106125,8 @@ impl ::std::convert::From<SignalRef> for TimeunitTransformMaxbins {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum TimeunitTransformStep {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for TimeunitTransformStep {
     fn from(value: &TimeunitTransformStep) -> Self {
@@ -106187,17 +106135,17 @@ impl ::std::convert::From<&Self> for TimeunitTransformStep {
 }
 impl ::std::default::Default for TimeunitTransformStep {
     fn default() -> Self {
-        TimeunitTransformStep::Variant0(1_f64)
+        TimeunitTransformStep::Number(1_f64)
     }
 }
 impl ::std::convert::From<f64> for TimeunitTransformStep {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for TimeunitTransformStep {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`TimeunitTransformTimezone`"]
@@ -106436,27 +106384,27 @@ impl ::std::convert::TryFrom<::std::string::String> for TimeunitTransformType {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum TimeunitTransformUnits {
-    Variant0(::std::vec::Vec<TimeunitTransformUnitsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<TimeunitTransformUnitsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for TimeunitTransformUnits {
     fn from(value: &TimeunitTransformUnits) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<TimeunitTransformUnitsVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<TimeunitTransformUnitsArrayItem>>
     for TimeunitTransformUnits
 {
-    fn from(value: ::std::vec::Vec<TimeunitTransformUnitsVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<TimeunitTransformUnitsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for TimeunitTransformUnits {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`TimeunitTransformUnitsVariant0Item`"]
+#[doc = "`TimeunitTransformUnitsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -106487,28 +106435,28 @@ impl ::std::convert::From<SignalRef> for TimeunitTransformUnits {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TimeunitTransformUnitsVariant0Item {
-    Variant0(TimeunitTransformUnitsVariant0ItemVariant0),
+pub enum TimeunitTransformUnitsArrayItem {
+    Variant0(TimeunitTransformUnitsArrayItemVariant0),
     Variant1(SignalRef),
 }
-impl ::std::convert::From<&Self> for TimeunitTransformUnitsVariant0Item {
-    fn from(value: &TimeunitTransformUnitsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for TimeunitTransformUnitsArrayItem {
+    fn from(value: &TimeunitTransformUnitsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<TimeunitTransformUnitsVariant0ItemVariant0>
-    for TimeunitTransformUnitsVariant0Item
+impl ::std::convert::From<TimeunitTransformUnitsArrayItemVariant0>
+    for TimeunitTransformUnitsArrayItem
 {
-    fn from(value: TimeunitTransformUnitsVariant0ItemVariant0) -> Self {
+    fn from(value: TimeunitTransformUnitsArrayItemVariant0) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<SignalRef> for TimeunitTransformUnitsVariant0Item {
+impl ::std::convert::From<SignalRef> for TimeunitTransformUnitsArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`TimeunitTransformUnitsVariant0ItemVariant0`"]
+#[doc = "`TimeunitTransformUnitsArrayItemVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -106542,7 +106490,7 @@ impl ::std::convert::From<SignalRef> for TimeunitTransformUnitsVariant0Item {
     PartialEq,
     PartialOrd,
 )]
-pub enum TimeunitTransformUnitsVariant0ItemVariant0 {
+pub enum TimeunitTransformUnitsArrayItemVariant0 {
     #[serde(rename = "year")]
     Year,
     #[serde(rename = "quarter")]
@@ -106566,12 +106514,12 @@ pub enum TimeunitTransformUnitsVariant0ItemVariant0 {
     #[serde(rename = "milliseconds")]
     Milliseconds,
 }
-impl ::std::convert::From<&Self> for TimeunitTransformUnitsVariant0ItemVariant0 {
-    fn from(value: &TimeunitTransformUnitsVariant0ItemVariant0) -> Self {
+impl ::std::convert::From<&Self> for TimeunitTransformUnitsArrayItemVariant0 {
+    fn from(value: &TimeunitTransformUnitsArrayItemVariant0) -> Self {
         value.clone()
     }
 }
-impl ::std::fmt::Display for TimeunitTransformUnitsVariant0ItemVariant0 {
+impl ::std::fmt::Display for TimeunitTransformUnitsArrayItemVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
             Self::Year => f.write_str("year"),
@@ -106588,7 +106536,7 @@ impl ::std::fmt::Display for TimeunitTransformUnitsVariant0ItemVariant0 {
         }
     }
 }
-impl ::std::str::FromStr for TimeunitTransformUnitsVariant0ItemVariant0 {
+impl ::std::str::FromStr for TimeunitTransformUnitsArrayItemVariant0 {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         match value {
@@ -106607,15 +106555,13 @@ impl ::std::str::FromStr for TimeunitTransformUnitsVariant0ItemVariant0 {
         }
     }
 }
-impl ::std::convert::TryFrom<&str> for TimeunitTransformUnitsVariant0ItemVariant0 {
+impl ::std::convert::TryFrom<&str> for TimeunitTransformUnitsArrayItemVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for TimeunitTransformUnitsVariant0ItemVariant0
-{
+impl ::std::convert::TryFrom<&::std::string::String> for TimeunitTransformUnitsArrayItemVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: &::std::string::String,
@@ -106623,7 +106569,7 @@ impl ::std::convert::TryFrom<&::std::string::String>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<::std::string::String> for TimeunitTransformUnitsVariant0ItemVariant0 {
+impl ::std::convert::TryFrom<::std::string::String> for TimeunitTransformUnitsArrayItemVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: ::std::string::String,
@@ -107006,64 +106952,64 @@ impl ::std::convert::TryFrom<::std::string::String> for TimeunitTransformUnitsVa
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Title {
-    Variant0(::std::string::String),
-    Variant1 {
+    String(::std::string::String),
+    Object {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        align: ::std::option::Option<TitleVariant1Align>,
+        align: ::std::option::Option<TitleObjectAlign>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        anchor: ::std::option::Option<TitleVariant1Anchor>,
+        anchor: ::std::option::Option<TitleObjectAnchor>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        angle: ::std::option::Option<TitleVariant1Angle>,
+        angle: ::std::option::Option<TitleObjectAngle>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         aria: ::std::option::Option<bool>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        baseline: ::std::option::Option<TitleVariant1Baseline>,
+        baseline: ::std::option::Option<TitleObjectBaseline>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        color: ::std::option::Option<TitleVariant1Color>,
+        color: ::std::option::Option<TitleObjectColor>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        dx: ::std::option::Option<TitleVariant1Dx>,
+        dx: ::std::option::Option<TitleObjectDx>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        dy: ::std::option::Option<TitleVariant1Dy>,
+        dy: ::std::option::Option<TitleObjectDy>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        encode: ::std::option::Option<TitleVariant1Encode>,
+        encode: ::std::option::Option<TitleObjectEncode>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        font: ::std::option::Option<TitleVariant1Font>,
+        font: ::std::option::Option<TitleObjectFont>,
         #[serde(
             rename = "fontSize",
             default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
-        font_size: ::std::option::Option<TitleVariant1FontSize>,
+        font_size: ::std::option::Option<TitleObjectFontSize>,
         #[serde(
             rename = "fontStyle",
             default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
-        font_style: ::std::option::Option<TitleVariant1FontStyle>,
+        font_style: ::std::option::Option<TitleObjectFontStyle>,
         #[serde(
             rename = "fontWeight",
             default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
-        font_weight: ::std::option::Option<TitleVariant1FontWeight>,
+        font_weight: ::std::option::Option<TitleObjectFontWeight>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        frame: ::std::option::Option<TitleVariant1Frame>,
+        frame: ::std::option::Option<TitleObjectFrame>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         interactive: ::std::option::Option<bool>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        limit: ::std::option::Option<TitleVariant1Limit>,
+        limit: ::std::option::Option<TitleObjectLimit>,
         #[serde(
             rename = "lineHeight",
             default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
-        line_height: ::std::option::Option<TitleVariant1LineHeight>,
+        line_height: ::std::option::Option<TitleObjectLineHeight>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         name: ::std::option::Option<::std::string::String>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        offset: ::std::option::Option<TitleVariant1Offset>,
+        offset: ::std::option::Option<TitleObjectOffset>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        orient: ::std::option::Option<TitleVariant1Orient>,
+        orient: ::std::option::Option<TitleObjectOrient>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         style: ::std::option::Option<Style>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -107073,37 +107019,37 @@ pub enum Title {
             default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
-        subtitle_color: ::std::option::Option<TitleVariant1SubtitleColor>,
+        subtitle_color: ::std::option::Option<TitleObjectSubtitleColor>,
         #[serde(
             rename = "subtitleFont",
             default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
-        subtitle_font: ::std::option::Option<TitleVariant1SubtitleFont>,
+        subtitle_font: ::std::option::Option<TitleObjectSubtitleFont>,
         #[serde(
             rename = "subtitleFontSize",
             default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
-        subtitle_font_size: ::std::option::Option<TitleVariant1SubtitleFontSize>,
+        subtitle_font_size: ::std::option::Option<TitleObjectSubtitleFontSize>,
         #[serde(
             rename = "subtitleFontStyle",
             default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
-        subtitle_font_style: ::std::option::Option<TitleVariant1SubtitleFontStyle>,
+        subtitle_font_style: ::std::option::Option<TitleObjectSubtitleFontStyle>,
         #[serde(
             rename = "subtitleFontWeight",
             default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
-        subtitle_font_weight: ::std::option::Option<TitleVariant1SubtitleFontWeight>,
+        subtitle_font_weight: ::std::option::Option<TitleObjectSubtitleFontWeight>,
         #[serde(
             rename = "subtitleLineHeight",
             default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
-        subtitle_line_height: ::std::option::Option<TitleVariant1SubtitleLineHeight>,
+        subtitle_line_height: ::std::option::Option<TitleObjectSubtitleLineHeight>,
         #[serde(
             rename = "subtitlePadding",
             default,
@@ -107121,7 +107067,7 @@ impl ::std::convert::From<&Self> for Title {
         value.clone()
     }
 }
-#[doc = "`TitleVariant1Align`"]
+#[doc = "`TitleObjectAlign`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107144,26 +107090,26 @@ impl ::std::convert::From<&Self> for Title {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TitleVariant1Align {
-    Variant0(TitleVariant1AlignVariant0),
+pub enum TitleObjectAlign {
+    Variant0(TitleObjectAlignVariant0),
     Variant1(AlignValue),
 }
-impl ::std::convert::From<&Self> for TitleVariant1Align {
-    fn from(value: &TitleVariant1Align) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectAlign {
+    fn from(value: &TitleObjectAlign) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<TitleVariant1AlignVariant0> for TitleVariant1Align {
-    fn from(value: TitleVariant1AlignVariant0) -> Self {
+impl ::std::convert::From<TitleObjectAlignVariant0> for TitleObjectAlign {
+    fn from(value: TitleObjectAlignVariant0) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<AlignValue> for TitleVariant1Align {
+impl ::std::convert::From<AlignValue> for TitleObjectAlign {
     fn from(value: AlignValue) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`TitleVariant1AlignVariant0`"]
+#[doc = "`TitleObjectAlignVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107189,7 +107135,7 @@ impl ::std::convert::From<AlignValue> for TitleVariant1Align {
     PartialEq,
     PartialOrd,
 )]
-pub enum TitleVariant1AlignVariant0 {
+pub enum TitleObjectAlignVariant0 {
     #[serde(rename = "left")]
     Left,
     #[serde(rename = "right")]
@@ -107197,12 +107143,12 @@ pub enum TitleVariant1AlignVariant0 {
     #[serde(rename = "center")]
     Center,
 }
-impl ::std::convert::From<&Self> for TitleVariant1AlignVariant0 {
-    fn from(value: &TitleVariant1AlignVariant0) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectAlignVariant0 {
+    fn from(value: &TitleObjectAlignVariant0) -> Self {
         value.clone()
     }
 }
-impl ::std::fmt::Display for TitleVariant1AlignVariant0 {
+impl ::std::fmt::Display for TitleObjectAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
             Self::Left => f.write_str("left"),
@@ -107211,7 +107157,7 @@ impl ::std::fmt::Display for TitleVariant1AlignVariant0 {
         }
     }
 }
-impl ::std::str::FromStr for TitleVariant1AlignVariant0 {
+impl ::std::str::FromStr for TitleObjectAlignVariant0 {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         match value {
@@ -107222,13 +107168,13 @@ impl ::std::str::FromStr for TitleVariant1AlignVariant0 {
         }
     }
 }
-impl ::std::convert::TryFrom<&str> for TitleVariant1AlignVariant0 {
+impl ::std::convert::TryFrom<&str> for TitleObjectAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for TitleVariant1AlignVariant0 {
+impl ::std::convert::TryFrom<&::std::string::String> for TitleObjectAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: &::std::string::String,
@@ -107236,7 +107182,7 @@ impl ::std::convert::TryFrom<&::std::string::String> for TitleVariant1AlignVaria
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<::std::string::String> for TitleVariant1AlignVariant0 {
+impl ::std::convert::TryFrom<::std::string::String> for TitleObjectAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: ::std::string::String,
@@ -107244,7 +107190,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TitleVariant1AlignVarian
         value.parse()
     }
 }
-#[doc = "`TitleVariant1Anchor`"]
+#[doc = "`TitleObjectAnchor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107268,28 +107214,26 @@ impl ::std::convert::TryFrom<::std::string::String> for TitleVariant1AlignVarian
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TitleVariant1Anchor {
-    Variant0(::std::option::Option<TitleVariant1AnchorVariant0>),
+pub enum TitleObjectAnchor {
+    Variant0(::std::option::Option<TitleObjectAnchorVariant0>),
     Variant1(AnchorValue),
 }
-impl ::std::convert::From<&Self> for TitleVariant1Anchor {
-    fn from(value: &TitleVariant1Anchor) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectAnchor {
+    fn from(value: &TitleObjectAnchor) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::option::Option<TitleVariant1AnchorVariant0>>
-    for TitleVariant1Anchor
-{
-    fn from(value: ::std::option::Option<TitleVariant1AnchorVariant0>) -> Self {
+impl ::std::convert::From<::std::option::Option<TitleObjectAnchorVariant0>> for TitleObjectAnchor {
+    fn from(value: ::std::option::Option<TitleObjectAnchorVariant0>) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<AnchorValue> for TitleVariant1Anchor {
+impl ::std::convert::From<AnchorValue> for TitleObjectAnchor {
     fn from(value: AnchorValue) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`TitleVariant1AnchorVariant0`"]
+#[doc = "`TitleObjectAnchorVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107316,7 +107260,7 @@ impl ::std::convert::From<AnchorValue> for TitleVariant1Anchor {
     PartialEq,
     PartialOrd,
 )]
-pub enum TitleVariant1AnchorVariant0 {
+pub enum TitleObjectAnchorVariant0 {
     #[serde(rename = "start")]
     Start,
     #[serde(rename = "middle")]
@@ -107324,12 +107268,12 @@ pub enum TitleVariant1AnchorVariant0 {
     #[serde(rename = "end")]
     End,
 }
-impl ::std::convert::From<&Self> for TitleVariant1AnchorVariant0 {
-    fn from(value: &TitleVariant1AnchorVariant0) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectAnchorVariant0 {
+    fn from(value: &TitleObjectAnchorVariant0) -> Self {
         value.clone()
     }
 }
-impl ::std::fmt::Display for TitleVariant1AnchorVariant0 {
+impl ::std::fmt::Display for TitleObjectAnchorVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
             Self::Start => f.write_str("start"),
@@ -107338,7 +107282,7 @@ impl ::std::fmt::Display for TitleVariant1AnchorVariant0 {
         }
     }
 }
-impl ::std::str::FromStr for TitleVariant1AnchorVariant0 {
+impl ::std::str::FromStr for TitleObjectAnchorVariant0 {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         match value {
@@ -107349,13 +107293,13 @@ impl ::std::str::FromStr for TitleVariant1AnchorVariant0 {
         }
     }
 }
-impl ::std::convert::TryFrom<&str> for TitleVariant1AnchorVariant0 {
+impl ::std::convert::TryFrom<&str> for TitleObjectAnchorVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for TitleVariant1AnchorVariant0 {
+impl ::std::convert::TryFrom<&::std::string::String> for TitleObjectAnchorVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: &::std::string::String,
@@ -107363,7 +107307,7 @@ impl ::std::convert::TryFrom<&::std::string::String> for TitleVariant1AnchorVari
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<::std::string::String> for TitleVariant1AnchorVariant0 {
+impl ::std::convert::TryFrom<::std::string::String> for TitleObjectAnchorVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: ::std::string::String,
@@ -107371,7 +107315,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TitleVariant1AnchorVaria
         value.parse()
     }
 }
-#[doc = "`TitleVariant1Angle`"]
+#[doc = "`TitleObjectAngle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107390,26 +107334,26 @@ impl ::std::convert::TryFrom<::std::string::String> for TitleVariant1AnchorVaria
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TitleVariant1Angle {
+pub enum TitleObjectAngle {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for TitleVariant1Angle {
-    fn from(value: &TitleVariant1Angle) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectAngle {
+    fn from(value: &TitleObjectAngle) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for TitleVariant1Angle {
+impl ::std::convert::From<f64> for TitleObjectAngle {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<NumberValue> for TitleVariant1Angle {
+impl ::std::convert::From<NumberValue> for TitleObjectAngle {
     fn from(value: NumberValue) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`TitleVariant1Baseline`"]
+#[doc = "`TitleObjectBaseline`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107435,26 +107379,26 @@ impl ::std::convert::From<NumberValue> for TitleVariant1Angle {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TitleVariant1Baseline {
-    Variant0(TitleVariant1BaselineVariant0),
+pub enum TitleObjectBaseline {
+    Variant0(TitleObjectBaselineVariant0),
     Variant1(BaselineValue),
 }
-impl ::std::convert::From<&Self> for TitleVariant1Baseline {
-    fn from(value: &TitleVariant1Baseline) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectBaseline {
+    fn from(value: &TitleObjectBaseline) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<TitleVariant1BaselineVariant0> for TitleVariant1Baseline {
-    fn from(value: TitleVariant1BaselineVariant0) -> Self {
+impl ::std::convert::From<TitleObjectBaselineVariant0> for TitleObjectBaseline {
+    fn from(value: TitleObjectBaselineVariant0) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<BaselineValue> for TitleVariant1Baseline {
+impl ::std::convert::From<BaselineValue> for TitleObjectBaseline {
     fn from(value: BaselineValue) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`TitleVariant1BaselineVariant0`"]
+#[doc = "`TitleObjectBaselineVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107483,7 +107427,7 @@ impl ::std::convert::From<BaselineValue> for TitleVariant1Baseline {
     PartialEq,
     PartialOrd,
 )]
-pub enum TitleVariant1BaselineVariant0 {
+pub enum TitleObjectBaselineVariant0 {
     #[serde(rename = "top")]
     Top,
     #[serde(rename = "middle")]
@@ -107497,12 +107441,12 @@ pub enum TitleVariant1BaselineVariant0 {
     #[serde(rename = "line-bottom")]
     LineBottom,
 }
-impl ::std::convert::From<&Self> for TitleVariant1BaselineVariant0 {
-    fn from(value: &TitleVariant1BaselineVariant0) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectBaselineVariant0 {
+    fn from(value: &TitleObjectBaselineVariant0) -> Self {
         value.clone()
     }
 }
-impl ::std::fmt::Display for TitleVariant1BaselineVariant0 {
+impl ::std::fmt::Display for TitleObjectBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
             Self::Top => f.write_str("top"),
@@ -107514,7 +107458,7 @@ impl ::std::fmt::Display for TitleVariant1BaselineVariant0 {
         }
     }
 }
-impl ::std::str::FromStr for TitleVariant1BaselineVariant0 {
+impl ::std::str::FromStr for TitleObjectBaselineVariant0 {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         match value {
@@ -107528,13 +107472,13 @@ impl ::std::str::FromStr for TitleVariant1BaselineVariant0 {
         }
     }
 }
-impl ::std::convert::TryFrom<&str> for TitleVariant1BaselineVariant0 {
+impl ::std::convert::TryFrom<&str> for TitleObjectBaselineVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for TitleVariant1BaselineVariant0 {
+impl ::std::convert::TryFrom<&::std::string::String> for TitleObjectBaselineVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: &::std::string::String,
@@ -107542,7 +107486,7 @@ impl ::std::convert::TryFrom<&::std::string::String> for TitleVariant1BaselineVa
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<::std::string::String> for TitleVariant1BaselineVariant0 {
+impl ::std::convert::TryFrom<::std::string::String> for TitleObjectBaselineVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: ::std::string::String,
@@ -107550,7 +107494,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TitleVariant1BaselineVar
         value.parse()
     }
 }
-#[doc = "`TitleVariant1Color`"]
+#[doc = "`TitleObjectColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107572,22 +107516,22 @@ impl ::std::convert::TryFrom<::std::string::String> for TitleVariant1BaselineVar
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TitleVariant1Color {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+pub enum TitleObjectColor {
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for TitleVariant1Color {
-    fn from(value: &TitleVariant1Color) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectColor {
+    fn from(value: &TitleObjectColor) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<ColorValue> for TitleVariant1Color {
+impl ::std::convert::From<ColorValue> for TitleObjectColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
-#[doc = "`TitleVariant1Dx`"]
+#[doc = "`TitleObjectDx`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107606,26 +107550,26 @@ impl ::std::convert::From<ColorValue> for TitleVariant1Color {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TitleVariant1Dx {
+pub enum TitleObjectDx {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for TitleVariant1Dx {
-    fn from(value: &TitleVariant1Dx) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectDx {
+    fn from(value: &TitleObjectDx) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for TitleVariant1Dx {
+impl ::std::convert::From<f64> for TitleObjectDx {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<NumberValue> for TitleVariant1Dx {
+impl ::std::convert::From<NumberValue> for TitleObjectDx {
     fn from(value: NumberValue) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`TitleVariant1Dy`"]
+#[doc = "`TitleObjectDy`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107644,26 +107588,26 @@ impl ::std::convert::From<NumberValue> for TitleVariant1Dx {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TitleVariant1Dy {
+pub enum TitleObjectDy {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for TitleVariant1Dy {
-    fn from(value: &TitleVariant1Dy) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectDy {
+    fn from(value: &TitleObjectDy) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for TitleVariant1Dy {
+impl ::std::convert::From<f64> for TitleObjectDy {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<NumberValue> for TitleVariant1Dy {
+impl ::std::convert::From<NumberValue> for TitleObjectDy {
     fn from(value: NumberValue) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`TitleVariant1Encode`"]
+#[doc = "`TitleObjectEncode`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107699,28 +107643,28 @@ impl ::std::convert::From<NumberValue> for TitleVariant1Dy {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct TitleVariant1Encode {
+pub struct TitleObjectEncode {
     #[serde(
         flatten,
         default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub subtype_0: ::std::option::Option<
-        ::std::collections::HashMap<TitleVariant1EncodeSubtype0Key, EncodeEntry>,
+        ::std::collections::HashMap<TitleObjectEncodeSubtype0Key, EncodeEntry>,
     >,
     #[serde(
         flatten,
         default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
-    pub subtype_1: ::std::option::Option<TitleVariant1EncodeSubtype1>,
+    pub subtype_1: ::std::option::Option<TitleObjectEncodeSubtype1>,
 }
-impl ::std::convert::From<&TitleVariant1Encode> for TitleVariant1Encode {
-    fn from(value: &TitleVariant1Encode) -> Self {
+impl ::std::convert::From<&TitleObjectEncode> for TitleObjectEncode {
+    fn from(value: &TitleObjectEncode) -> Self {
         value.clone()
     }
 }
-impl ::std::default::Default for TitleVariant1Encode {
+impl ::std::default::Default for TitleObjectEncode {
     fn default() -> Self {
         Self {
             subtype_0: Default::default(),
@@ -107728,7 +107672,7 @@ impl ::std::default::Default for TitleVariant1Encode {
         }
     }
 }
-#[doc = "`TitleVariant1EncodeSubtype0Key`"]
+#[doc = "`TitleObjectEncodeSubtype0Key`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107741,24 +107685,24 @@ impl ::std::default::Default for TitleVariant1Encode {
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[serde(transparent)]
-pub struct TitleVariant1EncodeSubtype0Key(::std::string::String);
-impl ::std::ops::Deref for TitleVariant1EncodeSubtype0Key {
+pub struct TitleObjectEncodeSubtype0Key(::std::string::String);
+impl ::std::ops::Deref for TitleObjectEncodeSubtype0Key {
     type Target = ::std::string::String;
     fn deref(&self) -> &::std::string::String {
         &self.0
     }
 }
-impl ::std::convert::From<TitleVariant1EncodeSubtype0Key> for ::std::string::String {
-    fn from(value: TitleVariant1EncodeSubtype0Key) -> Self {
+impl ::std::convert::From<TitleObjectEncodeSubtype0Key> for ::std::string::String {
+    fn from(value: TitleObjectEncodeSubtype0Key) -> Self {
         value.0
     }
 }
-impl ::std::convert::From<&TitleVariant1EncodeSubtype0Key> for TitleVariant1EncodeSubtype0Key {
-    fn from(value: &TitleVariant1EncodeSubtype0Key) -> Self {
+impl ::std::convert::From<&TitleObjectEncodeSubtype0Key> for TitleObjectEncodeSubtype0Key {
+    fn from(value: &TitleObjectEncodeSubtype0Key) -> Self {
         value.clone()
     }
 }
-impl ::std::str::FromStr for TitleVariant1EncodeSubtype0Key {
+impl ::std::str::FromStr for TitleObjectEncodeSubtype0Key {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         static PATTERN: ::std::sync::LazyLock<::regress::Regex> =
@@ -107771,13 +107715,13 @@ impl ::std::str::FromStr for TitleVariant1EncodeSubtype0Key {
         Ok(Self(value.to_string()))
     }
 }
-impl ::std::convert::TryFrom<&str> for TitleVariant1EncodeSubtype0Key {
+impl ::std::convert::TryFrom<&str> for TitleObjectEncodeSubtype0Key {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for TitleVariant1EncodeSubtype0Key {
+impl ::std::convert::TryFrom<&::std::string::String> for TitleObjectEncodeSubtype0Key {
     type Error = self::error::ConversionError;
     fn try_from(
         value: &::std::string::String,
@@ -107785,7 +107729,7 @@ impl ::std::convert::TryFrom<&::std::string::String> for TitleVariant1EncodeSubt
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<::std::string::String> for TitleVariant1EncodeSubtype0Key {
+impl ::std::convert::TryFrom<::std::string::String> for TitleObjectEncodeSubtype0Key {
     type Error = self::error::ConversionError;
     fn try_from(
         value: ::std::string::String,
@@ -107793,7 +107737,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TitleVariant1EncodeSubty
         value.parse()
     }
 }
-impl<'de> ::serde::Deserialize<'de> for TitleVariant1EncodeSubtype0Key {
+impl<'de> ::serde::Deserialize<'de> for TitleObjectEncodeSubtype0Key {
     fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
     where
         D: ::serde::Deserializer<'de>,
@@ -107805,7 +107749,7 @@ impl<'de> ::serde::Deserialize<'de> for TitleVariant1EncodeSubtype0Key {
             })
     }
 }
-#[doc = "`TitleVariant1EncodeSubtype1`"]
+#[doc = "`TitleObjectEncodeSubtype1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107829,7 +107773,7 @@ impl<'de> ::serde::Deserialize<'de> for TitleVariant1EncodeSubtype0Key {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
-pub struct TitleVariant1EncodeSubtype1 {
+pub struct TitleObjectEncodeSubtype1 {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub group: ::std::option::Option<GuideEncode>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -107837,12 +107781,12 @@ pub struct TitleVariant1EncodeSubtype1 {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
 }
-impl ::std::convert::From<&TitleVariant1EncodeSubtype1> for TitleVariant1EncodeSubtype1 {
-    fn from(value: &TitleVariant1EncodeSubtype1) -> Self {
+impl ::std::convert::From<&TitleObjectEncodeSubtype1> for TitleObjectEncodeSubtype1 {
+    fn from(value: &TitleObjectEncodeSubtype1) -> Self {
         value.clone()
     }
 }
-impl ::std::default::Default for TitleVariant1EncodeSubtype1 {
+impl ::std::default::Default for TitleObjectEncodeSubtype1 {
     fn default() -> Self {
         Self {
             group: Default::default(),
@@ -107851,7 +107795,7 @@ impl ::std::default::Default for TitleVariant1EncodeSubtype1 {
         }
     }
 }
-#[doc = "`TitleVariant1Font`"]
+#[doc = "`TitleObjectFont`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107870,21 +107814,21 @@ impl ::std::default::Default for TitleVariant1EncodeSubtype1 {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TitleVariant1Font {
+pub enum TitleObjectFont {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for TitleVariant1Font {
-    fn from(value: &TitleVariant1Font) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectFont {
+    fn from(value: &TitleObjectFont) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<StringValue> for TitleVariant1Font {
+impl ::std::convert::From<StringValue> for TitleObjectFont {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`TitleVariant1FontSize`"]
+#[doc = "`TitleObjectFontSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107903,26 +107847,26 @@ impl ::std::convert::From<StringValue> for TitleVariant1Font {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TitleVariant1FontSize {
+pub enum TitleObjectFontSize {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for TitleVariant1FontSize {
-    fn from(value: &TitleVariant1FontSize) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectFontSize {
+    fn from(value: &TitleObjectFontSize) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for TitleVariant1FontSize {
+impl ::std::convert::From<f64> for TitleObjectFontSize {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<NumberValue> for TitleVariant1FontSize {
+impl ::std::convert::From<NumberValue> for TitleObjectFontSize {
     fn from(value: NumberValue) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`TitleVariant1FontStyle`"]
+#[doc = "`TitleObjectFontStyle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107941,21 +107885,21 @@ impl ::std::convert::From<NumberValue> for TitleVariant1FontSize {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TitleVariant1FontStyle {
+pub enum TitleObjectFontStyle {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for TitleVariant1FontStyle {
-    fn from(value: &TitleVariant1FontStyle) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectFontStyle {
+    fn from(value: &TitleObjectFontStyle) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<StringValue> for TitleVariant1FontStyle {
+impl ::std::convert::From<StringValue> for TitleObjectFontStyle {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`TitleVariant1FontWeight`"]
+#[doc = "`TitleObjectFontWeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -107998,26 +107942,26 @@ impl ::std::convert::From<StringValue> for TitleVariant1FontStyle {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TitleVariant1FontWeight {
+pub enum TitleObjectFontWeight {
     Variant0(MyEnum),
     Variant1(FontWeightValue),
 }
-impl ::std::convert::From<&Self> for TitleVariant1FontWeight {
-    fn from(value: &TitleVariant1FontWeight) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectFontWeight {
+    fn from(value: &TitleObjectFontWeight) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<MyEnum> for TitleVariant1FontWeight {
+impl ::std::convert::From<MyEnum> for TitleObjectFontWeight {
     fn from(value: MyEnum) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<FontWeightValue> for TitleVariant1FontWeight {
+impl ::std::convert::From<FontWeightValue> for TitleObjectFontWeight {
     fn from(value: FontWeightValue) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`TitleVariant1Frame`"]
+#[doc = "`TitleObjectFrame`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108039,26 +107983,26 @@ impl ::std::convert::From<FontWeightValue> for TitleVariant1FontWeight {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TitleVariant1Frame {
-    Variant0(TitleVariant1FrameVariant0),
+pub enum TitleObjectFrame {
+    Variant0(TitleObjectFrameVariant0),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for TitleVariant1Frame {
-    fn from(value: &TitleVariant1Frame) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectFrame {
+    fn from(value: &TitleObjectFrame) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<TitleVariant1FrameVariant0> for TitleVariant1Frame {
-    fn from(value: TitleVariant1FrameVariant0) -> Self {
+impl ::std::convert::From<TitleObjectFrameVariant0> for TitleObjectFrame {
+    fn from(value: TitleObjectFrameVariant0) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<StringValue> for TitleVariant1Frame {
+impl ::std::convert::From<StringValue> for TitleObjectFrame {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`TitleVariant1FrameVariant0`"]
+#[doc = "`TitleObjectFrameVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108083,18 +108027,18 @@ impl ::std::convert::From<StringValue> for TitleVariant1Frame {
     PartialEq,
     PartialOrd,
 )]
-pub enum TitleVariant1FrameVariant0 {
+pub enum TitleObjectFrameVariant0 {
     #[serde(rename = "group")]
     Group,
     #[serde(rename = "bounds")]
     Bounds,
 }
-impl ::std::convert::From<&Self> for TitleVariant1FrameVariant0 {
-    fn from(value: &TitleVariant1FrameVariant0) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectFrameVariant0 {
+    fn from(value: &TitleObjectFrameVariant0) -> Self {
         value.clone()
     }
 }
-impl ::std::fmt::Display for TitleVariant1FrameVariant0 {
+impl ::std::fmt::Display for TitleObjectFrameVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
             Self::Group => f.write_str("group"),
@@ -108102,7 +108046,7 @@ impl ::std::fmt::Display for TitleVariant1FrameVariant0 {
         }
     }
 }
-impl ::std::str::FromStr for TitleVariant1FrameVariant0 {
+impl ::std::str::FromStr for TitleObjectFrameVariant0 {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         match value {
@@ -108112,13 +108056,13 @@ impl ::std::str::FromStr for TitleVariant1FrameVariant0 {
         }
     }
 }
-impl ::std::convert::TryFrom<&str> for TitleVariant1FrameVariant0 {
+impl ::std::convert::TryFrom<&str> for TitleObjectFrameVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for TitleVariant1FrameVariant0 {
+impl ::std::convert::TryFrom<&::std::string::String> for TitleObjectFrameVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: &::std::string::String,
@@ -108126,7 +108070,7 @@ impl ::std::convert::TryFrom<&::std::string::String> for TitleVariant1FrameVaria
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<::std::string::String> for TitleVariant1FrameVariant0 {
+impl ::std::convert::TryFrom<::std::string::String> for TitleObjectFrameVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: ::std::string::String,
@@ -108134,7 +108078,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TitleVariant1FrameVarian
         value.parse()
     }
 }
-#[doc = "`TitleVariant1Limit`"]
+#[doc = "`TitleObjectLimit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108153,26 +108097,26 @@ impl ::std::convert::TryFrom<::std::string::String> for TitleVariant1FrameVarian
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TitleVariant1Limit {
+pub enum TitleObjectLimit {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for TitleVariant1Limit {
-    fn from(value: &TitleVariant1Limit) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectLimit {
+    fn from(value: &TitleObjectLimit) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for TitleVariant1Limit {
+impl ::std::convert::From<f64> for TitleObjectLimit {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<NumberValue> for TitleVariant1Limit {
+impl ::std::convert::From<NumberValue> for TitleObjectLimit {
     fn from(value: NumberValue) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`TitleVariant1LineHeight`"]
+#[doc = "`TitleObjectLineHeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108191,26 +108135,26 @@ impl ::std::convert::From<NumberValue> for TitleVariant1Limit {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TitleVariant1LineHeight {
+pub enum TitleObjectLineHeight {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for TitleVariant1LineHeight {
-    fn from(value: &TitleVariant1LineHeight) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectLineHeight {
+    fn from(value: &TitleObjectLineHeight) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for TitleVariant1LineHeight {
+impl ::std::convert::From<f64> for TitleObjectLineHeight {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<NumberValue> for TitleVariant1LineHeight {
+impl ::std::convert::From<NumberValue> for TitleObjectLineHeight {
     fn from(value: NumberValue) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`TitleVariant1Offset`"]
+#[doc = "`TitleObjectOffset`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108229,26 +108173,26 @@ impl ::std::convert::From<NumberValue> for TitleVariant1LineHeight {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TitleVariant1Offset {
+pub enum TitleObjectOffset {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for TitleVariant1Offset {
-    fn from(value: &TitleVariant1Offset) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectOffset {
+    fn from(value: &TitleObjectOffset) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for TitleVariant1Offset {
+impl ::std::convert::From<f64> for TitleObjectOffset {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<NumberValue> for TitleVariant1Offset {
+impl ::std::convert::From<NumberValue> for TitleObjectOffset {
     fn from(value: NumberValue) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`TitleVariant1Orient`"]
+#[doc = "`TitleObjectOrient`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108274,26 +108218,26 @@ impl ::std::convert::From<NumberValue> for TitleVariant1Offset {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TitleVariant1Orient {
-    Variant0(TitleVariant1OrientVariant0),
+pub enum TitleObjectOrient {
+    Variant0(TitleObjectOrientVariant0),
     Variant1(SignalRef),
 }
-impl ::std::convert::From<&Self> for TitleVariant1Orient {
-    fn from(value: &TitleVariant1Orient) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectOrient {
+    fn from(value: &TitleObjectOrient) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<TitleVariant1OrientVariant0> for TitleVariant1Orient {
-    fn from(value: TitleVariant1OrientVariant0) -> Self {
+impl ::std::convert::From<TitleObjectOrientVariant0> for TitleObjectOrient {
+    fn from(value: TitleObjectOrientVariant0) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<SignalRef> for TitleVariant1Orient {
+impl ::std::convert::From<SignalRef> for TitleObjectOrient {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`TitleVariant1OrientVariant0`"]
+#[doc = "`TitleObjectOrientVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108322,7 +108266,7 @@ impl ::std::convert::From<SignalRef> for TitleVariant1Orient {
     PartialEq,
     PartialOrd,
 )]
-pub enum TitleVariant1OrientVariant0 {
+pub enum TitleObjectOrientVariant0 {
     #[serde(rename = "none")]
     None,
     #[serde(rename = "left")]
@@ -108334,12 +108278,12 @@ pub enum TitleVariant1OrientVariant0 {
     #[serde(rename = "bottom")]
     Bottom,
 }
-impl ::std::convert::From<&Self> for TitleVariant1OrientVariant0 {
-    fn from(value: &TitleVariant1OrientVariant0) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectOrientVariant0 {
+    fn from(value: &TitleObjectOrientVariant0) -> Self {
         value.clone()
     }
 }
-impl ::std::fmt::Display for TitleVariant1OrientVariant0 {
+impl ::std::fmt::Display for TitleObjectOrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
             Self::None => f.write_str("none"),
@@ -108350,7 +108294,7 @@ impl ::std::fmt::Display for TitleVariant1OrientVariant0 {
         }
     }
 }
-impl ::std::str::FromStr for TitleVariant1OrientVariant0 {
+impl ::std::str::FromStr for TitleObjectOrientVariant0 {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         match value {
@@ -108363,13 +108307,13 @@ impl ::std::str::FromStr for TitleVariant1OrientVariant0 {
         }
     }
 }
-impl ::std::convert::TryFrom<&str> for TitleVariant1OrientVariant0 {
+impl ::std::convert::TryFrom<&str> for TitleObjectOrientVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for TitleVariant1OrientVariant0 {
+impl ::std::convert::TryFrom<&::std::string::String> for TitleObjectOrientVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: &::std::string::String,
@@ -108377,7 +108321,7 @@ impl ::std::convert::TryFrom<&::std::string::String> for TitleVariant1OrientVari
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<::std::string::String> for TitleVariant1OrientVariant0 {
+impl ::std::convert::TryFrom<::std::string::String> for TitleObjectOrientVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: ::std::string::String,
@@ -108385,7 +108329,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TitleVariant1OrientVaria
         value.parse()
     }
 }
-#[doc = "`TitleVariant1SubtitleColor`"]
+#[doc = "`TitleObjectSubtitleColor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108407,22 +108351,22 @@ impl ::std::convert::TryFrom<::std::string::String> for TitleVariant1OrientVaria
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TitleVariant1SubtitleColor {
-    Variant0,
-    Variant1(::std::string::String),
-    Variant2(ColorValue),
+pub enum TitleObjectSubtitleColor {
+    Null,
+    String(::std::string::String),
+    ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for TitleVariant1SubtitleColor {
-    fn from(value: &TitleVariant1SubtitleColor) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectSubtitleColor {
+    fn from(value: &TitleObjectSubtitleColor) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<ColorValue> for TitleVariant1SubtitleColor {
+impl ::std::convert::From<ColorValue> for TitleObjectSubtitleColor {
     fn from(value: ColorValue) -> Self {
-        Self::Variant2(value)
+        Self::ColorValue(value)
     }
 }
-#[doc = "`TitleVariant1SubtitleFont`"]
+#[doc = "`TitleObjectSubtitleFont`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108441,21 +108385,21 @@ impl ::std::convert::From<ColorValue> for TitleVariant1SubtitleColor {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TitleVariant1SubtitleFont {
+pub enum TitleObjectSubtitleFont {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for TitleVariant1SubtitleFont {
-    fn from(value: &TitleVariant1SubtitleFont) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectSubtitleFont {
+    fn from(value: &TitleObjectSubtitleFont) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<StringValue> for TitleVariant1SubtitleFont {
+impl ::std::convert::From<StringValue> for TitleObjectSubtitleFont {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`TitleVariant1SubtitleFontSize`"]
+#[doc = "`TitleObjectSubtitleFontSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108474,26 +108418,26 @@ impl ::std::convert::From<StringValue> for TitleVariant1SubtitleFont {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TitleVariant1SubtitleFontSize {
+pub enum TitleObjectSubtitleFontSize {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for TitleVariant1SubtitleFontSize {
-    fn from(value: &TitleVariant1SubtitleFontSize) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectSubtitleFontSize {
+    fn from(value: &TitleObjectSubtitleFontSize) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for TitleVariant1SubtitleFontSize {
+impl ::std::convert::From<f64> for TitleObjectSubtitleFontSize {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<NumberValue> for TitleVariant1SubtitleFontSize {
+impl ::std::convert::From<NumberValue> for TitleObjectSubtitleFontSize {
     fn from(value: NumberValue) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`TitleVariant1SubtitleFontStyle`"]
+#[doc = "`TitleObjectSubtitleFontStyle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108512,21 +108456,21 @@ impl ::std::convert::From<NumberValue> for TitleVariant1SubtitleFontSize {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TitleVariant1SubtitleFontStyle {
+pub enum TitleObjectSubtitleFontStyle {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for TitleVariant1SubtitleFontStyle {
-    fn from(value: &TitleVariant1SubtitleFontStyle) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectSubtitleFontStyle {
+    fn from(value: &TitleObjectSubtitleFontStyle) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<StringValue> for TitleVariant1SubtitleFontStyle {
+impl ::std::convert::From<StringValue> for TitleObjectSubtitleFontStyle {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`TitleVariant1SubtitleFontWeight`"]
+#[doc = "`TitleObjectSubtitleFontWeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108569,26 +108513,26 @@ impl ::std::convert::From<StringValue> for TitleVariant1SubtitleFontStyle {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TitleVariant1SubtitleFontWeight {
+pub enum TitleObjectSubtitleFontWeight {
     Variant0(MyEnum),
     Variant1(FontWeightValue),
 }
-impl ::std::convert::From<&Self> for TitleVariant1SubtitleFontWeight {
-    fn from(value: &TitleVariant1SubtitleFontWeight) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectSubtitleFontWeight {
+    fn from(value: &TitleObjectSubtitleFontWeight) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<MyEnum> for TitleVariant1SubtitleFontWeight {
+impl ::std::convert::From<MyEnum> for TitleObjectSubtitleFontWeight {
     fn from(value: MyEnum) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<FontWeightValue> for TitleVariant1SubtitleFontWeight {
+impl ::std::convert::From<FontWeightValue> for TitleObjectSubtitleFontWeight {
     fn from(value: FontWeightValue) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`TitleVariant1SubtitleLineHeight`"]
+#[doc = "`TitleObjectSubtitleLineHeight`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -108607,21 +108551,21 @@ impl ::std::convert::From<FontWeightValue> for TitleVariant1SubtitleFontWeight {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TitleVariant1SubtitleLineHeight {
+pub enum TitleObjectSubtitleLineHeight {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for TitleVariant1SubtitleLineHeight {
-    fn from(value: &TitleVariant1SubtitleLineHeight) -> Self {
+impl ::std::convert::From<&Self> for TitleObjectSubtitleLineHeight {
+    fn from(value: &TitleObjectSubtitleLineHeight) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for TitleVariant1SubtitleLineHeight {
+impl ::std::convert::From<f64> for TitleObjectSubtitleLineHeight {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<NumberValue> for TitleVariant1SubtitleLineHeight {
+impl ::std::convert::From<NumberValue> for TitleObjectSubtitleLineHeight {
     fn from(value: NumberValue) -> Self {
         Self::Variant1(value)
     }
@@ -109601,8 +109545,8 @@ impl ::std::convert::From<&TreeTransform> for TreeTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum TreeTransformAs {
-    Variant0([TreeTransformAsVariant0Item; 4usize]),
-    Variant1(SignalRef),
+    Array([TreeTransformAsArrayItem; 4usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for TreeTransformAs {
     fn from(value: &TreeTransformAs) -> Self {
@@ -109611,25 +109555,25 @@ impl ::std::convert::From<&Self> for TreeTransformAs {
 }
 impl ::std::default::Default for TreeTransformAs {
     fn default() -> Self {
-        TreeTransformAs::Variant0([
-            TreeTransformAsVariant0Item::Variant0("x".to_string()),
-            TreeTransformAsVariant0Item::Variant0("y".to_string()),
-            TreeTransformAsVariant0Item::Variant0("depth".to_string()),
-            TreeTransformAsVariant0Item::Variant0("children".to_string()),
+        TreeTransformAs::Array([
+            TreeTransformAsArrayItem::String("x".to_string()),
+            TreeTransformAsArrayItem::String("y".to_string()),
+            TreeTransformAsArrayItem::String("depth".to_string()),
+            TreeTransformAsArrayItem::String("children".to_string()),
         ])
     }
 }
-impl ::std::convert::From<[TreeTransformAsVariant0Item; 4usize]> for TreeTransformAs {
-    fn from(value: [TreeTransformAsVariant0Item; 4usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[TreeTransformAsArrayItem; 4usize]> for TreeTransformAs {
+    fn from(value: [TreeTransformAsArrayItem; 4usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for TreeTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`TreeTransformAsVariant0Item`"]
+#[doc = "`TreeTransformAsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -109648,18 +109592,18 @@ impl ::std::convert::From<SignalRef> for TreeTransformAs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TreeTransformAsVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum TreeTransformAsArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for TreeTransformAsVariant0Item {
-    fn from(value: &TreeTransformAsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for TreeTransformAsArrayItem {
+    fn from(value: &TreeTransformAsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for TreeTransformAsVariant0Item {
+impl ::std::convert::From<SignalRef> for TreeTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`TreeTransformField`"]
@@ -109864,25 +109808,25 @@ impl ::std::convert::TryFrom<::std::string::String> for TreeTransformMethodVaria
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum TreeTransformNodeSize {
-    Variant0([TreeTransformNodeSizeVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([TreeTransformNodeSizeArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for TreeTransformNodeSize {
     fn from(value: &TreeTransformNodeSize) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<[TreeTransformNodeSizeVariant0Item; 2usize]> for TreeTransformNodeSize {
-    fn from(value: [TreeTransformNodeSizeVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[TreeTransformNodeSizeArrayItem; 2usize]> for TreeTransformNodeSize {
+    fn from(value: [TreeTransformNodeSizeArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for TreeTransformNodeSize {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`TreeTransformNodeSizeVariant0Item`"]
+#[doc = "`TreeTransformNodeSizeArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -109901,23 +109845,23 @@ impl ::std::convert::From<SignalRef> for TreeTransformNodeSize {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TreeTransformNodeSizeVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum TreeTransformNodeSizeArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for TreeTransformNodeSizeVariant0Item {
-    fn from(value: &TreeTransformNodeSizeVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for TreeTransformNodeSizeArrayItem {
+    fn from(value: &TreeTransformNodeSizeArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for TreeTransformNodeSizeVariant0Item {
+impl ::std::convert::From<f64> for TreeTransformNodeSizeArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for TreeTransformNodeSizeVariant0Item {
+impl ::std::convert::From<SignalRef> for TreeTransformNodeSizeArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`TreeTransformSeparation`"]
@@ -109941,8 +109885,8 @@ impl ::std::convert::From<SignalRef> for TreeTransformNodeSizeVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum TreeTransformSeparation {
-    Variant0(bool),
-    Variant1(SignalRef),
+    Boolean(bool),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for TreeTransformSeparation {
     fn from(value: &TreeTransformSeparation) -> Self {
@@ -109951,17 +109895,17 @@ impl ::std::convert::From<&Self> for TreeTransformSeparation {
 }
 impl ::std::default::Default for TreeTransformSeparation {
     fn default() -> Self {
-        TreeTransformSeparation::Variant0(true)
+        TreeTransformSeparation::Boolean(true)
     }
 }
 impl ::std::convert::From<bool> for TreeTransformSeparation {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<SignalRef> for TreeTransformSeparation {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`TreeTransformSize`"]
@@ -109996,25 +109940,25 @@ impl ::std::convert::From<SignalRef> for TreeTransformSeparation {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum TreeTransformSize {
-    Variant0([TreeTransformSizeVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([TreeTransformSizeArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for TreeTransformSize {
     fn from(value: &TreeTransformSize) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<[TreeTransformSizeVariant0Item; 2usize]> for TreeTransformSize {
-    fn from(value: [TreeTransformSizeVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[TreeTransformSizeArrayItem; 2usize]> for TreeTransformSize {
+    fn from(value: [TreeTransformSizeArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for TreeTransformSize {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`TreeTransformSizeVariant0Item`"]
+#[doc = "`TreeTransformSizeArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -110033,23 +109977,23 @@ impl ::std::convert::From<SignalRef> for TreeTransformSize {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TreeTransformSizeVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum TreeTransformSizeArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for TreeTransformSizeVariant0Item {
-    fn from(value: &TreeTransformSizeVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for TreeTransformSizeArrayItem {
+    fn from(value: &TreeTransformSizeArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for TreeTransformSizeVariant0Item {
+impl ::std::convert::From<f64> for TreeTransformSizeArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for TreeTransformSizeVariant0Item {
+impl ::std::convert::From<SignalRef> for TreeTransformSizeArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`TreeTransformType`"]
@@ -110537,8 +110481,8 @@ impl ::std::convert::From<&TreemapTransform> for TreemapTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum TreemapTransformAs {
-    Variant0([TreemapTransformAsVariant0Item; 6usize]),
-    Variant1(SignalRef),
+    Array([TreemapTransformAsArrayItem; 6usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for TreemapTransformAs {
     fn from(value: &TreemapTransformAs) -> Self {
@@ -110547,27 +110491,27 @@ impl ::std::convert::From<&Self> for TreemapTransformAs {
 }
 impl ::std::default::Default for TreemapTransformAs {
     fn default() -> Self {
-        TreemapTransformAs::Variant0([
-            TreemapTransformAsVariant0Item::Variant0("x0".to_string()),
-            TreemapTransformAsVariant0Item::Variant0("y0".to_string()),
-            TreemapTransformAsVariant0Item::Variant0("x1".to_string()),
-            TreemapTransformAsVariant0Item::Variant0("y1".to_string()),
-            TreemapTransformAsVariant0Item::Variant0("depth".to_string()),
-            TreemapTransformAsVariant0Item::Variant0("children".to_string()),
+        TreemapTransformAs::Array([
+            TreemapTransformAsArrayItem::String("x0".to_string()),
+            TreemapTransformAsArrayItem::String("y0".to_string()),
+            TreemapTransformAsArrayItem::String("x1".to_string()),
+            TreemapTransformAsArrayItem::String("y1".to_string()),
+            TreemapTransformAsArrayItem::String("depth".to_string()),
+            TreemapTransformAsArrayItem::String("children".to_string()),
         ])
     }
 }
-impl ::std::convert::From<[TreemapTransformAsVariant0Item; 6usize]> for TreemapTransformAs {
-    fn from(value: [TreemapTransformAsVariant0Item; 6usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[TreemapTransformAsArrayItem; 6usize]> for TreemapTransformAs {
+    fn from(value: [TreemapTransformAsArrayItem; 6usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for TreemapTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`TreemapTransformAsVariant0Item`"]
+#[doc = "`TreemapTransformAsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -110586,18 +110530,18 @@ impl ::std::convert::From<SignalRef> for TreemapTransformAs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TreemapTransformAsVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum TreemapTransformAsArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for TreemapTransformAsVariant0Item {
-    fn from(value: &TreemapTransformAsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for TreemapTransformAsArrayItem {
+    fn from(value: &TreemapTransformAsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for TreemapTransformAsVariant0Item {
+impl ::std::convert::From<SignalRef> for TreemapTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`TreemapTransformField`"]
@@ -110814,8 +110758,8 @@ impl ::std::convert::TryFrom<::std::string::String> for TreemapTransformMethodVa
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum TreemapTransformPadding {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for TreemapTransformPadding {
     fn from(value: &TreemapTransformPadding) -> Self {
@@ -110824,12 +110768,12 @@ impl ::std::convert::From<&Self> for TreemapTransformPadding {
 }
 impl ::std::convert::From<f64> for TreemapTransformPadding {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for TreemapTransformPadding {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`TreemapTransformPaddingBottom`"]
@@ -110852,8 +110796,8 @@ impl ::std::convert::From<SignalRef> for TreemapTransformPadding {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum TreemapTransformPaddingBottom {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for TreemapTransformPaddingBottom {
     fn from(value: &TreemapTransformPaddingBottom) -> Self {
@@ -110862,12 +110806,12 @@ impl ::std::convert::From<&Self> for TreemapTransformPaddingBottom {
 }
 impl ::std::convert::From<f64> for TreemapTransformPaddingBottom {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for TreemapTransformPaddingBottom {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`TreemapTransformPaddingInner`"]
@@ -110890,8 +110834,8 @@ impl ::std::convert::From<SignalRef> for TreemapTransformPaddingBottom {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum TreemapTransformPaddingInner {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for TreemapTransformPaddingInner {
     fn from(value: &TreemapTransformPaddingInner) -> Self {
@@ -110900,12 +110844,12 @@ impl ::std::convert::From<&Self> for TreemapTransformPaddingInner {
 }
 impl ::std::convert::From<f64> for TreemapTransformPaddingInner {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for TreemapTransformPaddingInner {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`TreemapTransformPaddingLeft`"]
@@ -110928,8 +110872,8 @@ impl ::std::convert::From<SignalRef> for TreemapTransformPaddingInner {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum TreemapTransformPaddingLeft {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for TreemapTransformPaddingLeft {
     fn from(value: &TreemapTransformPaddingLeft) -> Self {
@@ -110938,12 +110882,12 @@ impl ::std::convert::From<&Self> for TreemapTransformPaddingLeft {
 }
 impl ::std::convert::From<f64> for TreemapTransformPaddingLeft {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for TreemapTransformPaddingLeft {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`TreemapTransformPaddingOuter`"]
@@ -110966,8 +110910,8 @@ impl ::std::convert::From<SignalRef> for TreemapTransformPaddingLeft {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum TreemapTransformPaddingOuter {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for TreemapTransformPaddingOuter {
     fn from(value: &TreemapTransformPaddingOuter) -> Self {
@@ -110976,12 +110920,12 @@ impl ::std::convert::From<&Self> for TreemapTransformPaddingOuter {
 }
 impl ::std::convert::From<f64> for TreemapTransformPaddingOuter {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for TreemapTransformPaddingOuter {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`TreemapTransformPaddingRight`"]
@@ -111004,8 +110948,8 @@ impl ::std::convert::From<SignalRef> for TreemapTransformPaddingOuter {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum TreemapTransformPaddingRight {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for TreemapTransformPaddingRight {
     fn from(value: &TreemapTransformPaddingRight) -> Self {
@@ -111014,12 +110958,12 @@ impl ::std::convert::From<&Self> for TreemapTransformPaddingRight {
 }
 impl ::std::convert::From<f64> for TreemapTransformPaddingRight {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for TreemapTransformPaddingRight {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`TreemapTransformPaddingTop`"]
@@ -111042,8 +110986,8 @@ impl ::std::convert::From<SignalRef> for TreemapTransformPaddingRight {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum TreemapTransformPaddingTop {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for TreemapTransformPaddingTop {
     fn from(value: &TreemapTransformPaddingTop) -> Self {
@@ -111052,12 +110996,12 @@ impl ::std::convert::From<&Self> for TreemapTransformPaddingTop {
 }
 impl ::std::convert::From<f64> for TreemapTransformPaddingTop {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for TreemapTransformPaddingTop {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`TreemapTransformRatio`"]
@@ -111081,8 +111025,8 @@ impl ::std::convert::From<SignalRef> for TreemapTransformPaddingTop {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum TreemapTransformRatio {
-    Variant0(f64),
-    Variant1(SignalRef),
+    Number(f64),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for TreemapTransformRatio {
     fn from(value: &TreemapTransformRatio) -> Self {
@@ -111091,17 +111035,17 @@ impl ::std::convert::From<&Self> for TreemapTransformRatio {
 }
 impl ::std::default::Default for TreemapTransformRatio {
     fn default() -> Self {
-        TreemapTransformRatio::Variant0(1.618033988749895_f64)
+        TreemapTransformRatio::Number(1.618033988749895_f64)
     }
 }
 impl ::std::convert::From<f64> for TreemapTransformRatio {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for TreemapTransformRatio {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`TreemapTransformRound`"]
@@ -111124,8 +111068,8 @@ impl ::std::convert::From<SignalRef> for TreemapTransformRatio {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum TreemapTransformRound {
-    Variant0(bool),
-    Variant1(SignalRef),
+    Boolean(bool),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for TreemapTransformRound {
     fn from(value: &TreemapTransformRound) -> Self {
@@ -111134,12 +111078,12 @@ impl ::std::convert::From<&Self> for TreemapTransformRound {
 }
 impl ::std::convert::From<bool> for TreemapTransformRound {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<SignalRef> for TreemapTransformRound {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`TreemapTransformSize`"]
@@ -111174,25 +111118,25 @@ impl ::std::convert::From<SignalRef> for TreemapTransformRound {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum TreemapTransformSize {
-    Variant0([TreemapTransformSizeVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([TreemapTransformSizeArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for TreemapTransformSize {
     fn from(value: &TreemapTransformSize) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<[TreemapTransformSizeVariant0Item; 2usize]> for TreemapTransformSize {
-    fn from(value: [TreemapTransformSizeVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[TreemapTransformSizeArrayItem; 2usize]> for TreemapTransformSize {
+    fn from(value: [TreemapTransformSizeArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for TreemapTransformSize {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`TreemapTransformSizeVariant0Item`"]
+#[doc = "`TreemapTransformSizeArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -111211,23 +111155,23 @@ impl ::std::convert::From<SignalRef> for TreemapTransformSize {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum TreemapTransformSizeVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum TreemapTransformSizeArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for TreemapTransformSizeVariant0Item {
-    fn from(value: &TreemapTransformSizeVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for TreemapTransformSizeArrayItem {
+    fn from(value: &TreemapTransformSizeArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for TreemapTransformSizeVariant0Item {
+impl ::std::convert::From<f64> for TreemapTransformSizeArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for TreemapTransformSizeVariant0Item {
+impl ::std::convert::From<SignalRef> for TreemapTransformSizeArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`TreemapTransformType`"]
@@ -111451,8 +111395,8 @@ impl ::std::convert::From<&VoronoiTransform> for VoronoiTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum VoronoiTransformAs {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for VoronoiTransformAs {
     fn from(value: &VoronoiTransformAs) -> Self {
@@ -111461,12 +111405,12 @@ impl ::std::convert::From<&Self> for VoronoiTransformAs {
 }
 impl ::std::default::Default for VoronoiTransformAs {
     fn default() -> Self {
-        VoronoiTransformAs::Variant0("path".to_string())
+        VoronoiTransformAs::String("path".to_string())
     }
 }
 impl ::std::convert::From<SignalRef> for VoronoiTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`VoronoiTransformExtent`"]
@@ -111502,8 +111446,8 @@ impl ::std::convert::From<SignalRef> for VoronoiTransformAs {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum VoronoiTransformExtent {
-    Variant0([::serde_json::Value; 2usize]),
-    Variant1(SignalRef),
+    Array([::serde_json::Value; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for VoronoiTransformExtent {
     fn from(value: &VoronoiTransformExtent) -> Self {
@@ -111512,7 +111456,7 @@ impl ::std::convert::From<&Self> for VoronoiTransformExtent {
 }
 impl ::std::default::Default for VoronoiTransformExtent {
     fn default() -> Self {
-        VoronoiTransformExtent::Variant0([
+        VoronoiTransformExtent::Array([
             ::serde_json::from_str::<::serde_json::Value>("[-100000,-100000]").unwrap(),
             ::serde_json::from_str::<::serde_json::Value>("[100000,100000]").unwrap(),
         ])
@@ -111520,12 +111464,12 @@ impl ::std::default::Default for VoronoiTransformExtent {
 }
 impl ::std::convert::From<[::serde_json::Value; 2usize]> for VoronoiTransformExtent {
     fn from(value: [::serde_json::Value; 2usize]) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for VoronoiTransformExtent {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`VoronoiTransformSize`"]
@@ -111560,25 +111504,25 @@ impl ::std::convert::From<SignalRef> for VoronoiTransformExtent {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum VoronoiTransformSize {
-    Variant0([VoronoiTransformSizeVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([VoronoiTransformSizeArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for VoronoiTransformSize {
     fn from(value: &VoronoiTransformSize) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<[VoronoiTransformSizeVariant0Item; 2usize]> for VoronoiTransformSize {
-    fn from(value: [VoronoiTransformSizeVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[VoronoiTransformSizeArrayItem; 2usize]> for VoronoiTransformSize {
+    fn from(value: [VoronoiTransformSizeArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for VoronoiTransformSize {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`VoronoiTransformSizeVariant0Item`"]
+#[doc = "`VoronoiTransformSizeArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -111597,23 +111541,23 @@ impl ::std::convert::From<SignalRef> for VoronoiTransformSize {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum VoronoiTransformSizeVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum VoronoiTransformSizeArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for VoronoiTransformSizeVariant0Item {
-    fn from(value: &VoronoiTransformSizeVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for VoronoiTransformSizeArrayItem {
+    fn from(value: &VoronoiTransformSizeArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for VoronoiTransformSizeVariant0Item {
+impl ::std::convert::From<f64> for VoronoiTransformSizeArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for VoronoiTransformSizeVariant0Item {
+impl ::std::convert::From<SignalRef> for VoronoiTransformSizeArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`VoronoiTransformType`"]
@@ -112070,25 +112014,25 @@ impl ::std::convert::From<&WindowTransform> for WindowTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum WindowTransformAs {
-    Variant0(::std::vec::Vec<WindowTransformAsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<WindowTransformAsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for WindowTransformAs {
     fn from(value: &WindowTransformAs) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<WindowTransformAsVariant0Item>> for WindowTransformAs {
-    fn from(value: ::std::vec::Vec<WindowTransformAsVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<WindowTransformAsArrayItem>> for WindowTransformAs {
+    fn from(value: ::std::vec::Vec<WindowTransformAsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for WindowTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`WindowTransformAsVariant0Item`"]
+#[doc = "`WindowTransformAsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -112110,19 +112054,19 @@ impl ::std::convert::From<SignalRef> for WindowTransformAs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum WindowTransformAsVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
-    Variant2,
+pub enum WindowTransformAsArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
+    Null,
 }
-impl ::std::convert::From<&Self> for WindowTransformAsVariant0Item {
-    fn from(value: &WindowTransformAsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for WindowTransformAsArrayItem {
+    fn from(value: &WindowTransformAsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for WindowTransformAsVariant0Item {
+impl ::std::convert::From<SignalRef> for WindowTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`WindowTransformFields`"]
@@ -112161,27 +112105,27 @@ impl ::std::convert::From<SignalRef> for WindowTransformAsVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum WindowTransformFields {
-    Variant0(::std::vec::Vec<WindowTransformFieldsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<WindowTransformFieldsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for WindowTransformFields {
     fn from(value: &WindowTransformFields) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<WindowTransformFieldsVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<WindowTransformFieldsArrayItem>>
     for WindowTransformFields
 {
-    fn from(value: ::std::vec::Vec<WindowTransformFieldsVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<WindowTransformFieldsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for WindowTransformFields {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`WindowTransformFieldsVariant0Item`"]
+#[doc = "`WindowTransformFieldsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -112206,30 +112150,30 @@ impl ::std::convert::From<SignalRef> for WindowTransformFields {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum WindowTransformFieldsVariant0Item {
-    Variant0(ScaleField),
-    Variant1(ParamField),
-    Variant2(Expr),
-    Variant3,
+pub enum WindowTransformFieldsArrayItem {
+    ScaleField(ScaleField),
+    ParamField(ParamField),
+    Expr(Expr),
+    Null,
 }
-impl ::std::convert::From<&Self> for WindowTransformFieldsVariant0Item {
-    fn from(value: &WindowTransformFieldsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for WindowTransformFieldsArrayItem {
+    fn from(value: &WindowTransformFieldsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<ScaleField> for WindowTransformFieldsVariant0Item {
+impl ::std::convert::From<ScaleField> for WindowTransformFieldsArrayItem {
     fn from(value: ScaleField) -> Self {
-        Self::Variant0(value)
+        Self::ScaleField(value)
     }
 }
-impl ::std::convert::From<ParamField> for WindowTransformFieldsVariant0Item {
+impl ::std::convert::From<ParamField> for WindowTransformFieldsArrayItem {
     fn from(value: ParamField) -> Self {
-        Self::Variant1(value)
+        Self::ParamField(value)
     }
 }
-impl ::std::convert::From<Expr> for WindowTransformFieldsVariant0Item {
+impl ::std::convert::From<Expr> for WindowTransformFieldsArrayItem {
     fn from(value: Expr) -> Self {
-        Self::Variant2(value)
+        Self::Expr(value)
     }
 }
 #[doc = "`WindowTransformFrame`"]
@@ -112271,8 +112215,8 @@ impl ::std::convert::From<Expr> for WindowTransformFieldsVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum WindowTransformFrame {
-    Variant0([WindowTransformFrameVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([WindowTransformFrameArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for WindowTransformFrame {
     fn from(value: &WindowTransformFrame) -> Self {
@@ -112281,23 +112225,23 @@ impl ::std::convert::From<&Self> for WindowTransformFrame {
 }
 impl ::std::default::Default for WindowTransformFrame {
     fn default() -> Self {
-        WindowTransformFrame::Variant0([
-            WindowTransformFrameVariant0Item::Variant2,
-            WindowTransformFrameVariant0Item::Variant0(0_f64),
+        WindowTransformFrame::Array([
+            WindowTransformFrameArrayItem::Null,
+            WindowTransformFrameArrayItem::Number(0_f64),
         ])
     }
 }
-impl ::std::convert::From<[WindowTransformFrameVariant0Item; 2usize]> for WindowTransformFrame {
-    fn from(value: [WindowTransformFrameVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[WindowTransformFrameArrayItem; 2usize]> for WindowTransformFrame {
+    fn from(value: [WindowTransformFrameArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for WindowTransformFrame {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`WindowTransformFrameVariant0Item`"]
+#[doc = "`WindowTransformFrameArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -112319,24 +112263,24 @@ impl ::std::convert::From<SignalRef> for WindowTransformFrame {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum WindowTransformFrameVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
-    Variant2,
+pub enum WindowTransformFrameArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
+    Null,
 }
-impl ::std::convert::From<&Self> for WindowTransformFrameVariant0Item {
-    fn from(value: &WindowTransformFrameVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for WindowTransformFrameArrayItem {
+    fn from(value: &WindowTransformFrameArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for WindowTransformFrameVariant0Item {
+impl ::std::convert::From<f64> for WindowTransformFrameArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for WindowTransformFrameVariant0Item {
+impl ::std::convert::From<SignalRef> for WindowTransformFrameArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`WindowTransformGroupby`"]
@@ -112372,27 +112316,27 @@ impl ::std::convert::From<SignalRef> for WindowTransformFrameVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum WindowTransformGroupby {
-    Variant0(::std::vec::Vec<WindowTransformGroupbyVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<WindowTransformGroupbyArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for WindowTransformGroupby {
     fn from(value: &WindowTransformGroupby) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<WindowTransformGroupbyVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<WindowTransformGroupbyArrayItem>>
     for WindowTransformGroupby
 {
-    fn from(value: ::std::vec::Vec<WindowTransformGroupbyVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<WindowTransformGroupbyArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for WindowTransformGroupby {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`WindowTransformGroupbyVariant0Item`"]
+#[doc = "`WindowTransformGroupbyArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -112414,27 +112358,27 @@ impl ::std::convert::From<SignalRef> for WindowTransformGroupby {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum WindowTransformGroupbyVariant0Item {
+pub enum WindowTransformGroupbyArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for WindowTransformGroupbyVariant0Item {
-    fn from(value: &WindowTransformGroupbyVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for WindowTransformGroupbyArrayItem {
+    fn from(value: &WindowTransformGroupbyArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<ScaleField> for WindowTransformGroupbyVariant0Item {
+impl ::std::convert::From<ScaleField> for WindowTransformGroupbyArrayItem {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
     }
 }
-impl ::std::convert::From<ParamField> for WindowTransformGroupbyVariant0Item {
+impl ::std::convert::From<ParamField> for WindowTransformGroupbyArrayItem {
     fn from(value: ParamField) -> Self {
         Self::ParamField(value)
     }
 }
-impl ::std::convert::From<Expr> for WindowTransformGroupbyVariant0Item {
+impl ::std::convert::From<Expr> for WindowTransformGroupbyArrayItem {
     fn from(value: Expr) -> Self {
         Self::Expr(value)
     }
@@ -112459,8 +112403,8 @@ impl ::std::convert::From<Expr> for WindowTransformGroupbyVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum WindowTransformIgnorePeers {
-    Variant0(bool),
-    Variant1(SignalRef),
+    Boolean(bool),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for WindowTransformIgnorePeers {
     fn from(value: &WindowTransformIgnorePeers) -> Self {
@@ -112469,12 +112413,12 @@ impl ::std::convert::From<&Self> for WindowTransformIgnorePeers {
 }
 impl ::std::convert::From<bool> for WindowTransformIgnorePeers {
     fn from(value: bool) -> Self {
-        Self::Variant0(value)
+        Self::Boolean(value)
     }
 }
 impl ::std::convert::From<SignalRef> for WindowTransformIgnorePeers {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`WindowTransformOps`"]
@@ -112545,25 +112489,25 @@ impl ::std::convert::From<SignalRef> for WindowTransformIgnorePeers {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum WindowTransformOps {
-    Variant0(::std::vec::Vec<WindowTransformOpsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<WindowTransformOpsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for WindowTransformOps {
     fn from(value: &WindowTransformOps) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<WindowTransformOpsVariant0Item>> for WindowTransformOps {
-    fn from(value: ::std::vec::Vec<WindowTransformOpsVariant0Item>) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<::std::vec::Vec<WindowTransformOpsArrayItem>> for WindowTransformOps {
+    fn from(value: ::std::vec::Vec<WindowTransformOpsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for WindowTransformOps {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`WindowTransformOpsVariant0Item`"]
+#[doc = "`WindowTransformOpsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -112620,28 +112564,26 @@ impl ::std::convert::From<SignalRef> for WindowTransformOps {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum WindowTransformOpsVariant0Item {
-    Variant0(WindowTransformOpsVariant0ItemVariant0),
+pub enum WindowTransformOpsArrayItem {
+    Variant0(WindowTransformOpsArrayItemVariant0),
     Variant1(SignalRef),
 }
-impl ::std::convert::From<&Self> for WindowTransformOpsVariant0Item {
-    fn from(value: &WindowTransformOpsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for WindowTransformOpsArrayItem {
+    fn from(value: &WindowTransformOpsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<WindowTransformOpsVariant0ItemVariant0>
-    for WindowTransformOpsVariant0Item
-{
-    fn from(value: WindowTransformOpsVariant0ItemVariant0) -> Self {
+impl ::std::convert::From<WindowTransformOpsArrayItemVariant0> for WindowTransformOpsArrayItem {
+    fn from(value: WindowTransformOpsArrayItemVariant0) -> Self {
         Self::Variant0(value)
     }
 }
-impl ::std::convert::From<SignalRef> for WindowTransformOpsVariant0Item {
+impl ::std::convert::From<SignalRef> for WindowTransformOpsArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
     }
 }
-#[doc = "`WindowTransformOpsVariant0ItemVariant0`"]
+#[doc = "`WindowTransformOpsArrayItemVariant0`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -112701,7 +112643,7 @@ impl ::std::convert::From<SignalRef> for WindowTransformOpsVariant0Item {
     PartialEq,
     PartialOrd,
 )]
-pub enum WindowTransformOpsVariant0ItemVariant0 {
+pub enum WindowTransformOpsArrayItemVariant0 {
     #[serde(rename = "row_number")]
     RowXnumber,
     #[serde(rename = "rank")]
@@ -112777,12 +112719,12 @@ pub enum WindowTransformOpsVariant0ItemVariant0 {
     #[serde(rename = "argmax")]
     Argmax,
 }
-impl ::std::convert::From<&Self> for WindowTransformOpsVariant0ItemVariant0 {
-    fn from(value: &WindowTransformOpsVariant0ItemVariant0) -> Self {
+impl ::std::convert::From<&Self> for WindowTransformOpsArrayItemVariant0 {
+    fn from(value: &WindowTransformOpsArrayItemVariant0) -> Self {
         value.clone()
     }
 }
-impl ::std::fmt::Display for WindowTransformOpsVariant0ItemVariant0 {
+impl ::std::fmt::Display for WindowTransformOpsArrayItemVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
             Self::RowXnumber => f.write_str("row_number"),
@@ -112825,7 +112767,7 @@ impl ::std::fmt::Display for WindowTransformOpsVariant0ItemVariant0 {
         }
     }
 }
-impl ::std::str::FromStr for WindowTransformOpsVariant0ItemVariant0 {
+impl ::std::str::FromStr for WindowTransformOpsArrayItemVariant0 {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         match value {
@@ -112870,13 +112812,13 @@ impl ::std::str::FromStr for WindowTransformOpsVariant0ItemVariant0 {
         }
     }
 }
-impl ::std::convert::TryFrom<&str> for WindowTransformOpsVariant0ItemVariant0 {
+impl ::std::convert::TryFrom<&str> for WindowTransformOpsArrayItemVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for WindowTransformOpsVariant0ItemVariant0 {
+impl ::std::convert::TryFrom<&::std::string::String> for WindowTransformOpsArrayItemVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: &::std::string::String,
@@ -112884,7 +112826,7 @@ impl ::std::convert::TryFrom<&::std::string::String> for WindowTransformOpsVaria
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<::std::string::String> for WindowTransformOpsVariant0ItemVariant0 {
+impl ::std::convert::TryFrom<::std::string::String> for WindowTransformOpsArrayItemVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
         value: ::std::string::String,
@@ -112925,27 +112867,27 @@ impl ::std::convert::TryFrom<::std::string::String> for WindowTransformOpsVarian
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum WindowTransformParams {
-    Variant0(::std::vec::Vec<WindowTransformParamsVariant0Item>),
-    Variant1(SignalRef),
+    Array(::std::vec::Vec<WindowTransformParamsArrayItem>),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for WindowTransformParams {
     fn from(value: &WindowTransformParams) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<::std::vec::Vec<WindowTransformParamsVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<WindowTransformParamsArrayItem>>
     for WindowTransformParams
 {
-    fn from(value: ::std::vec::Vec<WindowTransformParamsVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<WindowTransformParamsArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for WindowTransformParams {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`WindowTransformParamsVariant0Item`"]
+#[doc = "`WindowTransformParamsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -112967,24 +112909,24 @@ impl ::std::convert::From<SignalRef> for WindowTransformParams {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum WindowTransformParamsVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
-    Variant2,
+pub enum WindowTransformParamsArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
+    Null,
 }
-impl ::std::convert::From<&Self> for WindowTransformParamsVariant0Item {
-    fn from(value: &WindowTransformParamsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for WindowTransformParamsArrayItem {
+    fn from(value: &WindowTransformParamsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for WindowTransformParamsVariant0Item {
+impl ::std::convert::From<f64> for WindowTransformParamsArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for WindowTransformParamsVariant0Item {
+impl ::std::convert::From<SignalRef> for WindowTransformParamsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`WindowTransformType`"]
@@ -113373,8 +113315,8 @@ impl ::std::convert::From<&WordcloudTransform> for WordcloudTransform {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum WordcloudTransformAs {
-    Variant0([WordcloudTransformAsVariant0Item; 7usize]),
-    Variant1(SignalRef),
+    Array([WordcloudTransformAsArrayItem; 7usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for WordcloudTransformAs {
     fn from(value: &WordcloudTransformAs) -> Self {
@@ -113383,28 +113325,28 @@ impl ::std::convert::From<&Self> for WordcloudTransformAs {
 }
 impl ::std::default::Default for WordcloudTransformAs {
     fn default() -> Self {
-        WordcloudTransformAs::Variant0([
-            WordcloudTransformAsVariant0Item::Variant0("x".to_string()),
-            WordcloudTransformAsVariant0Item::Variant0("y".to_string()),
-            WordcloudTransformAsVariant0Item::Variant0("font".to_string()),
-            WordcloudTransformAsVariant0Item::Variant0("fontSize".to_string()),
-            WordcloudTransformAsVariant0Item::Variant0("fontStyle".to_string()),
-            WordcloudTransformAsVariant0Item::Variant0("fontWeight".to_string()),
-            WordcloudTransformAsVariant0Item::Variant0("angle".to_string()),
+        WordcloudTransformAs::Array([
+            WordcloudTransformAsArrayItem::String("x".to_string()),
+            WordcloudTransformAsArrayItem::String("y".to_string()),
+            WordcloudTransformAsArrayItem::String("font".to_string()),
+            WordcloudTransformAsArrayItem::String("fontSize".to_string()),
+            WordcloudTransformAsArrayItem::String("fontStyle".to_string()),
+            WordcloudTransformAsArrayItem::String("fontWeight".to_string()),
+            WordcloudTransformAsArrayItem::String("angle".to_string()),
         ])
     }
 }
-impl ::std::convert::From<[WordcloudTransformAsVariant0Item; 7usize]> for WordcloudTransformAs {
-    fn from(value: [WordcloudTransformAsVariant0Item; 7usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[WordcloudTransformAsArrayItem; 7usize]> for WordcloudTransformAs {
+    fn from(value: [WordcloudTransformAsArrayItem; 7usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for WordcloudTransformAs {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`WordcloudTransformAsVariant0Item`"]
+#[doc = "`WordcloudTransformAsArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -113423,18 +113365,18 @@ impl ::std::convert::From<SignalRef> for WordcloudTransformAs {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum WordcloudTransformAsVariant0Item {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+pub enum WordcloudTransformAsArrayItem {
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for WordcloudTransformAsVariant0Item {
-    fn from(value: &WordcloudTransformAsVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for WordcloudTransformAsArrayItem {
+    fn from(value: &WordcloudTransformAsArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<SignalRef> for WordcloudTransformAsVariant0Item {
+impl ::std::convert::From<SignalRef> for WordcloudTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`WordcloudTransformFont`"]
@@ -113464,10 +113406,10 @@ impl ::std::convert::From<SignalRef> for WordcloudTransformAsVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum WordcloudTransformFont {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
-    Variant2(Expr),
-    Variant3(ParamField),
+    String(::std::string::String),
+    SignalRef(SignalRef),
+    Expr(Expr),
+    ParamField(ParamField),
 }
 impl ::std::convert::From<&Self> for WordcloudTransformFont {
     fn from(value: &WordcloudTransformFont) -> Self {
@@ -113476,22 +113418,22 @@ impl ::std::convert::From<&Self> for WordcloudTransformFont {
 }
 impl ::std::default::Default for WordcloudTransformFont {
     fn default() -> Self {
-        WordcloudTransformFont::Variant0("sans-serif".to_string())
+        WordcloudTransformFont::String("sans-serif".to_string())
     }
 }
 impl ::std::convert::From<SignalRef> for WordcloudTransformFont {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 impl ::std::convert::From<Expr> for WordcloudTransformFont {
     fn from(value: Expr) -> Self {
-        Self::Variant2(value)
+        Self::Expr(value)
     }
 }
 impl ::std::convert::From<ParamField> for WordcloudTransformFont {
     fn from(value: ParamField) -> Self {
-        Self::Variant3(value)
+        Self::ParamField(value)
     }
 }
 #[doc = "`WordcloudTransformFontSize`"]
@@ -113521,10 +113463,10 @@ impl ::std::convert::From<ParamField> for WordcloudTransformFont {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum WordcloudTransformFontSize {
-    Variant0(f64),
-    Variant1(SignalRef),
-    Variant2(Expr),
-    Variant3(ParamField),
+    Number(f64),
+    SignalRef(SignalRef),
+    Expr(Expr),
+    ParamField(ParamField),
 }
 impl ::std::convert::From<&Self> for WordcloudTransformFontSize {
     fn from(value: &WordcloudTransformFontSize) -> Self {
@@ -113533,27 +113475,27 @@ impl ::std::convert::From<&Self> for WordcloudTransformFontSize {
 }
 impl ::std::default::Default for WordcloudTransformFontSize {
     fn default() -> Self {
-        WordcloudTransformFontSize::Variant0(14_f64)
+        WordcloudTransformFontSize::Number(14_f64)
     }
 }
 impl ::std::convert::From<f64> for WordcloudTransformFontSize {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for WordcloudTransformFontSize {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 impl ::std::convert::From<Expr> for WordcloudTransformFontSize {
     fn from(value: Expr) -> Self {
-        Self::Variant2(value)
+        Self::Expr(value)
     }
 }
 impl ::std::convert::From<ParamField> for WordcloudTransformFontSize {
     fn from(value: ParamField) -> Self {
-        Self::Variant3(value)
+        Self::ParamField(value)
     }
 }
 #[doc = "`WordcloudTransformFontSizeRange`"]
@@ -113593,9 +113535,9 @@ impl ::std::convert::From<ParamField> for WordcloudTransformFontSize {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum WordcloudTransformFontSizeRange {
-    Variant0(::std::vec::Vec<WordcloudTransformFontSizeRangeVariant0Item>),
-    Variant1(SignalRef),
-    Variant2,
+    Array(::std::vec::Vec<WordcloudTransformFontSizeRangeArrayItem>),
+    SignalRef(SignalRef),
+    Null,
 }
 impl ::std::convert::From<&Self> for WordcloudTransformFontSizeRange {
     fn from(value: &WordcloudTransformFontSizeRange) -> Self {
@@ -113604,25 +113546,25 @@ impl ::std::convert::From<&Self> for WordcloudTransformFontSizeRange {
 }
 impl ::std::default::Default for WordcloudTransformFontSizeRange {
     fn default() -> Self {
-        WordcloudTransformFontSizeRange::Variant0(vec![
-            WordcloudTransformFontSizeRangeVariant0Item::Variant0(10_f64),
-            WordcloudTransformFontSizeRangeVariant0Item::Variant0(50_f64),
+        WordcloudTransformFontSizeRange::Array(vec![
+            WordcloudTransformFontSizeRangeArrayItem::Number(10_f64),
+            WordcloudTransformFontSizeRangeArrayItem::Number(50_f64),
         ])
     }
 }
-impl ::std::convert::From<::std::vec::Vec<WordcloudTransformFontSizeRangeVariant0Item>>
+impl ::std::convert::From<::std::vec::Vec<WordcloudTransformFontSizeRangeArrayItem>>
     for WordcloudTransformFontSizeRange
 {
-    fn from(value: ::std::vec::Vec<WordcloudTransformFontSizeRangeVariant0Item>) -> Self {
-        Self::Variant0(value)
+    fn from(value: ::std::vec::Vec<WordcloudTransformFontSizeRangeArrayItem>) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for WordcloudTransformFontSizeRange {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`WordcloudTransformFontSizeRangeVariant0Item`"]
+#[doc = "`WordcloudTransformFontSizeRangeArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -113641,23 +113583,23 @@ impl ::std::convert::From<SignalRef> for WordcloudTransformFontSizeRange {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum WordcloudTransformFontSizeRangeVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum WordcloudTransformFontSizeRangeArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for WordcloudTransformFontSizeRangeVariant0Item {
-    fn from(value: &WordcloudTransformFontSizeRangeVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for WordcloudTransformFontSizeRangeArrayItem {
+    fn from(value: &WordcloudTransformFontSizeRangeArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for WordcloudTransformFontSizeRangeVariant0Item {
+impl ::std::convert::From<f64> for WordcloudTransformFontSizeRangeArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for WordcloudTransformFontSizeRangeVariant0Item {
+impl ::std::convert::From<SignalRef> for WordcloudTransformFontSizeRangeArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`WordcloudTransformFontStyle`"]
@@ -113687,10 +113629,10 @@ impl ::std::convert::From<SignalRef> for WordcloudTransformFontSizeRangeVariant0
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum WordcloudTransformFontStyle {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
-    Variant2(Expr),
-    Variant3(ParamField),
+    String(::std::string::String),
+    SignalRef(SignalRef),
+    Expr(Expr),
+    ParamField(ParamField),
 }
 impl ::std::convert::From<&Self> for WordcloudTransformFontStyle {
     fn from(value: &WordcloudTransformFontStyle) -> Self {
@@ -113699,22 +113641,22 @@ impl ::std::convert::From<&Self> for WordcloudTransformFontStyle {
 }
 impl ::std::default::Default for WordcloudTransformFontStyle {
     fn default() -> Self {
-        WordcloudTransformFontStyle::Variant0("normal".to_string())
+        WordcloudTransformFontStyle::String("normal".to_string())
     }
 }
 impl ::std::convert::From<SignalRef> for WordcloudTransformFontStyle {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 impl ::std::convert::From<Expr> for WordcloudTransformFontStyle {
     fn from(value: Expr) -> Self {
-        Self::Variant2(value)
+        Self::Expr(value)
     }
 }
 impl ::std::convert::From<ParamField> for WordcloudTransformFontStyle {
     fn from(value: ParamField) -> Self {
-        Self::Variant3(value)
+        Self::ParamField(value)
     }
 }
 #[doc = "`WordcloudTransformFontWeight`"]
@@ -113744,10 +113686,10 @@ impl ::std::convert::From<ParamField> for WordcloudTransformFontStyle {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum WordcloudTransformFontWeight {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
-    Variant2(Expr),
-    Variant3(ParamField),
+    String(::std::string::String),
+    SignalRef(SignalRef),
+    Expr(Expr),
+    ParamField(ParamField),
 }
 impl ::std::convert::From<&Self> for WordcloudTransformFontWeight {
     fn from(value: &WordcloudTransformFontWeight) -> Self {
@@ -113756,22 +113698,22 @@ impl ::std::convert::From<&Self> for WordcloudTransformFontWeight {
 }
 impl ::std::default::Default for WordcloudTransformFontWeight {
     fn default() -> Self {
-        WordcloudTransformFontWeight::Variant0("normal".to_string())
+        WordcloudTransformFontWeight::String("normal".to_string())
     }
 }
 impl ::std::convert::From<SignalRef> for WordcloudTransformFontWeight {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 impl ::std::convert::From<Expr> for WordcloudTransformFontWeight {
     fn from(value: Expr) -> Self {
-        Self::Variant2(value)
+        Self::Expr(value)
     }
 }
 impl ::std::convert::From<ParamField> for WordcloudTransformFontWeight {
     fn from(value: ParamField) -> Self {
-        Self::Variant3(value)
+        Self::ParamField(value)
     }
 }
 #[doc = "`WordcloudTransformPadding`"]
@@ -113800,10 +113742,10 @@ impl ::std::convert::From<ParamField> for WordcloudTransformFontWeight {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum WordcloudTransformPadding {
-    Variant0(f64),
-    Variant1(SignalRef),
-    Variant2(Expr),
-    Variant3(ParamField),
+    Number(f64),
+    SignalRef(SignalRef),
+    Expr(Expr),
+    ParamField(ParamField),
 }
 impl ::std::convert::From<&Self> for WordcloudTransformPadding {
     fn from(value: &WordcloudTransformPadding) -> Self {
@@ -113812,22 +113754,22 @@ impl ::std::convert::From<&Self> for WordcloudTransformPadding {
 }
 impl ::std::convert::From<f64> for WordcloudTransformPadding {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for WordcloudTransformPadding {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 impl ::std::convert::From<Expr> for WordcloudTransformPadding {
     fn from(value: Expr) -> Self {
-        Self::Variant2(value)
+        Self::Expr(value)
     }
 }
 impl ::std::convert::From<ParamField> for WordcloudTransformPadding {
     fn from(value: ParamField) -> Self {
-        Self::Variant3(value)
+        Self::ParamField(value)
     }
 }
 #[doc = "`WordcloudTransformRotate`"]
@@ -113856,10 +113798,10 @@ impl ::std::convert::From<ParamField> for WordcloudTransformPadding {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum WordcloudTransformRotate {
-    Variant0(f64),
-    Variant1(SignalRef),
-    Variant2(Expr),
-    Variant3(ParamField),
+    Number(f64),
+    SignalRef(SignalRef),
+    Expr(Expr),
+    ParamField(ParamField),
 }
 impl ::std::convert::From<&Self> for WordcloudTransformRotate {
     fn from(value: &WordcloudTransformRotate) -> Self {
@@ -113868,22 +113810,22 @@ impl ::std::convert::From<&Self> for WordcloudTransformRotate {
 }
 impl ::std::convert::From<f64> for WordcloudTransformRotate {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
 impl ::std::convert::From<SignalRef> for WordcloudTransformRotate {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 impl ::std::convert::From<Expr> for WordcloudTransformRotate {
     fn from(value: Expr) -> Self {
-        Self::Variant2(value)
+        Self::Expr(value)
     }
 }
 impl ::std::convert::From<ParamField> for WordcloudTransformRotate {
     fn from(value: ParamField) -> Self {
-        Self::Variant3(value)
+        Self::ParamField(value)
     }
 }
 #[doc = "`WordcloudTransformSize`"]
@@ -113918,25 +113860,25 @@ impl ::std::convert::From<ParamField> for WordcloudTransformRotate {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum WordcloudTransformSize {
-    Variant0([WordcloudTransformSizeVariant0Item; 2usize]),
-    Variant1(SignalRef),
+    Array([WordcloudTransformSizeArrayItem; 2usize]),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for WordcloudTransformSize {
     fn from(value: &WordcloudTransformSize) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<[WordcloudTransformSizeVariant0Item; 2usize]> for WordcloudTransformSize {
-    fn from(value: [WordcloudTransformSizeVariant0Item; 2usize]) -> Self {
-        Self::Variant0(value)
+impl ::std::convert::From<[WordcloudTransformSizeArrayItem; 2usize]> for WordcloudTransformSize {
+    fn from(value: [WordcloudTransformSizeArrayItem; 2usize]) -> Self {
+        Self::Array(value)
     }
 }
 impl ::std::convert::From<SignalRef> for WordcloudTransformSize {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
-#[doc = "`WordcloudTransformSizeVariant0Item`"]
+#[doc = "`WordcloudTransformSizeArrayItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -113955,23 +113897,23 @@ impl ::std::convert::From<SignalRef> for WordcloudTransformSize {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum WordcloudTransformSizeVariant0Item {
-    Variant0(f64),
-    Variant1(SignalRef),
+pub enum WordcloudTransformSizeArrayItem {
+    Number(f64),
+    SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for WordcloudTransformSizeVariant0Item {
-    fn from(value: &WordcloudTransformSizeVariant0Item) -> Self {
+impl ::std::convert::From<&Self> for WordcloudTransformSizeArrayItem {
+    fn from(value: &WordcloudTransformSizeArrayItem) -> Self {
         value.clone()
     }
 }
-impl ::std::convert::From<f64> for WordcloudTransformSizeVariant0Item {
+impl ::std::convert::From<f64> for WordcloudTransformSizeArrayItem {
     fn from(value: f64) -> Self {
-        Self::Variant0(value)
+        Self::Number(value)
     }
 }
-impl ::std::convert::From<SignalRef> for WordcloudTransformSizeVariant0Item {
+impl ::std::convert::From<SignalRef> for WordcloudTransformSizeArrayItem {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`WordcloudTransformSpiral`"]
@@ -113994,8 +113936,8 @@ impl ::std::convert::From<SignalRef> for WordcloudTransformSizeVariant0Item {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum WordcloudTransformSpiral {
-    Variant0(::std::string::String),
-    Variant1(SignalRef),
+    String(::std::string::String),
+    SignalRef(SignalRef),
 }
 impl ::std::convert::From<&Self> for WordcloudTransformSpiral {
     fn from(value: &WordcloudTransformSpiral) -> Self {
@@ -114004,7 +113946,7 @@ impl ::std::convert::From<&Self> for WordcloudTransformSpiral {
 }
 impl ::std::convert::From<SignalRef> for WordcloudTransformSpiral {
     fn from(value: SignalRef) -> Self {
-        Self::Variant1(value)
+        Self::SignalRef(value)
     }
 }
 #[doc = "`WordcloudTransformText`"]
@@ -114138,179 +114080,179 @@ pub mod defaults {
         T::try_from(V).unwrap()
     }
     pub(super) fn aggregate_transform_drop() -> super::AggregateTransformDrop {
-        super::AggregateTransformDrop::Variant0(true)
+        super::AggregateTransformDrop::Boolean(true)
     }
     pub(super) fn bin_transform_as() -> super::BinTransformAs {
-        super::BinTransformAs::Variant0([
-            super::BinTransformAsVariant0Item::Variant0("bin0".to_string()),
-            super::BinTransformAsVariant0Item::Variant0("bin1".to_string()),
+        super::BinTransformAs::Array([
+            super::BinTransformAsArrayItem::String("bin0".to_string()),
+            super::BinTransformAsArrayItem::String("bin1".to_string()),
         ])
     }
     pub(super) fn bin_transform_base() -> super::BinTransformBase {
-        super::BinTransformBase::Variant0(10_f64)
+        super::BinTransformBase::Number(10_f64)
     }
     pub(super) fn bin_transform_divide() -> super::BinTransformDivide {
-        super::BinTransformDivide::Variant0(vec![
-            super::BinTransformDivideVariant0Item::Variant0(5_f64),
-            super::BinTransformDivideVariant0Item::Variant0(2_f64),
+        super::BinTransformDivide::Array(vec![
+            super::BinTransformDivideArrayItem::Number(5_f64),
+            super::BinTransformDivideArrayItem::Number(2_f64),
         ])
     }
     pub(super) fn bin_transform_interval() -> super::BinTransformInterval {
-        super::BinTransformInterval::Variant0(true)
+        super::BinTransformInterval::Boolean(true)
     }
     pub(super) fn bin_transform_maxbins() -> super::BinTransformMaxbins {
-        super::BinTransformMaxbins::Variant0(20_f64)
+        super::BinTransformMaxbins::Number(20_f64)
     }
     pub(super) fn bin_transform_nice() -> super::BinTransformNice {
-        super::BinTransformNice::Variant0(true)
+        super::BinTransformNice::Boolean(true)
     }
     pub(super) fn contour_transform_smooth() -> super::ContourTransformSmooth {
-        super::ContourTransformSmooth::Variant0(true)
+        super::ContourTransformSmooth::Boolean(true)
     }
     pub(super) fn countpattern_transform_as() -> super::CountpatternTransformAs {
-        super::CountpatternTransformAs::Variant0([
-            super::CountpatternTransformAsVariant0Item::Variant0("text".to_string()),
-            super::CountpatternTransformAsVariant0Item::Variant0("count".to_string()),
+        super::CountpatternTransformAs::Array([
+            super::CountpatternTransformAsArrayItem::String("text".to_string()),
+            super::CountpatternTransformAsArrayItem::String("count".to_string()),
         ])
     }
     pub(super) fn countpattern_transform_case() -> super::CountpatternTransformCase {
         super::CountpatternTransformCase::Variant0(super::CountpatternTransformCaseVariant0::Mixed)
     }
     pub(super) fn countpattern_transform_pattern() -> super::CountpatternTransformPattern {
-        super::CountpatternTransformPattern::Variant0("[\\w\"]+".to_string())
+        super::CountpatternTransformPattern::String("[\\w\"]+".to_string())
     }
     pub(super) fn cross_transform_as() -> super::CrossTransformAs {
-        super::CrossTransformAs::Variant0([
-            super::CrossTransformAsVariant0Item::Variant0("a".to_string()),
-            super::CrossTransformAsVariant0Item::Variant0("b".to_string()),
+        super::CrossTransformAs::Array([
+            super::CrossTransformAsArrayItem::String("a".to_string()),
+            super::CrossTransformAsArrayItem::String("b".to_string()),
         ])
     }
     pub(super) fn density_transform_as() -> super::DensityTransformAs {
-        super::DensityTransformAs::Variant0(vec![
-            super::DensityTransformAsVariant0Item::Variant0("value".to_string()),
-            super::DensityTransformAsVariant0Item::Variant0("density".to_string()),
+        super::DensityTransformAs::Array(vec![
+            super::DensityTransformAsArrayItem::String("value".to_string()),
+            super::DensityTransformAsArrayItem::String("density".to_string()),
         ])
     }
     pub(super) fn density_transform_maxsteps() -> super::DensityTransformMaxsteps {
-        super::DensityTransformMaxsteps::Variant0(200_f64)
+        super::DensityTransformMaxsteps::Number(200_f64)
     }
     pub(super) fn density_transform_method() -> super::DensityTransformMethod {
-        super::DensityTransformMethod::Variant0("pdf".to_string())
+        super::DensityTransformMethod::String("pdf".to_string())
     }
     pub(super) fn density_transform_minsteps() -> super::DensityTransformMinsteps {
-        super::DensityTransformMinsteps::Variant0(25_f64)
+        super::DensityTransformMinsteps::Number(25_f64)
     }
     pub(super) fn density_transform_distribution_lognormal_stdev(
     ) -> super::DensityTransformDistributionStdev {
-        super::DensityTransformDistributionStdev::Variant0(1_f64)
+        super::DensityTransformDistributionStdev::Number(1_f64)
     }
     pub(super) fn density_transform_distribution_normal_stdev(
     ) -> super::DensityTransformDistributionStdev {
-        super::DensityTransformDistributionStdev::Variant0(1_f64)
+        super::DensityTransformDistributionStdev::Number(1_f64)
     }
     pub(super) fn density_transform_distribution_uniform_max(
     ) -> super::DensityTransformDistributionMax {
-        super::DensityTransformDistributionMax::Variant0(1_f64)
+        super::DensityTransformDistributionMax::Number(1_f64)
     }
     pub(super) fn dotbin_transform_as() -> super::DotbinTransformAs {
-        super::DotbinTransformAs::Variant0("bin".to_string())
+        super::DotbinTransformAs::String("bin".to_string())
     }
     pub(super) fn fold_transform_as() -> super::FoldTransformAs {
-        super::FoldTransformAs::Variant0([
-            super::FoldTransformAsVariant0Item::Variant0("key".to_string()),
-            super::FoldTransformAsVariant0Item::Variant0("value".to_string()),
+        super::FoldTransformAs::Array([
+            super::FoldTransformAsArrayItem::String("key".to_string()),
+            super::FoldTransformAsArrayItem::String("value".to_string()),
         ])
     }
     pub(super) fn force_transform_alpha() -> super::ForceTransformAlpha {
-        super::ForceTransformAlpha::Variant0(1_f64)
+        super::ForceTransformAlpha::Number(1_f64)
     }
     pub(super) fn force_transform_alpha_min() -> super::ForceTransformAlphaMin {
-        super::ForceTransformAlphaMin::Variant0(0.001_f64)
+        super::ForceTransformAlphaMin::Number(0.001_f64)
     }
     pub(super) fn force_transform_as() -> super::ForceTransformAs {
-        super::ForceTransformAs::Variant0(vec![
-            super::ForceTransformAsVariant0Item::Variant0("x".to_string()),
-            super::ForceTransformAsVariant0Item::Variant0("y".to_string()),
-            super::ForceTransformAsVariant0Item::Variant0("vx".to_string()),
-            super::ForceTransformAsVariant0Item::Variant0("vy".to_string()),
+        super::ForceTransformAs::Array(vec![
+            super::ForceTransformAsArrayItem::String("x".to_string()),
+            super::ForceTransformAsArrayItem::String("y".to_string()),
+            super::ForceTransformAsArrayItem::String("vx".to_string()),
+            super::ForceTransformAsArrayItem::String("vy".to_string()),
         ])
     }
     pub(super) fn force_transform_iterations() -> super::ForceTransformIterations {
-        super::ForceTransformIterations::Variant0(300_f64)
+        super::ForceTransformIterations::Number(300_f64)
     }
     pub(super) fn force_transform_velocity_decay() -> super::ForceTransformVelocityDecay {
-        super::ForceTransformVelocityDecay::Variant0(0.4_f64)
+        super::ForceTransformVelocityDecay::Number(0.4_f64)
     }
     pub(super) fn force_transform_forces_item_collide_iterations(
     ) -> super::ForceTransformForcesItemIterations {
-        super::ForceTransformForcesItemIterations::Variant0(1_f64)
+        super::ForceTransformForcesItemIterations::Number(1_f64)
     }
     pub(super) fn force_transform_forces_item_collide_strength(
     ) -> super::ForceTransformForcesItemStrength {
-        super::ForceTransformForcesItemStrength::Variant0(0.7_f64)
+        super::ForceTransformForcesItemStrength::Number(0.7_f64)
     }
     pub(super) fn force_transform_forces_item_link_distance(
     ) -> super::ForceTransformForcesItemDistance {
-        super::ForceTransformForcesItemDistance::Variant0(30_f64)
+        super::ForceTransformForcesItemDistance::Number(30_f64)
     }
     pub(super) fn force_transform_forces_item_link_iterations(
     ) -> super::ForceTransformForcesItemIterations {
-        super::ForceTransformForcesItemIterations::Variant0(1_f64)
+        super::ForceTransformForcesItemIterations::Number(1_f64)
     }
     pub(super) fn force_transform_forces_item_nbody_distance_min(
     ) -> super::ForceTransformForcesItemDistanceMin {
-        super::ForceTransformForcesItemDistanceMin::Variant0(1_f64)
+        super::ForceTransformForcesItemDistanceMin::Number(1_f64)
     }
     pub(super) fn force_transform_forces_item_nbody_strength(
     ) -> super::ForceTransformForcesItemStrength {
-        super::ForceTransformForcesItemStrength::Variant0(-30_f64)
+        super::ForceTransformForcesItemStrength::Number(-30_f64)
     }
     pub(super) fn force_transform_forces_item_nbody_theta() -> super::ForceTransformForcesItemTheta
     {
-        super::ForceTransformForcesItemTheta::Variant0(0.9_f64)
+        super::ForceTransformForcesItemTheta::Number(0.9_f64)
     }
     pub(super) fn force_transform_forces_item_x_strength() -> super::ForceTransformForcesItemStrength
     {
-        super::ForceTransformForcesItemStrength::Variant0(0.1_f64)
+        super::ForceTransformForcesItemStrength::Number(0.1_f64)
     }
     pub(super) fn force_transform_forces_item_y_strength() -> super::ForceTransformForcesItemStrength
     {
-        super::ForceTransformForcesItemStrength::Variant0(0.1_f64)
+        super::ForceTransformForcesItemStrength::Number(0.1_f64)
     }
     pub(super) fn geopath_transform_as() -> super::GeopathTransformAs {
-        super::GeopathTransformAs::Variant0("path".to_string())
+        super::GeopathTransformAs::String("path".to_string())
     }
     pub(super) fn geopoint_transform_as() -> super::GeopointTransformAs {
-        super::GeopointTransformAs::Variant0([
-            super::GeopointTransformAsVariant0Item::Variant0("x".to_string()),
-            super::GeopointTransformAsVariant0Item::Variant0("y".to_string()),
+        super::GeopointTransformAs::Array([
+            super::GeopointTransformAsArrayItem::String("x".to_string()),
+            super::GeopointTransformAsArrayItem::String("y".to_string()),
         ])
     }
     pub(super) fn geoshape_transform_as() -> super::GeoshapeTransformAs {
-        super::GeoshapeTransformAs::Variant0("shape".to_string())
+        super::GeoshapeTransformAs::String("shape".to_string())
     }
     pub(super) fn geoshape_transform_field() -> super::GeoshapeTransformField {
-        super::GeoshapeTransformField::ScaleField(super::ScaleField(
-            super::StringOrSignal::Variant0("datum".to_string()),
-        ))
+        super::GeoshapeTransformField::ScaleField(super::ScaleField(super::StringOrSignal::String(
+            "datum".to_string(),
+        )))
     }
     pub(super) fn graticule_transform_precision() -> super::GraticuleTransformPrecision {
-        super::GraticuleTransformPrecision::Variant0(2.5_f64)
+        super::GraticuleTransformPrecision::Number(2.5_f64)
     }
     pub(super) fn graticule_transform_step_major() -> super::GraticuleTransformStepMajor {
-        super::GraticuleTransformStepMajor::Variant0([
-            super::GraticuleTransformStepMajorVariant0Item::Variant0(90_f64),
-            super::GraticuleTransformStepMajorVariant0Item::Variant0(360_f64),
+        super::GraticuleTransformStepMajor::Array([
+            super::GraticuleTransformStepMajorArrayItem::Number(90_f64),
+            super::GraticuleTransformStepMajorArrayItem::Number(360_f64),
         ])
     }
     pub(super) fn graticule_transform_step_minor() -> super::GraticuleTransformStepMinor {
-        super::GraticuleTransformStepMinor::Variant0([
-            super::GraticuleTransformStepMinorVariant0Item::Variant0(10_f64),
-            super::GraticuleTransformStepMinorVariant0Item::Variant0(10_f64),
+        super::GraticuleTransformStepMinor::Array([
+            super::GraticuleTransformStepMinorArrayItem::Number(10_f64),
+            super::GraticuleTransformStepMinorArrayItem::Number(10_f64),
         ])
     }
     pub(super) fn heatmap_transform_as() -> super::HeatmapTransformAs {
-        super::HeatmapTransformAs::Variant0("image".to_string())
+        super::HeatmapTransformAs::String("image".to_string())
     }
     pub(super) fn heatmap_transform_resolve() -> super::HeatmapTransformResolve {
         super::HeatmapTransformResolve::Variant0(
@@ -114321,7 +114263,7 @@ pub mod defaults {
         super::ImputeTransformMethod::Variant0(super::ImputeTransformMethodVariant0::Value)
     }
     pub(super) fn isocontour_transform_as() -> super::IsocontourTransformAs {
-        super::IsocontourTransformAs::Variant0("contour".to_string())
+        super::IsocontourTransformAs::String("contour".to_string())
     }
     pub(super) fn isocontour_transform_resolve() -> super::IsocontourTransformResolve {
         super::IsocontourTransformResolve::Variant0(
@@ -114329,66 +114271,66 @@ pub mod defaults {
         )
     }
     pub(super) fn isocontour_transform_smooth() -> super::IsocontourTransformSmooth {
-        super::IsocontourTransformSmooth::Variant0(true)
+        super::IsocontourTransformSmooth::Boolean(true)
     }
     pub(super) fn isocontour_transform_zero() -> super::IsocontourTransformZero {
-        super::IsocontourTransformZero::Variant0(true)
+        super::IsocontourTransformZero::Boolean(true)
     }
     pub(super) fn kde2d_transform_as() -> super::Kde2dTransformAs {
-        super::Kde2dTransformAs::Variant0("grid".to_string())
+        super::Kde2dTransformAs::String("grid".to_string())
     }
     pub(super) fn kde_transform_as() -> super::KdeTransformAs {
-        super::KdeTransformAs::Variant0(vec![
-            super::KdeTransformAsVariant0Item::Variant0("value".to_string()),
-            super::KdeTransformAsVariant0Item::Variant0("density".to_string()),
+        super::KdeTransformAs::Array(vec![
+            super::KdeTransformAsArrayItem::String("value".to_string()),
+            super::KdeTransformAsArrayItem::String("density".to_string()),
         ])
     }
     pub(super) fn kde_transform_maxsteps() -> super::KdeTransformMaxsteps {
-        super::KdeTransformMaxsteps::Variant0(200_f64)
+        super::KdeTransformMaxsteps::Number(200_f64)
     }
     pub(super) fn kde_transform_minsteps() -> super::KdeTransformMinsteps {
-        super::KdeTransformMinsteps::Variant0(25_f64)
+        super::KdeTransformMinsteps::Number(25_f64)
     }
     pub(super) fn kde_transform_resolve() -> super::KdeTransformResolve {
         super::KdeTransformResolve::Variant0(super::KdeTransformResolveVariant0::Independent)
     }
     pub(super) fn label_transform_anchor() -> super::LabelTransformAnchor {
-        super::LabelTransformAnchor::Variant0(vec![
-            super::LabelTransformAnchorVariant0Item::Variant0("top-left".to_string()),
-            super::LabelTransformAnchorVariant0Item::Variant0("left".to_string()),
-            super::LabelTransformAnchorVariant0Item::Variant0("bottom-left".to_string()),
-            super::LabelTransformAnchorVariant0Item::Variant0("top".to_string()),
-            super::LabelTransformAnchorVariant0Item::Variant0("bottom".to_string()),
-            super::LabelTransformAnchorVariant0Item::Variant0("top-right".to_string()),
-            super::LabelTransformAnchorVariant0Item::Variant0("right".to_string()),
-            super::LabelTransformAnchorVariant0Item::Variant0("bottom-right".to_string()),
+        super::LabelTransformAnchor::Array(vec![
+            super::LabelTransformAnchorArrayItem::String("top-left".to_string()),
+            super::LabelTransformAnchorArrayItem::String("left".to_string()),
+            super::LabelTransformAnchorArrayItem::String("bottom-left".to_string()),
+            super::LabelTransformAnchorArrayItem::String("top".to_string()),
+            super::LabelTransformAnchorArrayItem::String("bottom".to_string()),
+            super::LabelTransformAnchorArrayItem::String("top-right".to_string()),
+            super::LabelTransformAnchorArrayItem::String("right".to_string()),
+            super::LabelTransformAnchorArrayItem::String("bottom-right".to_string()),
         ])
     }
     pub(super) fn label_transform_as() -> super::LabelTransformAs {
-        super::LabelTransformAs::Variant0([
-            super::LabelTransformAsVariant0Item::Variant0("x".to_string()),
-            super::LabelTransformAsVariant0Item::Variant0("y".to_string()),
-            super::LabelTransformAsVariant0Item::Variant0("opacity".to_string()),
-            super::LabelTransformAsVariant0Item::Variant0("align".to_string()),
-            super::LabelTransformAsVariant0Item::Variant0("baseline".to_string()),
+        super::LabelTransformAs::Array([
+            super::LabelTransformAsArrayItem::String("x".to_string()),
+            super::LabelTransformAsArrayItem::String("y".to_string()),
+            super::LabelTransformAsArrayItem::String("opacity".to_string()),
+            super::LabelTransformAsArrayItem::String("align".to_string()),
+            super::LabelTransformAsArrayItem::String("baseline".to_string()),
         ])
     }
     pub(super) fn label_transform_avoid_base_mark() -> super::LabelTransformAvoidBaseMark {
-        super::LabelTransformAvoidBaseMark::Variant0(true)
+        super::LabelTransformAvoidBaseMark::Boolean(true)
     }
     pub(super) fn label_transform_line_anchor() -> super::LabelTransformLineAnchor {
-        super::LabelTransformLineAnchor::Variant0("end".to_string())
+        super::LabelTransformLineAnchor::String("end".to_string())
     }
     pub(super) fn label_transform_method() -> super::LabelTransformMethod {
-        super::LabelTransformMethod::Variant0("naive".to_string())
+        super::LabelTransformMethod::String("naive".to_string())
     }
     pub(super) fn label_transform_offset() -> super::LabelTransformOffset {
-        super::LabelTransformOffset::Variant0(vec![
-            super::LabelTransformOffsetVariant0Item::Variant0(1_f64),
-        ])
+        super::LabelTransformOffset::Array(vec![super::LabelTransformOffsetArrayItem::Number(
+            1_f64,
+        )])
     }
     pub(super) fn linkpath_transform_as() -> super::LinkpathTransformAs {
-        super::LinkpathTransformAs::Variant0("path".to_string())
+        super::LinkpathTransformAs::String("path".to_string())
     }
     pub(super) fn linkpath_transform_orient() -> super::LinkpathTransformOrient {
         super::LinkpathTransformOrient::Variant0(super::LinkpathTransformOrientVariant0::Vertical)
@@ -114398,181 +114340,181 @@ pub mod defaults {
     }
     pub(super) fn linkpath_transform_source_x() -> super::LinkpathTransformSourceX {
         super::LinkpathTransformSourceX::ScaleField(super::ScaleField(
-            super::StringOrSignal::Variant0("source.x".to_string()),
+            super::StringOrSignal::String("source.x".to_string()),
         ))
     }
     pub(super) fn linkpath_transform_source_y() -> super::LinkpathTransformSourceY {
         super::LinkpathTransformSourceY::ScaleField(super::ScaleField(
-            super::StringOrSignal::Variant0("source.y".to_string()),
+            super::StringOrSignal::String("source.y".to_string()),
         ))
     }
     pub(super) fn linkpath_transform_target_x() -> super::LinkpathTransformTargetX {
         super::LinkpathTransformTargetX::ScaleField(super::ScaleField(
-            super::StringOrSignal::Variant0("target.x".to_string()),
+            super::StringOrSignal::String("target.x".to_string()),
         ))
     }
     pub(super) fn linkpath_transform_target_y() -> super::LinkpathTransformTargetY {
         super::LinkpathTransformTargetY::ScaleField(super::ScaleField(
-            super::StringOrSignal::Variant0("target.y".to_string()),
+            super::StringOrSignal::String("target.y".to_string()),
         ))
     }
     pub(super) fn loess_transform_bandwidth() -> super::LoessTransformBandwidth {
-        super::LoessTransformBandwidth::Variant0(0.3_f64)
+        super::LoessTransformBandwidth::Number(0.3_f64)
     }
     pub(super) fn pack_transform_as() -> super::PackTransformAs {
-        super::PackTransformAs::Variant0([
-            super::PackTransformAsVariant0Item::Variant0("x".to_string()),
-            super::PackTransformAsVariant0Item::Variant0("y".to_string()),
-            super::PackTransformAsVariant0Item::Variant0("r".to_string()),
-            super::PackTransformAsVariant0Item::Variant0("depth".to_string()),
-            super::PackTransformAsVariant0Item::Variant0("children".to_string()),
+        super::PackTransformAs::Array([
+            super::PackTransformAsArrayItem::String("x".to_string()),
+            super::PackTransformAsArrayItem::String("y".to_string()),
+            super::PackTransformAsArrayItem::String("r".to_string()),
+            super::PackTransformAsArrayItem::String("depth".to_string()),
+            super::PackTransformAsArrayItem::String("children".to_string()),
         ])
     }
     pub(super) fn partition_transform_as() -> super::PartitionTransformAs {
-        super::PartitionTransformAs::Variant0([
-            super::PartitionTransformAsVariant0Item::Variant0("x0".to_string()),
-            super::PartitionTransformAsVariant0Item::Variant0("y0".to_string()),
-            super::PartitionTransformAsVariant0Item::Variant0("x1".to_string()),
-            super::PartitionTransformAsVariant0Item::Variant0("y1".to_string()),
-            super::PartitionTransformAsVariant0Item::Variant0("depth".to_string()),
-            super::PartitionTransformAsVariant0Item::Variant0("children".to_string()),
+        super::PartitionTransformAs::Array([
+            super::PartitionTransformAsArrayItem::String("x0".to_string()),
+            super::PartitionTransformAsArrayItem::String("y0".to_string()),
+            super::PartitionTransformAsArrayItem::String("x1".to_string()),
+            super::PartitionTransformAsArrayItem::String("y1".to_string()),
+            super::PartitionTransformAsArrayItem::String("depth".to_string()),
+            super::PartitionTransformAsArrayItem::String("children".to_string()),
         ])
     }
     pub(super) fn pie_transform_as() -> super::PieTransformAs {
-        super::PieTransformAs::Variant0([
-            super::PieTransformAsVariant0Item::Variant0("startAngle".to_string()),
-            super::PieTransformAsVariant0Item::Variant0("endAngle".to_string()),
+        super::PieTransformAs::Array([
+            super::PieTransformAsArrayItem::String("startAngle".to_string()),
+            super::PieTransformAsArrayItem::String("endAngle".to_string()),
         ])
     }
     pub(super) fn pie_transform_end_angle() -> super::PieTransformEndAngle {
-        super::PieTransformEndAngle::Variant0(6.283185307179586_f64)
+        super::PieTransformEndAngle::Number(6.283185307179586_f64)
     }
     pub(super) fn pivot_transform_op() -> super::PivotTransformOp {
         super::PivotTransformOp::Variant0(super::PivotTransformOpVariant0::Sum)
     }
     pub(super) fn quantile_transform_as() -> super::QuantileTransformAs {
-        super::QuantileTransformAs::Variant0(vec![
-            super::QuantileTransformAsVariant0Item::Variant0("prob".to_string()),
-            super::QuantileTransformAsVariant0Item::Variant0("value".to_string()),
+        super::QuantileTransformAs::Array(vec![
+            super::QuantileTransformAsArrayItem::String("prob".to_string()),
+            super::QuantileTransformAsArrayItem::String("value".to_string()),
         ])
     }
     pub(super) fn quantile_transform_step() -> super::QuantileTransformStep {
-        super::QuantileTransformStep::Variant0(0.01_f64)
+        super::QuantileTransformStep::Number(0.01_f64)
     }
     pub(super) fn regression_transform_method() -> super::RegressionTransformMethod {
-        super::RegressionTransformMethod::Variant0("linear".to_string())
+        super::RegressionTransformMethod::String("linear".to_string())
     }
     pub(super) fn regression_transform_order() -> super::RegressionTransformOrder {
-        super::RegressionTransformOrder::Variant0(3_f64)
+        super::RegressionTransformOrder::Number(3_f64)
     }
     pub(super) fn sample_transform_size() -> super::SampleTransformSize {
-        super::SampleTransformSize::Variant0(1000_f64)
+        super::SampleTransformSize::Number(1000_f64)
     }
     pub(super) fn sequence_transform_as() -> super::SequenceTransformAs {
-        super::SequenceTransformAs::Variant0("data".to_string())
+        super::SequenceTransformAs::String("data".to_string())
     }
     pub(super) fn sequence_transform_step() -> super::SequenceTransformStep {
-        super::SequenceTransformStep::Variant0(1_f64)
+        super::SequenceTransformStep::Number(1_f64)
     }
     pub(super) fn stack_transform_as() -> super::StackTransformAs {
-        super::StackTransformAs::Variant0([
-            super::StackTransformAsVariant0Item::Variant0("y0".to_string()),
-            super::StackTransformAsVariant0Item::Variant0("y1".to_string()),
+        super::StackTransformAs::Array([
+            super::StackTransformAsArrayItem::String("y0".to_string()),
+            super::StackTransformAsArrayItem::String("y1".to_string()),
         ])
     }
     pub(super) fn stack_transform_offset() -> super::StackTransformOffset {
         super::StackTransformOffset::Variant0(super::StackTransformOffsetVariant0::Zero)
     }
     pub(super) fn timeunit_transform_as() -> super::TimeunitTransformAs {
-        super::TimeunitTransformAs::Variant0([
-            super::TimeunitTransformAsVariant0Item::Variant0("unit0".to_string()),
-            super::TimeunitTransformAsVariant0Item::Variant0("unit1".to_string()),
+        super::TimeunitTransformAs::Array([
+            super::TimeunitTransformAsArrayItem::String("unit0".to_string()),
+            super::TimeunitTransformAsArrayItem::String("unit1".to_string()),
         ])
     }
     pub(super) fn timeunit_transform_interval() -> super::TimeunitTransformInterval {
-        super::TimeunitTransformInterval::Variant0(true)
+        super::TimeunitTransformInterval::Boolean(true)
     }
     pub(super) fn timeunit_transform_maxbins() -> super::TimeunitTransformMaxbins {
-        super::TimeunitTransformMaxbins::Variant0(40_f64)
+        super::TimeunitTransformMaxbins::Number(40_f64)
     }
     pub(super) fn timeunit_transform_step() -> super::TimeunitTransformStep {
-        super::TimeunitTransformStep::Variant0(1_f64)
+        super::TimeunitTransformStep::Number(1_f64)
     }
     pub(super) fn timeunit_transform_timezone() -> super::TimeunitTransformTimezone {
         super::TimeunitTransformTimezone::Variant0(super::TimeunitTransformTimezoneVariant0::Local)
     }
     pub(super) fn tree_transform_as() -> super::TreeTransformAs {
-        super::TreeTransformAs::Variant0([
-            super::TreeTransformAsVariant0Item::Variant0("x".to_string()),
-            super::TreeTransformAsVariant0Item::Variant0("y".to_string()),
-            super::TreeTransformAsVariant0Item::Variant0("depth".to_string()),
-            super::TreeTransformAsVariant0Item::Variant0("children".to_string()),
+        super::TreeTransformAs::Array([
+            super::TreeTransformAsArrayItem::String("x".to_string()),
+            super::TreeTransformAsArrayItem::String("y".to_string()),
+            super::TreeTransformAsArrayItem::String("depth".to_string()),
+            super::TreeTransformAsArrayItem::String("children".to_string()),
         ])
     }
     pub(super) fn tree_transform_method() -> super::TreeTransformMethod {
         super::TreeTransformMethod::Variant0(super::TreeTransformMethodVariant0::Tidy)
     }
     pub(super) fn tree_transform_separation() -> super::TreeTransformSeparation {
-        super::TreeTransformSeparation::Variant0(true)
+        super::TreeTransformSeparation::Boolean(true)
     }
     pub(super) fn treemap_transform_as() -> super::TreemapTransformAs {
-        super::TreemapTransformAs::Variant0([
-            super::TreemapTransformAsVariant0Item::Variant0("x0".to_string()),
-            super::TreemapTransformAsVariant0Item::Variant0("y0".to_string()),
-            super::TreemapTransformAsVariant0Item::Variant0("x1".to_string()),
-            super::TreemapTransformAsVariant0Item::Variant0("y1".to_string()),
-            super::TreemapTransformAsVariant0Item::Variant0("depth".to_string()),
-            super::TreemapTransformAsVariant0Item::Variant0("children".to_string()),
+        super::TreemapTransformAs::Array([
+            super::TreemapTransformAsArrayItem::String("x0".to_string()),
+            super::TreemapTransformAsArrayItem::String("y0".to_string()),
+            super::TreemapTransformAsArrayItem::String("x1".to_string()),
+            super::TreemapTransformAsArrayItem::String("y1".to_string()),
+            super::TreemapTransformAsArrayItem::String("depth".to_string()),
+            super::TreemapTransformAsArrayItem::String("children".to_string()),
         ])
     }
     pub(super) fn treemap_transform_method() -> super::TreemapTransformMethod {
         super::TreemapTransformMethod::Variant0(super::TreemapTransformMethodVariant0::Squarify)
     }
     pub(super) fn treemap_transform_ratio() -> super::TreemapTransformRatio {
-        super::TreemapTransformRatio::Variant0(1.618033988749895_f64)
+        super::TreemapTransformRatio::Number(1.618033988749895_f64)
     }
     pub(super) fn voronoi_transform_as() -> super::VoronoiTransformAs {
-        super::VoronoiTransformAs::Variant0("path".to_string())
+        super::VoronoiTransformAs::String("path".to_string())
     }
     pub(super) fn voronoi_transform_extent() -> super::VoronoiTransformExtent {
-        super::VoronoiTransformExtent::Variant0([
+        super::VoronoiTransformExtent::Array([
             ::serde_json::from_str::<::serde_json::Value>("[-100000,-100000]").unwrap(),
             ::serde_json::from_str::<::serde_json::Value>("[100000,100000]").unwrap(),
         ])
     }
     pub(super) fn window_transform_frame() -> super::WindowTransformFrame {
-        super::WindowTransformFrame::Variant0([
-            super::WindowTransformFrameVariant0Item::Variant2,
-            super::WindowTransformFrameVariant0Item::Variant0(0_f64),
+        super::WindowTransformFrame::Array([
+            super::WindowTransformFrameArrayItem::Null,
+            super::WindowTransformFrameArrayItem::Number(0_f64),
         ])
     }
     pub(super) fn wordcloud_transform_as() -> super::WordcloudTransformAs {
-        super::WordcloudTransformAs::Variant0([
-            super::WordcloudTransformAsVariant0Item::Variant0("x".to_string()),
-            super::WordcloudTransformAsVariant0Item::Variant0("y".to_string()),
-            super::WordcloudTransformAsVariant0Item::Variant0("font".to_string()),
-            super::WordcloudTransformAsVariant0Item::Variant0("fontSize".to_string()),
-            super::WordcloudTransformAsVariant0Item::Variant0("fontStyle".to_string()),
-            super::WordcloudTransformAsVariant0Item::Variant0("fontWeight".to_string()),
-            super::WordcloudTransformAsVariant0Item::Variant0("angle".to_string()),
+        super::WordcloudTransformAs::Array([
+            super::WordcloudTransformAsArrayItem::String("x".to_string()),
+            super::WordcloudTransformAsArrayItem::String("y".to_string()),
+            super::WordcloudTransformAsArrayItem::String("font".to_string()),
+            super::WordcloudTransformAsArrayItem::String("fontSize".to_string()),
+            super::WordcloudTransformAsArrayItem::String("fontStyle".to_string()),
+            super::WordcloudTransformAsArrayItem::String("fontWeight".to_string()),
+            super::WordcloudTransformAsArrayItem::String("angle".to_string()),
         ])
     }
     pub(super) fn wordcloud_transform_font() -> super::WordcloudTransformFont {
-        super::WordcloudTransformFont::Variant0("sans-serif".to_string())
+        super::WordcloudTransformFont::String("sans-serif".to_string())
     }
     pub(super) fn wordcloud_transform_font_size() -> super::WordcloudTransformFontSize {
-        super::WordcloudTransformFontSize::Variant0(14_f64)
+        super::WordcloudTransformFontSize::Number(14_f64)
     }
     pub(super) fn wordcloud_transform_font_size_range() -> super::WordcloudTransformFontSizeRange {
-        super::WordcloudTransformFontSizeRange::Variant0(vec![
-            super::WordcloudTransformFontSizeRangeVariant0Item::Variant0(10_f64),
-            super::WordcloudTransformFontSizeRangeVariant0Item::Variant0(50_f64),
+        super::WordcloudTransformFontSizeRange::Array(vec![
+            super::WordcloudTransformFontSizeRangeArrayItem::Number(10_f64),
+            super::WordcloudTransformFontSizeRangeArrayItem::Number(50_f64),
         ])
     }
     pub(super) fn wordcloud_transform_font_style() -> super::WordcloudTransformFontStyle {
-        super::WordcloudTransformFontStyle::Variant0("normal".to_string())
+        super::WordcloudTransformFontStyle::String("normal".to_string())
     }
     pub(super) fn wordcloud_transform_font_weight() -> super::WordcloudTransformFontWeight {
-        super::WordcloudTransformFontWeight::Variant0("normal".to_string())
+        super::WordcloudTransformFontWeight::String("normal".to_string())
     }
 }

--- a/typify/tests/schemas/id-or-name.rs
+++ b/typify/tests/schemas/id-or-name.rs
@@ -139,8 +139,8 @@ impl ::std::convert::From<Name> for IdOrName {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum IdOrNameRedundant {
-    Variant0(::uuid::Uuid),
-    Variant1(Name),
+    Uuid(::uuid::Uuid),
+    String(Name),
 }
 impl ::std::convert::From<&Self> for IdOrNameRedundant {
     fn from(value: &IdOrNameRedundant) -> Self {
@@ -151,9 +151,9 @@ impl ::std::str::FromStr for IdOrNameRedundant {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if let Ok(v) = value.parse() {
-            Ok(Self::Variant0(v))
+            Ok(Self::Uuid(v))
         } else if let Ok(v) = value.parse() {
-            Ok(Self::Variant1(v))
+            Ok(Self::String(v))
         } else {
             Err("string conversion failed for all variants".into())
         }
@@ -184,19 +184,19 @@ impl ::std::convert::TryFrom<::std::string::String> for IdOrNameRedundant {
 impl ::std::fmt::Display for IdOrNameRedundant {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
+            Self::Uuid(x) => x.fmt(f),
+            Self::String(x) => x.fmt(f),
         }
     }
 }
 impl ::std::convert::From<::uuid::Uuid> for IdOrNameRedundant {
     fn from(value: ::uuid::Uuid) -> Self {
-        Self::Variant0(value)
+        Self::Uuid(value)
     }
 }
 impl ::std::convert::From<Name> for IdOrNameRedundant {
     fn from(value: Name) -> Self {
-        Self::Variant1(value)
+        Self::String(value)
     }
 }
 #[doc = "`IdOrYolo`"]

--- a/typify/tests/schemas/rust-collisions.rs
+++ b/typify/tests/schemas/rust-collisions.rs
@@ -383,7 +383,7 @@ impl ::std::convert::TryFrom<::std::string::String> for FormatCollision {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum KeywordFieldsEnum {
-    Variant0 {
+    Object {
         #[serde(rename = "impl")]
         impl_: ::std::string::String,
         #[serde(rename = "match")]
@@ -393,7 +393,7 @@ pub enum KeywordFieldsEnum {
         #[serde(rename = "type")]
         type_: ::std::string::String,
     },
-    Variant1([::std::string::String; 2usize]),
+    Array([::std::string::String; 2usize]),
 }
 impl ::std::convert::From<&Self> for KeywordFieldsEnum {
     fn from(value: &KeywordFieldsEnum) -> Self {
@@ -402,7 +402,7 @@ impl ::std::convert::From<&Self> for KeywordFieldsEnum {
 }
 impl ::std::convert::From<[::std::string::String; 2usize]> for KeywordFieldsEnum {
     fn from(value: [::std::string::String; 2usize]) -> Self {
-        Self::Variant1(value)
+        Self::Array(value)
     }
 }
 #[doc = "`MapOfKeywords`"]

--- a/typify/tests/schemas/various-enums.json
+++ b/typify/tests/schemas/various-enums.json
@@ -26,6 +26,47 @@
         }
       ]
     },
+    "one-of-raw-type": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "one-of-missing-title": {
+      "type": "object",
+      "oneOf": [
+        {
+          "title": "A",
+          "properties": {
+            "foo": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "title": "B",
+          "properties": {
+            "bar": {
+              "type": "integer"
+            }
+          }
+        },
+        {
+          "properties": {
+            "bar": {
+              "type": "integer"
+            },
+            "baz": {
+              "type": "integer"
+            }
+          }
+        }        
+      ]
+    },
     "IpNet": {
       "$comment": "we want to see *nice* variant names in the output",
       "oneOf": [

--- a/typify/tests/schemas/various-enums.rs
+++ b/typify/tests/schemas/various-enums.rs
@@ -1097,6 +1097,108 @@ impl ::std::convert::TryFrom<::std::string::String> for NullStringEnumWithUnknow
         value.parse()
     }
 }
+#[doc = "`OneOfMissingTitle`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"title\": \"A\","]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"foo\": {"]
+#[doc = "          \"type\": \"string\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"title\": \"B\","]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"bar\": {"]
+#[doc = "          \"type\": \"integer\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"bar\": {"]
+#[doc = "          \"type\": \"integer\""]
+#[doc = "        },"]
+#[doc = "        \"baz\": {"]
+#[doc = "          \"type\": \"integer\""]
+#[doc = "        }"]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum OneOfMissingTitle {
+    Variant0 {
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        foo: ::std::option::Option<::std::string::String>,
+    },
+    Variant1 {
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        bar: ::std::option::Option<i64>,
+    },
+    Variant2 {
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        bar: ::std::option::Option<i64>,
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        baz: ::std::option::Option<i64>,
+    },
+}
+impl ::std::convert::From<&Self> for OneOfMissingTitle {
+    fn from(value: &OneOfMissingTitle) -> Self {
+        value.clone()
+    }
+}
+#[doc = "`OneOfRawType`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"integer\""]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum OneOfRawType {
+    String(::std::string::String),
+    Integer(i64),
+}
+impl ::std::convert::From<&Self> for OneOfRawType {
+    fn from(value: &OneOfRawType) -> Self {
+        value.clone()
+    }
+}
+impl ::std::fmt::Display for OneOfRawType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::String(x) => x.fmt(f),
+            Self::Integer(x) => x.fmt(f),
+        }
+    }
+}
+impl ::std::convert::From<i64> for OneOfRawType {
+    fn from(value: i64) -> Self {
+        Self::Integer(value)
+    }
+}
 #[doc = "`OneOfTypes`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -1486,8 +1588,8 @@ impl ::std::fmt::Display for ReferenceDef {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum References {
-    Variant0(::std::vec::Vec<::std::string::String>),
-    Variant1(::std::collections::HashMap<::std::string::String, ReferencesVariant1Value>),
+    Array(::std::vec::Vec<::std::string::String>),
+    Object(::std::collections::HashMap<::std::string::String, ReferencesObjectValue>),
 }
 impl ::std::convert::From<&Self> for References {
     fn from(value: &References) -> Self {
@@ -1496,21 +1598,19 @@ impl ::std::convert::From<&Self> for References {
 }
 impl ::std::convert::From<::std::vec::Vec<::std::string::String>> for References {
     fn from(value: ::std::vec::Vec<::std::string::String>) -> Self {
-        Self::Variant0(value)
+        Self::Array(value)
     }
 }
-impl
-    ::std::convert::From<
-        ::std::collections::HashMap<::std::string::String, ReferencesVariant1Value>,
-    > for References
+impl ::std::convert::From<::std::collections::HashMap<::std::string::String, ReferencesObjectValue>>
+    for References
 {
     fn from(
-        value: ::std::collections::HashMap<::std::string::String, ReferencesVariant1Value>,
+        value: ::std::collections::HashMap<::std::string::String, ReferencesObjectValue>,
     ) -> Self {
-        Self::Variant1(value)
+        Self::Object(value)
     }
 }
-#[doc = "`ReferencesVariant1Value`"]
+#[doc = "`ReferencesObjectValue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -1529,16 +1629,16 @@ impl
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
-pub enum ReferencesVariant1Value {
+pub enum ReferencesObjectValue {
     StringVersion(StringVersion),
     ReferenceDef(ReferenceDef),
 }
-impl ::std::convert::From<&Self> for ReferencesVariant1Value {
-    fn from(value: &ReferencesVariant1Value) -> Self {
+impl ::std::convert::From<&Self> for ReferencesObjectValue {
+    fn from(value: &ReferencesObjectValue) -> Self {
         value.clone()
     }
 }
-impl ::std::fmt::Display for ReferencesVariant1Value {
+impl ::std::fmt::Display for ReferencesObjectValue {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::StringVersion(x) => x.fmt(f),
@@ -1546,12 +1646,12 @@ impl ::std::fmt::Display for ReferencesVariant1Value {
         }
     }
 }
-impl ::std::convert::From<StringVersion> for ReferencesVariant1Value {
+impl ::std::convert::From<StringVersion> for ReferencesObjectValue {
     fn from(value: StringVersion) -> Self {
         Self::StringVersion(value)
     }
 }
-impl ::std::convert::From<ReferenceDef> for ReferencesVariant1Value {
+impl ::std::convert::From<ReferenceDef> for ReferencesObjectValue {
     fn from(value: ReferenceDef) -> Self {
         Self::ReferenceDef(value)
     }


### PR DESCRIPTION
This is a breaking change.

This PR achieves two things:

- ~~change the logic to allow for combinations of named an unnamed (`VariantN`) variants in enums, rather than an all-or-nothing approach~~
- improve the name-finding heuristic to give reasonable defaults for the 7 instance types

You can see the outcome on the codegen from the snapshot tests, and I have included a new snapshot test that exercises the partially-named case. 

I decided to keep the Variant number as its index in the overall type list, not as its index amongst unnamed types such that its name is stable under the addition or removal of metadata earlier in the schema that would add or remove inferred names.

This also changes the behaviour upon encountering duplicates. Previously, there was a later check to assert the code did not produce them. Now, in the case that the inferred name is the same for two or more variants, we just eject the affected enum back to `VariantN`