### PR TITLE
release typify 0.5.0

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,7 +13,13 @@
 
 == Unreleased changes (release date TBD)
 
-https://github.com/oxidecomputer/typify/compare/v0.4.3\...HEAD[Full list of commits]
+https://github.com/oxidecomputer/typify/compare/v0.5.0\...HEAD[Full list of commits]
+
+== 0.5.0 (released 2025-10-06)
+
+https://github.com/oxidecomputer/typify/compare/v0.4.3\...v0.5.0[Full list of commits]
+
+* use inferred union variant names in more cases (#894)
 
 == 0.4.3 (released 2025-08-15)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "cargo-typify"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "typify"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "env_logger",
@@ -1301,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "typify-impl"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "env_logger",
  "expectorate",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "typify-macro"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-typify = { version = "0.4.3", path = "typify" }
-typify-impl = { version = "0.4.3", path = "typify-impl" }
-typify-macro = { version = "0.4.3", path = "typify-macro" }
+typify = { version = "0.5.0", path = "typify" }
+typify-impl = { version = "0.5.0", path = "typify-impl" }
+typify-macro = { version = "0.5.0", path = "typify-macro" }
 
 assert_cmd = "2.0.17"
 chrono = { version = "0.4.42", features = ["serde"] }

--- a/cargo-typify/Cargo.toml
+++ b/cargo-typify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-typify"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "cargo command to generate Rust code from a JSON Schema"

--- a/typify-impl/Cargo.toml
+++ b/typify-impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typify-impl"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "typify backend implementation"

--- a/typify-macro/Cargo.toml
+++ b/typify-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typify-macro"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "typify macro implementation"
@@ -19,4 +19,4 @@ serde = "1.0.228"
 serde_json = "1.0.145"
 serde_tokenstream = "0.2.2"
 syn = { version = "2.0", features = ["full", "extra-traits"] }
-typify-impl = { version = "0.4.3", path = "../typify-impl" }
+typify-impl = { version = "0.5.0", path = "../typify-impl" }

--- a/typify/Cargo.toml
+++ b/typify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typify"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "JSON schema to rust type code generator"


### PR DESCRIPTION
Hi! I am using progenitor and would like to see #894 landed in there. This PR is step 1 to realize that. I simply updated the changelog then ran:

```
cargo release --no-publish --no-push minor --execute
```

Just missing a tag and a push to crates. I opted for a minor since this will change many of the generated types. Not sure if you regard a breaking change to be just the interface of typify or of the interface of the generated code, or both. This is the most conservative version change (pre-1.0 breaking).

Cheers!