### PR TITLE
Obtain name from SchemaObject; otherwise, keep existing default `subtype_{idx}`

### DIFF
--- a/typify-impl/src/structs.rs
+++ b/typify-impl/src/structs.rs
@@ -288,8 +288,20 @@ impl TypeSpace {
                 }
 
                 // TODO we need a reasonable name that could be derived
-                // from the name of the type
-                let name = format!("subtype_{}", idx);
+                // from the name of the type.  Use of SchemaObject here
+                // accommodates "anyOf" and "allOf" but others, TBD. e.g.,
+                // "foo":{"items":{"anyOf":[{"$ref": "#/$defs/bar-baz"}, ...]}}
+                // provides "bar_baz".
+                let name = match schema {
+                    Schema::Object(SchemaObject {
+                        reference: Some(s), ..
+                    }) => match s.rsplit_once('/') {
+                        Some((_, name)) => name,
+                        None => s,
+                    }
+                    .replace('-', "_"),
+                    _ => format!("subtype_{}", idx),
+                };
 
                 Ok(StructProperty {
                     name,


### PR DESCRIPTION
Where existing behavior renders field names as `subtype_0`, this PR extracts a name from the relevant SchemaObject, when available.

- Preserves existing behavior for fall-through cases
- This scratches an itch from processing W3C's MNX current draft [mnx-schema.json](https://w3c-cg.github.io/mnx/docs/mnx-schema.json) 
    + e.g., had 60+ instances of `subtype_0` through `_4` in the resulting `.rs` file
    + That's as of their commit 0eda842 (latest as of creating this PR)
- Existing tests pass

EDIT: revised URI under link, as W3C has separated official versus Community Groups