### PR TITLE
style!: use inline format args in generated code

### DIFF
--- a/cargo-typify/tests/outputs/builder.rs
+++ b/cargo-typify/tests/outputs/builder.rs
@@ -238,7 +238,7 @@ pub mod builder {
         {
             self.veggie_like = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for veggie_like: {}", e));
+                .map_err(|e| format!("error converting supplied value for veggie_like: {e}"));
             self
         }
         pub fn veggie_name<T>(mut self, value: T) -> Self
@@ -248,7 +248,7 @@ pub mod builder {
         {
             self.veggie_name = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for veggie_name: {}", e));
+                .map_err(|e| format!("error converting supplied value for veggie_name: {e}"));
             self
         }
     }
@@ -291,7 +291,7 @@ pub mod builder {
         {
             self.fruits = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for fruits: {}", e));
+                .map_err(|e| format!("error converting supplied value for fruits: {e}"));
             self
         }
         pub fn vegetables<T>(mut self, value: T) -> Self
@@ -301,7 +301,7 @@ pub mod builder {
         {
             self.vegetables = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for vegetables: {}", e));
+                .map_err(|e| format!("error converting supplied value for vegetables: {e}"));
             self
         }
     }

--- a/cargo-typify/tests/outputs/custom_btree_map.rs
+++ b/cargo-typify/tests/outputs/custom_btree_map.rs
@@ -239,7 +239,7 @@ pub mod builder {
         {
             self.veggie_like = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for veggie_like: {}", e));
+                .map_err(|e| format!("error converting supplied value for veggie_like: {e}"));
             self
         }
         pub fn veggie_name<T>(mut self, value: T) -> Self
@@ -249,7 +249,7 @@ pub mod builder {
         {
             self.veggie_name = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for veggie_name: {}", e));
+                .map_err(|e| format!("error converting supplied value for veggie_name: {e}"));
             self
         }
     }
@@ -292,7 +292,7 @@ pub mod builder {
         {
             self.fruits = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for fruits: {}", e));
+                .map_err(|e| format!("error converting supplied value for fruits: {e}"));
             self
         }
         pub fn vegetables<T>(mut self, value: T) -> Self
@@ -302,7 +302,7 @@ pub mod builder {
         {
             self.vegetables = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for vegetables: {}", e));
+                .map_err(|e| format!("error converting supplied value for vegetables: {e}"));
             self
         }
     }

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -1147,7 +1147,7 @@ impl TypeEntry {
             prop_doc.push(prop.description.as_ref().map(|d| quote! { #[doc = #d] }));
             prop_name.push(format_ident!("{}", prop.name));
             prop_error.push(format!(
-                "error converting supplied value for {}: {{}}",
+                "error converting supplied value for {}: {{e}}",
                 prop.name,
             ));
 
@@ -1311,7 +1311,7 @@ impl TypeEntry {
                                     T::Error: ::std::fmt::Display,
                             {
                                 self.#prop_name = value.try_into()
-                                    .map_err(|e| format!(#prop_error, e));
+                                    .map_err(|e| format!(#prop_error));
                                 self
                             }
                         )*

--- a/typify-impl/tests/generator.out
+++ b/typify-impl/tests/generator.out
@@ -256,7 +256,7 @@ mod types {
             {
                 self.ok = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for ok: {}", e));
+                    .map_err(|e| format!("error converting supplied value for ok: {e}"));
                 self
             }
         }
@@ -294,7 +294,7 @@ mod types {
             {
                 self.value1 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for value1: {}", e));
+                    .map_err(|e| format!("error converting supplied value for value1: {e}"));
                 self
             }
             pub fn value2<T>(mut self, value: T) -> Self
@@ -304,7 +304,7 @@ mod types {
             {
                 self.value2 = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for value2: {}", e));
+                    .map_err(|e| format!("error converting supplied value for value2: {e}"));
                 self
             }
         }
@@ -348,7 +348,7 @@ mod types {
             {
                 self.a = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for a: {}", e));
+                    .map_err(|e| format!("error converting supplied value for a: {e}"));
                 self
             }
             pub fn b<T>(mut self, value: T) -> Self
@@ -358,7 +358,7 @@ mod types {
             {
                 self.b = value
                     .try_into()
-                    .map_err(|e| format!("error converting supplied value for b: {}", e));
+                    .map_err(|e| format!("error converting supplied value for b: {e}"));
                 self
             }
         }

--- a/typify/tests/schemas/deny-list.rs
+++ b/typify/tests/schemas/deny-list.rs
@@ -209,7 +209,7 @@ pub mod builder {
         {
             self.where_not = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for where_not: {}", e));
+                .map_err(|e| format!("error converting supplied value for where_not: {e}"));
             self
         }
         pub fn why_not<T>(mut self, value: T) -> Self
@@ -219,7 +219,7 @@ pub mod builder {
         {
             self.why_not = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for why_not: {}", e));
+                .map_err(|e| format!("error converting supplied value for why_not: {e}"));
             self
         }
     }

--- a/typify/tests/schemas/extraneous-enum.rs
+++ b/typify/tests/schemas/extraneous-enum.rs
@@ -172,7 +172,7 @@ pub mod builder {
         {
             self.letter = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for letter: {}", e));
+                .map_err(|e| format!("error converting supplied value for letter: {e}"));
             self
         }
     }

--- a/typify/tests/schemas/merged-schemas.rs
+++ b/typify/tests/schemas/merged-schemas.rs
@@ -1554,7 +1554,7 @@ pub mod builder {
         {
             self.bar = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for bar: {}", e));
+                .map_err(|e| format!("error converting supplied value for bar: {e}"));
             self
         }
     }
@@ -1591,7 +1591,7 @@ pub mod builder {
         {
             self.this = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for this: {}", e));
+                .map_err(|e| format!("error converting supplied value for this: {e}"));
             self
         }
     }
@@ -1631,7 +1631,7 @@ pub mod builder {
         {
             self.x = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for x: {}", e));
+                .map_err(|e| format!("error converting supplied value for x: {e}"));
             self
         }
         pub fn y<T>(mut self, value: T) -> Self
@@ -1641,7 +1641,7 @@ pub mod builder {
         {
             self.y = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for y: {}", e));
+                .map_err(|e| format!("error converting supplied value for y: {e}"));
             self
         }
     }
@@ -1686,7 +1686,7 @@ pub mod builder {
         {
             self.result = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for result: {}", e));
+                .map_err(|e| format!("error converting supplied value for result: {e}"));
             self
         }
     }
@@ -1728,7 +1728,7 @@ pub mod builder {
         {
             self.msg = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for msg: {}", e));
+                .map_err(|e| format!("error converting supplied value for msg: {e}"));
             self
         }
         pub fn result<T>(mut self, value: T) -> Self
@@ -1738,7 +1738,7 @@ pub mod builder {
         {
             self.result = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for result: {}", e));
+                .map_err(|e| format!("error converting supplied value for result: {e}"));
             self
         }
     }
@@ -1782,7 +1782,7 @@ pub mod builder {
         {
             self.msg = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for msg: {}", e));
+                .map_err(|e| format!("error converting supplied value for msg: {e}"));
             self
         }
         pub fn result<T>(mut self, value: T) -> Self
@@ -1792,7 +1792,7 @@ pub mod builder {
         {
             self.result = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for result: {}", e));
+                .map_err(|e| format!("error converting supplied value for result: {e}"));
             self
         }
     }
@@ -1860,7 +1860,7 @@ pub mod builder {
         {
             self.bar = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for bar: {}", e));
+                .map_err(|e| format!("error converting supplied value for bar: {e}"));
             self
         }
         pub fn baz<T>(mut self, value: T) -> Self
@@ -1870,7 +1870,7 @@ pub mod builder {
         {
             self.baz = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for baz: {}", e));
+                .map_err(|e| format!("error converting supplied value for baz: {e}"));
             self
         }
     }
@@ -1912,7 +1912,7 @@ pub mod builder {
         {
             self.suspended_by = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for suspended_by: {}", e));
+                .map_err(|e| format!("error converting supplied value for suspended_by: {e}"));
             self
         }
     }
@@ -1955,7 +1955,7 @@ pub mod builder {
         {
             self.suspended_by = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for suspended_by: {}", e));
+                .map_err(|e| format!("error converting supplied value for suspended_by: {e}"));
             self
         }
     }
@@ -1998,7 +1998,7 @@ pub mod builder {
         {
             self.email = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for email: {}", e));
+                .map_err(|e| format!("error converting supplied value for email: {e}"));
             self
         }
     }
@@ -2041,7 +2041,7 @@ pub mod builder {
         {
             self.email = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for email: {}", e));
+                .map_err(|e| format!("error converting supplied value for email: {e}"));
             self
         }
     }
@@ -2081,7 +2081,7 @@ pub mod builder {
         {
             self.a = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for a: {}", e));
+                .map_err(|e| format!("error converting supplied value for a: {e}"));
             self
         }
     }
@@ -2115,7 +2115,7 @@ pub mod builder {
         {
             self.tag = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for tag: {}", e));
+                .map_err(|e| format!("error converting supplied value for tag: {e}"));
             self
         }
     }
@@ -2154,7 +2154,7 @@ pub mod builder {
         {
             self.action = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for action: {}", e));
+                .map_err(|e| format!("error converting supplied value for action: {e}"));
             self
         }
     }

--- a/typify/tests/schemas/more_types.rs
+++ b/typify/tests/schemas/more_types.rs
@@ -212,7 +212,7 @@ pub mod builder {
         {
             self.foo = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for foo: {}", e));
+                .map_err(|e| format!("error converting supplied value for foo: {e}"));
             self
         }
     }
@@ -248,7 +248,7 @@ pub mod builder {
         {
             self.foo = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for foo: {}", e));
+                .map_err(|e| format!("error converting supplied value for foo: {e}"));
             self
         }
     }
@@ -289,7 +289,7 @@ pub mod builder {
         {
             self.foo = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for foo: {}", e));
+                .map_err(|e| format!("error converting supplied value for foo: {e}"));
             self
         }
         pub fn extra<T>(mut self, value: T) -> Self
@@ -301,7 +301,7 @@ pub mod builder {
         {
             self.extra = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for extra: {}", e));
+                .map_err(|e| format!("error converting supplied value for extra: {e}"));
             self
         }
     }
@@ -348,7 +348,7 @@ pub mod builder {
         {
             self.foo = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for foo: {}", e));
+                .map_err(|e| format!("error converting supplied value for foo: {e}"));
             self
         }
         pub fn extra<T>(mut self, value: T) -> Self
@@ -360,7 +360,7 @@ pub mod builder {
         {
             self.extra = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for extra: {}", e));
+                .map_err(|e| format!("error converting supplied value for extra: {e}"));
             self
         }
     }
@@ -402,7 +402,7 @@ pub mod builder {
         {
             self.foo = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for foo: {}", e));
+                .map_err(|e| format!("error converting supplied value for foo: {e}"));
             self
         }
     }

--- a/typify/tests/schemas/noisy-types.rs
+++ b/typify/tests/schemas/noisy-types.rs
@@ -202,7 +202,7 @@ pub mod builder {
         {
             self.ok = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for ok: {}", e));
+                .map_err(|e| format!("error converting supplied value for ok: {e}"));
             self
         }
     }

--- a/typify/tests/schemas/property-pattern.rs
+++ b/typify/tests/schemas/property-pattern.rs
@@ -176,7 +176,7 @@ pub mod builder {
         {
             self.rules = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for rules: {}", e));
+                .map_err(|e| format!("error converting supplied value for rules: {e}"));
             self
         }
     }

--- a/typify/tests/schemas/reflexive.rs
+++ b/typify/tests/schemas/reflexive.rs
@@ -96,7 +96,7 @@ pub mod builder {
         {
             self.children = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for children: {}", e));
+                .map_err(|e| format!("error converting supplied value for children: {e}"));
             self
         }
         pub fn value<T>(mut self, value: T) -> Self
@@ -106,7 +106,7 @@ pub mod builder {
         {
             self.value = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for value: {}", e));
+                .map_err(|e| format!("error converting supplied value for value: {e}"));
             self
         }
     }

--- a/typify/tests/schemas/rust-collisions.rs
+++ b/typify/tests/schemas/rust-collisions.rs
@@ -1792,7 +1792,7 @@ pub mod builder {
         {
             self.data = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for data: {}", e));
+                .map_err(|e| format!("error converting supplied value for data: {e}"));
             self
         }
     }
@@ -1828,7 +1828,7 @@ pub mod builder {
         {
             self.value = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for value: {}", e));
+                .map_err(|e| format!("error converting supplied value for value: {e}"));
             self
         }
     }
@@ -1869,7 +1869,7 @@ pub mod builder {
         {
             self.option = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for option: {}", e));
+                .map_err(|e| format!("error converting supplied value for option: {e}"));
             self
         }
     }
@@ -1912,7 +1912,7 @@ pub mod builder {
         {
             self.option = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for option: {}", e));
+                .map_err(|e| format!("error converting supplied value for option: {e}"));
             self
         }
     }
@@ -1952,7 +1952,7 @@ pub mod builder {
         {
             self.cleanup = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for cleanup: {}", e));
+                .map_err(|e| format!("error converting supplied value for cleanup: {e}"));
             self
         }
     }
@@ -1995,7 +1995,7 @@ pub mod builder {
         {
             self.normal = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for normal: {}", e));
+                .map_err(|e| format!("error converting supplied value for normal: {e}"));
             self
         }
         pub fn extra<T>(mut self, value: T) -> Self
@@ -2007,7 +2007,7 @@ pub mod builder {
         {
             self.extra = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for extra: {}", e));
+                .map_err(|e| format!("error converting supplied value for extra: {e}"));
             self
         }
     }
@@ -2057,7 +2057,7 @@ pub mod builder {
         {
             self.keyword_map = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for keyword_map: {}", e));
+                .map_err(|e| format!("error converting supplied value for keyword_map: {e}"));
             self
         }
     }
@@ -2109,7 +2109,7 @@ pub mod builder {
         {
             self.option_type = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for option_type: {}", e));
+                .map_err(|e| format!("error converting supplied value for option_type: {e}"));
             self
         }
         pub fn type_<T>(mut self, value: T) -> Self
@@ -2119,7 +2119,7 @@ pub mod builder {
         {
             self.type_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for type_: {}", e));
+                .map_err(|e| format!("error converting supplied value for type_: {e}"));
             self
         }
         pub fn types<T>(mut self, value: T) -> Self
@@ -2129,7 +2129,7 @@ pub mod builder {
         {
             self.types = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for types: {}", e));
+                .map_err(|e| format!("error converting supplied value for types: {e}"));
             self
         }
     }
@@ -2176,7 +2176,7 @@ pub mod builder {
         {
             self.type_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for type_: {}", e));
+                .map_err(|e| format!("error converting supplied value for type_: {e}"));
             self
         }
     }
@@ -2220,7 +2220,7 @@ pub mod builder {
         {
             self.maybe = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for maybe: {}", e));
+                .map_err(|e| format!("error converting supplied value for maybe: {e}"));
             self
         }
     }
@@ -2258,7 +2258,7 @@ pub mod builder {
         {
             self.pointer = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for pointer: {}", e));
+                .map_err(|e| format!("error converting supplied value for pointer: {e}"));
             self
         }
     }
@@ -2394,7 +2394,7 @@ pub mod builder {
         {
             self.abstract_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for abstract_: {}", e));
+                .map_err(|e| format!("error converting supplied value for abstract_: {e}"));
             self
         }
         pub fn as_<T>(mut self, value: T) -> Self
@@ -2404,7 +2404,7 @@ pub mod builder {
         {
             self.as_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for as_: {}", e));
+                .map_err(|e| format!("error converting supplied value for as_: {e}"));
             self
         }
         pub fn async_<T>(mut self, value: T) -> Self
@@ -2414,7 +2414,7 @@ pub mod builder {
         {
             self.async_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for async_: {}", e));
+                .map_err(|e| format!("error converting supplied value for async_: {e}"));
             self
         }
         pub fn await_<T>(mut self, value: T) -> Self
@@ -2424,7 +2424,7 @@ pub mod builder {
         {
             self.await_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for await_: {}", e));
+                .map_err(|e| format!("error converting supplied value for await_: {e}"));
             self
         }
         pub fn become_<T>(mut self, value: T) -> Self
@@ -2434,7 +2434,7 @@ pub mod builder {
         {
             self.become_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for become_: {}", e));
+                .map_err(|e| format!("error converting supplied value for become_: {e}"));
             self
         }
         pub fn box_<T>(mut self, value: T) -> Self
@@ -2444,7 +2444,7 @@ pub mod builder {
         {
             self.box_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for box_: {}", e));
+                .map_err(|e| format!("error converting supplied value for box_: {e}"));
             self
         }
         pub fn break_<T>(mut self, value: T) -> Self
@@ -2454,7 +2454,7 @@ pub mod builder {
         {
             self.break_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for break_: {}", e));
+                .map_err(|e| format!("error converting supplied value for break_: {e}"));
             self
         }
         pub fn const_<T>(mut self, value: T) -> Self
@@ -2464,7 +2464,7 @@ pub mod builder {
         {
             self.const_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for const_: {}", e));
+                .map_err(|e| format!("error converting supplied value for const_: {e}"));
             self
         }
         pub fn continue_<T>(mut self, value: T) -> Self
@@ -2474,7 +2474,7 @@ pub mod builder {
         {
             self.continue_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for continue_: {}", e));
+                .map_err(|e| format!("error converting supplied value for continue_: {e}"));
             self
         }
         pub fn crate_<T>(mut self, value: T) -> Self
@@ -2484,7 +2484,7 @@ pub mod builder {
         {
             self.crate_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for crate_: {}", e));
+                .map_err(|e| format!("error converting supplied value for crate_: {e}"));
             self
         }
         pub fn do_<T>(mut self, value: T) -> Self
@@ -2494,7 +2494,7 @@ pub mod builder {
         {
             self.do_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for do_: {}", e));
+                .map_err(|e| format!("error converting supplied value for do_: {e}"));
             self
         }
         pub fn dyn_<T>(mut self, value: T) -> Self
@@ -2504,7 +2504,7 @@ pub mod builder {
         {
             self.dyn_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for dyn_: {}", e));
+                .map_err(|e| format!("error converting supplied value for dyn_: {e}"));
             self
         }
         pub fn else_<T>(mut self, value: T) -> Self
@@ -2514,7 +2514,7 @@ pub mod builder {
         {
             self.else_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for else_: {}", e));
+                .map_err(|e| format!("error converting supplied value for else_: {e}"));
             self
         }
         pub fn enum_<T>(mut self, value: T) -> Self
@@ -2524,7 +2524,7 @@ pub mod builder {
         {
             self.enum_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for enum_: {}", e));
+                .map_err(|e| format!("error converting supplied value for enum_: {e}"));
             self
         }
         pub fn extern_<T>(mut self, value: T) -> Self
@@ -2534,7 +2534,7 @@ pub mod builder {
         {
             self.extern_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for extern_: {}", e));
+                .map_err(|e| format!("error converting supplied value for extern_: {e}"));
             self
         }
         pub fn false_<T>(mut self, value: T) -> Self
@@ -2544,7 +2544,7 @@ pub mod builder {
         {
             self.false_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for false_: {}", e));
+                .map_err(|e| format!("error converting supplied value for false_: {e}"));
             self
         }
         pub fn final_<T>(mut self, value: T) -> Self
@@ -2554,7 +2554,7 @@ pub mod builder {
         {
             self.final_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for final_: {}", e));
+                .map_err(|e| format!("error converting supplied value for final_: {e}"));
             self
         }
         pub fn fn_<T>(mut self, value: T) -> Self
@@ -2564,7 +2564,7 @@ pub mod builder {
         {
             self.fn_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for fn_: {}", e));
+                .map_err(|e| format!("error converting supplied value for fn_: {e}"));
             self
         }
         pub fn for_<T>(mut self, value: T) -> Self
@@ -2574,7 +2574,7 @@ pub mod builder {
         {
             self.for_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for for_: {}", e));
+                .map_err(|e| format!("error converting supplied value for for_: {e}"));
             self
         }
         pub fn if_<T>(mut self, value: T) -> Self
@@ -2584,7 +2584,7 @@ pub mod builder {
         {
             self.if_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for if_: {}", e));
+                .map_err(|e| format!("error converting supplied value for if_: {e}"));
             self
         }
         pub fn impl_<T>(mut self, value: T) -> Self
@@ -2594,7 +2594,7 @@ pub mod builder {
         {
             self.impl_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for impl_: {}", e));
+                .map_err(|e| format!("error converting supplied value for impl_: {e}"));
             self
         }
         pub fn in_<T>(mut self, value: T) -> Self
@@ -2604,7 +2604,7 @@ pub mod builder {
         {
             self.in_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for in_: {}", e));
+                .map_err(|e| format!("error converting supplied value for in_: {e}"));
             self
         }
         pub fn let_<T>(mut self, value: T) -> Self
@@ -2614,7 +2614,7 @@ pub mod builder {
         {
             self.let_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for let_: {}", e));
+                .map_err(|e| format!("error converting supplied value for let_: {e}"));
             self
         }
         pub fn loop_<T>(mut self, value: T) -> Self
@@ -2624,7 +2624,7 @@ pub mod builder {
         {
             self.loop_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for loop_: {}", e));
+                .map_err(|e| format!("error converting supplied value for loop_: {e}"));
             self
         }
         pub fn macro_<T>(mut self, value: T) -> Self
@@ -2634,7 +2634,7 @@ pub mod builder {
         {
             self.macro_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for macro_: {}", e));
+                .map_err(|e| format!("error converting supplied value for macro_: {e}"));
             self
         }
         pub fn match_<T>(mut self, value: T) -> Self
@@ -2644,7 +2644,7 @@ pub mod builder {
         {
             self.match_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for match_: {}", e));
+                .map_err(|e| format!("error converting supplied value for match_: {e}"));
             self
         }
         pub fn mod_<T>(mut self, value: T) -> Self
@@ -2654,7 +2654,7 @@ pub mod builder {
         {
             self.mod_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for mod_: {}", e));
+                .map_err(|e| format!("error converting supplied value for mod_: {e}"));
             self
         }
         pub fn move_<T>(mut self, value: T) -> Self
@@ -2664,7 +2664,7 @@ pub mod builder {
         {
             self.move_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for move_: {}", e));
+                .map_err(|e| format!("error converting supplied value for move_: {e}"));
             self
         }
         pub fn mut_<T>(mut self, value: T) -> Self
@@ -2674,7 +2674,7 @@ pub mod builder {
         {
             self.mut_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for mut_: {}", e));
+                .map_err(|e| format!("error converting supplied value for mut_: {e}"));
             self
         }
         pub fn override_<T>(mut self, value: T) -> Self
@@ -2684,7 +2684,7 @@ pub mod builder {
         {
             self.override_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for override_: {}", e));
+                .map_err(|e| format!("error converting supplied value for override_: {e}"));
             self
         }
         pub fn priv_<T>(mut self, value: T) -> Self
@@ -2694,7 +2694,7 @@ pub mod builder {
         {
             self.priv_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for priv_: {}", e));
+                .map_err(|e| format!("error converting supplied value for priv_: {e}"));
             self
         }
         pub fn pub_<T>(mut self, value: T) -> Self
@@ -2704,7 +2704,7 @@ pub mod builder {
         {
             self.pub_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for pub_: {}", e));
+                .map_err(|e| format!("error converting supplied value for pub_: {e}"));
             self
         }
         pub fn ref_<T>(mut self, value: T) -> Self
@@ -2714,7 +2714,7 @@ pub mod builder {
         {
             self.ref_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for ref_: {}", e));
+                .map_err(|e| format!("error converting supplied value for ref_: {e}"));
             self
         }
         pub fn return_<T>(mut self, value: T) -> Self
@@ -2724,7 +2724,7 @@ pub mod builder {
         {
             self.return_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for return_: {}", e));
+                .map_err(|e| format!("error converting supplied value for return_: {e}"));
             self
         }
         pub fn self_<T>(mut self, value: T) -> Self
@@ -2734,7 +2734,7 @@ pub mod builder {
         {
             self.self_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for self_: {}", e));
+                .map_err(|e| format!("error converting supplied value for self_: {e}"));
             self
         }
         pub fn static_<T>(mut self, value: T) -> Self
@@ -2744,7 +2744,7 @@ pub mod builder {
         {
             self.static_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for static_: {}", e));
+                .map_err(|e| format!("error converting supplied value for static_: {e}"));
             self
         }
         pub fn struct_<T>(mut self, value: T) -> Self
@@ -2754,7 +2754,7 @@ pub mod builder {
         {
             self.struct_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for struct_: {}", e));
+                .map_err(|e| format!("error converting supplied value for struct_: {e}"));
             self
         }
         pub fn super_<T>(mut self, value: T) -> Self
@@ -2764,7 +2764,7 @@ pub mod builder {
         {
             self.super_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for super_: {}", e));
+                .map_err(|e| format!("error converting supplied value for super_: {e}"));
             self
         }
         pub fn trait_<T>(mut self, value: T) -> Self
@@ -2774,7 +2774,7 @@ pub mod builder {
         {
             self.trait_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for trait_: {}", e));
+                .map_err(|e| format!("error converting supplied value for trait_: {e}"));
             self
         }
         pub fn true_<T>(mut self, value: T) -> Self
@@ -2784,7 +2784,7 @@ pub mod builder {
         {
             self.true_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for true_: {}", e));
+                .map_err(|e| format!("error converting supplied value for true_: {e}"));
             self
         }
         pub fn try_<T>(mut self, value: T) -> Self
@@ -2794,7 +2794,7 @@ pub mod builder {
         {
             self.try_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for try_: {}", e));
+                .map_err(|e| format!("error converting supplied value for try_: {e}"));
             self
         }
         pub fn type_<T>(mut self, value: T) -> Self
@@ -2804,7 +2804,7 @@ pub mod builder {
         {
             self.type_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for type_: {}", e));
+                .map_err(|e| format!("error converting supplied value for type_: {e}"));
             self
         }
         pub fn typeof_<T>(mut self, value: T) -> Self
@@ -2814,7 +2814,7 @@ pub mod builder {
         {
             self.typeof_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for typeof_: {}", e));
+                .map_err(|e| format!("error converting supplied value for typeof_: {e}"));
             self
         }
         pub fn unsafe_<T>(mut self, value: T) -> Self
@@ -2824,7 +2824,7 @@ pub mod builder {
         {
             self.unsafe_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for unsafe_: {}", e));
+                .map_err(|e| format!("error converting supplied value for unsafe_: {e}"));
             self
         }
         pub fn unsized_<T>(mut self, value: T) -> Self
@@ -2834,7 +2834,7 @@ pub mod builder {
         {
             self.unsized_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for unsized_: {}", e));
+                .map_err(|e| format!("error converting supplied value for unsized_: {e}"));
             self
         }
         pub fn use_<T>(mut self, value: T) -> Self
@@ -2844,7 +2844,7 @@ pub mod builder {
         {
             self.use_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for use_: {}", e));
+                .map_err(|e| format!("error converting supplied value for use_: {e}"));
             self
         }
         pub fn virtual_<T>(mut self, value: T) -> Self
@@ -2854,7 +2854,7 @@ pub mod builder {
         {
             self.virtual_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for virtual_: {}", e));
+                .map_err(|e| format!("error converting supplied value for virtual_: {e}"));
             self
         }
         pub fn where_<T>(mut self, value: T) -> Self
@@ -2864,7 +2864,7 @@ pub mod builder {
         {
             self.where_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for where_: {}", e));
+                .map_err(|e| format!("error converting supplied value for where_: {e}"));
             self
         }
         pub fn while_<T>(mut self, value: T) -> Self
@@ -2874,7 +2874,7 @@ pub mod builder {
         {
             self.while_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for while_: {}", e));
+                .map_err(|e| format!("error converting supplied value for while_: {e}"));
             self
         }
         pub fn yield_<T>(mut self, value: T) -> Self
@@ -2884,7 +2884,7 @@ pub mod builder {
         {
             self.yield_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for yield_: {}", e));
+                .map_err(|e| format!("error converting supplied value for yield_: {e}"));
             self
         }
     }
@@ -3022,7 +3022,7 @@ pub mod builder {
         {
             self.message = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for message: {}", e));
+                .map_err(|e| format!("error converting supplied value for message: {e}"));
             self
         }
     }
@@ -3072,7 +3072,7 @@ pub mod builder {
         {
             self.boxed = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for boxed: {}", e));
+                .map_err(|e| format!("error converting supplied value for boxed: {e}"));
             self
         }
         pub fn convert<T>(mut self, value: T) -> Self
@@ -3082,7 +3082,7 @@ pub mod builder {
         {
             self.convert = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for convert: {}", e));
+                .map_err(|e| format!("error converting supplied value for convert: {e}"));
             self
         }
         pub fn fmt<T>(mut self, value: T) -> Self
@@ -3092,7 +3092,7 @@ pub mod builder {
         {
             self.fmt = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for fmt: {}", e));
+                .map_err(|e| format!("error converting supplied value for fmt: {e}"));
             self
         }
         pub fn option<T>(mut self, value: T) -> Self
@@ -3102,7 +3102,7 @@ pub mod builder {
         {
             self.option = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for option: {}", e));
+                .map_err(|e| format!("error converting supplied value for option: {e}"));
             self
         }
         pub fn result<T>(mut self, value: T) -> Self
@@ -3112,7 +3112,7 @@ pub mod builder {
         {
             self.result = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for result: {}", e));
+                .map_err(|e| format!("error converting supplied value for result: {e}"));
             self
         }
         pub fn str<T>(mut self, value: T) -> Self
@@ -3122,7 +3122,7 @@ pub mod builder {
         {
             self.str = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for str: {}", e));
+                .map_err(|e| format!("error converting supplied value for str: {e}"));
             self
         }
         pub fn string<T>(mut self, value: T) -> Self
@@ -3132,7 +3132,7 @@ pub mod builder {
         {
             self.string = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for string: {}", e));
+                .map_err(|e| format!("error converting supplied value for string: {e}"));
             self
         }
     }
@@ -3182,7 +3182,7 @@ pub mod builder {
         {
             self.value = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for value: {}", e));
+                .map_err(|e| format!("error converting supplied value for value: {e}"));
             self
         }
     }
@@ -3220,7 +3220,7 @@ pub mod builder {
         {
             self.value = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for value: {}", e));
+                .map_err(|e| format!("error converting supplied value for value: {e}"));
             self
         }
     }
@@ -3260,7 +3260,7 @@ pub mod builder {
         {
             self.value = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for value: {}", e));
+                .map_err(|e| format!("error converting supplied value for value: {e}"));
             self
         }
     }
@@ -3298,7 +3298,7 @@ pub mod builder {
         {
             self.value = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for value: {}", e));
+                .map_err(|e| format!("error converting supplied value for value: {e}"));
             self
         }
     }
@@ -3338,7 +3338,7 @@ pub mod builder {
         {
             self.value = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for value: {}", e));
+                .map_err(|e| format!("error converting supplied value for value: {e}"));
             self
         }
     }
@@ -3378,7 +3378,7 @@ pub mod builder {
         {
             self.value = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for value: {}", e));
+                .map_err(|e| format!("error converting supplied value for value: {e}"));
             self
         }
     }
@@ -3416,7 +3416,7 @@ pub mod builder {
         {
             self.value = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for value: {}", e));
+                .map_err(|e| format!("error converting supplied value for value: {e}"));
             self
         }
     }
@@ -3456,7 +3456,7 @@ pub mod builder {
         {
             self.text = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for text: {}", e));
+                .map_err(|e| format!("error converting supplied value for text: {e}"));
             self
         }
     }
@@ -3492,7 +3492,7 @@ pub mod builder {
         {
             self.data = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for data: {}", e));
+                .map_err(|e| format!("error converting supplied value for data: {e}"));
             self
         }
     }
@@ -3533,7 +3533,7 @@ pub mod builder {
         {
             self.boxed_field = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for boxed_field: {}", e));
+                .map_err(|e| format!("error converting supplied value for boxed_field: {e}"));
             self
         }
         pub fn optional_field<T>(mut self, value: T) -> Self
@@ -3543,7 +3543,7 @@ pub mod builder {
         {
             self.optional_field = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for optional_field: {}", e));
+                .map_err(|e| format!("error converting supplied value for optional_field: {e}"));
             self
         }
     }
@@ -3585,7 +3585,7 @@ pub mod builder {
         {
             self.items = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for items: {}", e));
+                .map_err(|e| format!("error converting supplied value for items: {e}"));
             self
         }
     }

--- a/typify/tests/schemas/simple-types.rs
+++ b/typify/tests/schemas/simple-types.rs
@@ -236,7 +236,7 @@ pub mod builder {
         {
             self.value = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for value: {}", e));
+                .map_err(|e| format!("error converting supplied value for value: {e}"));
             self
         }
     }
@@ -276,7 +276,7 @@ pub mod builder {
         {
             self.flush_timeout = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for flush_timeout: {}", e));
+                .map_err(|e| format!("error converting supplied value for flush_timeout: {e}"));
             self
         }
     }
@@ -326,7 +326,7 @@ pub mod builder {
         {
             self.max = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for max: {}", e));
+                .map_err(|e| format!("error converting supplied value for max: {e}"));
             self
         }
         pub fn min<T>(mut self, value: T) -> Self
@@ -336,7 +336,7 @@ pub mod builder {
         {
             self.min = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for min: {}", e));
+                .map_err(|e| format!("error converting supplied value for min: {e}"));
             self
         }
         pub fn min_and_max<T>(mut self, value: T) -> Self
@@ -346,7 +346,7 @@ pub mod builder {
         {
             self.min_and_max = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for min_and_max: {}", e));
+                .map_err(|e| format!("error converting supplied value for min_and_max: {e}"));
             self
         }
         pub fn min_non_zero<T>(mut self, value: T) -> Self
@@ -356,7 +356,7 @@ pub mod builder {
         {
             self.min_non_zero = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for min_non_zero: {}", e));
+                .map_err(|e| format!("error converting supplied value for min_non_zero: {e}"));
             self
         }
         pub fn min_uint_non_zero<T>(mut self, value: T) -> Self
@@ -364,12 +364,9 @@ pub mod builder {
             T: ::std::convert::TryInto<::std::num::NonZeroU64>,
             T::Error: ::std::fmt::Display,
         {
-            self.min_uint_non_zero = value.try_into().map_err(|e| {
-                format!(
-                    "error converting supplied value for min_uint_non_zero: {}",
-                    e
-                )
-            });
+            self.min_uint_non_zero = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for min_uint_non_zero: {e}"));
             self
         }
         pub fn no_bounds<T>(mut self, value: T) -> Self
@@ -379,7 +376,7 @@ pub mod builder {
         {
             self.no_bounds = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for no_bounds: {}", e));
+                .map_err(|e| format!("error converting supplied value for no_bounds: {e}"));
             self
         }
     }

--- a/typify/tests/schemas/type-with-modified-generation.rs
+++ b/typify/tests/schemas/type-with-modified-generation.rs
@@ -142,7 +142,7 @@ pub mod builder {
         {
             self.converted_type = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for converted_type: {}", e));
+                .map_err(|e| format!("error converting supplied value for converted_type: {e}"));
             self
         }
         pub fn patched_type<T>(mut self, value: T) -> Self
@@ -152,7 +152,7 @@ pub mod builder {
         {
             self.patched_type = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for patched_type: {}", e));
+                .map_err(|e| format!("error converting supplied value for patched_type: {e}"));
             self
         }
         pub fn replaced_type<T>(mut self, value: T) -> Self
@@ -162,7 +162,7 @@ pub mod builder {
         {
             self.replaced_type = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for replaced_type: {}", e));
+                .map_err(|e| format!("error converting supplied value for replaced_type: {e}"));
             self
         }
     }

--- a/typify/tests/schemas/types-with-defaults.rs
+++ b/typify/tests/schemas/types-with-defaults.rs
@@ -309,7 +309,7 @@ pub mod builder {
         {
             self.when = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for when: {}", e));
+                .map_err(|e| format!("error converting supplied value for when: {e}"));
             self
         }
     }
@@ -352,7 +352,7 @@ pub mod builder {
         {
             self.big_nullable = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for big_nullable: {}", e));
+                .map_err(|e| format!("error converting supplied value for big_nullable: {e}"));
             self
         }
         pub fn little_u16<T>(mut self, value: T) -> Self
@@ -362,7 +362,7 @@ pub mod builder {
         {
             self.little_u16 = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for little_u16: {}", e));
+                .map_err(|e| format!("error converting supplied value for little_u16: {e}"));
             self
         }
         pub fn little_u8<T>(mut self, value: T) -> Self
@@ -372,7 +372,7 @@ pub mod builder {
         {
             self.little_u8 = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for little_u8: {}", e));
+                .map_err(|e| format!("error converting supplied value for little_u8: {e}"));
             self
         }
     }
@@ -419,7 +419,7 @@ pub mod builder {
         {
             self.thing = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for thing: {}", e));
+                .map_err(|e| format!("error converting supplied value for thing: {e}"));
             self
         }
     }
@@ -461,7 +461,7 @@ pub mod builder {
         {
             self.any = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for any: {}", e));
+                .map_err(|e| format!("error converting supplied value for any: {e}"));
             self
         }
         pub fn id<T>(mut self, value: T) -> Self
@@ -471,7 +471,7 @@ pub mod builder {
         {
             self.id = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
+                .map_err(|e| format!("error converting supplied value for id: {e}"));
             self
         }
     }
@@ -519,7 +519,7 @@ pub mod builder {
         {
             self.a = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for a: {}", e));
+                .map_err(|e| format!("error converting supplied value for a: {e}"));
             self
         }
         pub fn type_<T>(mut self, value: T) -> Self
@@ -529,7 +529,7 @@ pub mod builder {
         {
             self.type_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for type_: {}", e));
+                .map_err(|e| format!("error converting supplied value for type_: {e}"));
             self
         }
     }

--- a/typify/tests/schemas/untyped-enum-with-null.rs
+++ b/typify/tests/schemas/untyped-enum-with-null.rs
@@ -170,7 +170,7 @@ pub mod builder {
         {
             self.value = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for value: {}", e));
+                .map_err(|e| format!("error converting supplied value for value: {e}"));
             self
         }
     }

--- a/typify/tests/schemas/various-enums.rs
+++ b/typify/tests/schemas/various-enums.rs
@@ -1856,7 +1856,7 @@ pub mod builder {
         {
             self.alternate = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for alternate: {}", e));
+                .map_err(|e| format!("error converting supplied value for alternate: {e}"));
             self
         }
         pub fn state<T>(mut self, value: T) -> Self
@@ -1866,7 +1866,7 @@ pub mod builder {
         {
             self.state = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for state: {}", e));
+                .map_err(|e| format!("error converting supplied value for state: {e}"));
             self
         }
     }
@@ -1911,7 +1911,7 @@ pub mod builder {
         {
             self.prop = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for prop: {}", e));
+                .map_err(|e| format!("error converting supplied value for prop: {e}"));
             self
         }
     }

--- a/typify/tests/schemas/x-rust-type.rs
+++ b/typify/tests/schemas/x-rust-type.rs
@@ -124,7 +124,7 @@ pub mod builder {
         {
             self.option_marker = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for option_marker: {}", e));
+                .map_err(|e| format!("error converting supplied value for option_marker: {e}"));
             self
         }
         pub fn path<T>(mut self, value: T) -> Self
@@ -134,7 +134,7 @@ pub mod builder {
         {
             self.path = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for path: {}", e));
+                .map_err(|e| format!("error converting supplied value for path: {e}"));
             self
         }
     }


### PR DESCRIPTION
updates the codegen (at least, one part of it) to use inline format args.

this change is 'breaking' in the sense that the downstream code-gen tests in progenitor will need to be regenerated after pulling in this change