### PR TITLE
style!: use "Self" in generated code

### DIFF
--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -154,17 +154,17 @@ pub(crate) enum Name {
 impl Name {
     pub fn into_option(self) -> Option<String> {
         match self {
-            Name::Required(s) | Name::Suggested(s) => Some(s),
-            Name::Unknown => None,
+            Self::Required(s) | Self::Suggested(s) => Some(s),
+            Self::Unknown => None,
         }
     }
 
     pub fn append(&self, s: &str) -> Self {
         match self {
-            Name::Required(prefix) | Name::Suggested(prefix) => {
+            Self::Required(prefix) | Self::Suggested(prefix) => {
                 Self::Suggested(format!("{}_{}", prefix, s))
             }
-            Name::Unknown => Name::Unknown,
+            Self::Unknown => Self::Unknown,
         }
     }
 }

--- a/typify-impl/src/merge.rs
+++ b/typify-impl/src/merge.rs
@@ -1131,29 +1131,30 @@ trait Roughly {
 impl Roughly for schemars::schema::Schema {
     fn roughly(&self, other: &Self) -> bool {
         match (self, other) {
-            (Schema::Bool(a), Schema::Bool(b)) => a == b,
-            (Schema::Bool(false), _) | (_, Schema::Bool(false)) => false,
+            (Self::Bool(a), Self::Bool(b)) => a == b,
+            (Self::Bool(false), _) | (_, Self::Bool(false)) => false,
 
-            (Schema::Bool(true), Schema::Object(other))
-            | (Schema::Object(other), Schema::Bool(true)) => matches!(
-                other,
-                SchemaObject {
-                    metadata: _,
-                    instance_type: None,
-                    format: None,
-                    enum_values: None,
-                    const_value: None,
-                    subschemas: None,
-                    number: None,
-                    string: None,
-                    array: None,
-                    object: None,
-                    reference: None,
-                    extensions: _,
-                }
-            ),
+            (Self::Bool(true), Self::Object(other)) | (Self::Object(other), Self::Bool(true)) => {
+                matches!(
+                    other,
+                    SchemaObject {
+                        metadata: _,
+                        instance_type: None,
+                        format: None,
+                        enum_values: None,
+                        const_value: None,
+                        subschemas: None,
+                        number: None,
+                        string: None,
+                        array: None,
+                        object: None,
+                        reference: None,
+                        extensions: _,
+                    }
+                )
+            }
 
-            (Schema::Object(a), Schema::Object(b)) => {
+            (Self::Object(a), Self::Object(b)) => {
                 a.instance_type == b.instance_type
                     && a.format == b.format
                     && a.enum_values == b.enum_values

--- a/typify-impl/src/test_util.rs
+++ b/typify-impl/src/test_util.rs
@@ -283,9 +283,9 @@ impl SynCompare for Variant {
 impl SynCompare for Fields {
     fn syn_cmp(&self, other: &Self, _: bool) -> Result<(), String> {
         match (self, other) {
-            (Fields::Named(a), Fields::Named(b)) => a.syn_cmp(b, false),
-            (Fields::Unnamed(a), Fields::Unnamed(b)) => a.syn_cmp(b, false),
-            (Fields::Unit, Fields::Unit) => Ok(()),
+            (Self::Named(a), Self::Named(b)) => a.syn_cmp(b, false),
+            (Self::Unnamed(a), Self::Unnamed(b)) => a.syn_cmp(b, false),
+            (Self::Unit, Self::Unit) => Ok(()),
             _ => Err("mismatched field types".to_string()),
         }
     }
@@ -314,8 +314,8 @@ impl SynCompare for Field {
 impl SynCompare for Type {
     fn syn_cmp(&self, other: &Self, _: bool) -> Result<(), String> {
         match (self, other) {
-            (Type::Tuple(a), Type::Tuple(b)) => a.syn_cmp(b, false),
-            (Type::Path(a), Type::Path(b)) => a.syn_cmp(b, false),
+            (Self::Tuple(a), Self::Tuple(b)) => a.syn_cmp(b, false),
+            (Self::Path(a), Self::Path(b)) => a.syn_cmp(b, false),
             _ => Err(format!(
                 "unexpected or mismatched type pair: {:?} {:?}",
                 self, other

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -554,7 +554,7 @@ impl From<TypeEntryDetails> for TypeEntry {
 
 impl TypeEntry {
     pub(crate) fn new_native<S: ToString>(type_name: S, impls: &[TypeSpaceImpl]) -> Self {
-        TypeEntry {
+        Self {
             details: TypeEntryDetails::Native(TypeEntryNative {
                 type_name: type_name.to_string(),
                 impls: impls.to_vec(),
@@ -565,7 +565,7 @@ impl TypeEntry {
         }
     }
     pub(crate) fn new_native_params<S: ToString>(type_name: S, params: &[TypeId]) -> Self {
-        TypeEntry {
+        Self {
             details: TypeEntryDetails::Native(TypeEntryNative {
                 type_name: type_name.to_string(),
                 impls: Default::default(),
@@ -576,7 +576,7 @@ impl TypeEntry {
         }
     }
     pub(crate) fn new_boolean() -> Self {
-        TypeEntry {
+        Self {
             details: TypeEntryDetails::Boolean,
             extra_derives: Default::default(),
             extra_attrs: Default::default(),
@@ -586,7 +586,7 @@ impl TypeEntry {
         TypeEntryDetails::Integer(type_name.to_string()).into()
     }
     pub(crate) fn new_float<S: ToString>(type_name: S) -> Self {
-        TypeEntry {
+        Self {
             details: TypeEntryDetails::Float(type_name.to_string()),
             extra_derives: Default::default(),
             extra_attrs: Default::default(),


### PR DESCRIPTION
updates the codegen to use 'Self' to refer to own type.

this change is 'breaking' in the sense that the downstream code-gen tests in progenitor will need to be regenerated after pulling in this change