### PR TITLE
add MSRV check to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,3 +32,16 @@ jobs:
       run: cargo build --locked --tests --verbose
     - name: Run tests
       run: cargo test --locked --verbose
+
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: taiki-e/install-action@cargo-hack
+    - name: Check published packages on their declared MSRV
+      run: >-
+        cargo hack --workspace
+        --exclude typify-test
+        --exclude example-build
+        --exclude example-macro
+        --no-dev-deps --rust-version check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ members = [
 
 resolver = "2"
 
+[workspace.package]
+rust-version = "1.88.0"
+
 [workspace.dependencies]
 typify = { version = "0.7.0", path = "typify" }
 typify-impl = { version = "0.7.0", path = "typify-impl" }

--- a/cargo-typify/Cargo.toml
+++ b/cargo-typify/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/oxidecomputer/typify"
 readme = "README.md"
 keywords = ["json", "schema", "cargo"]
 categories = ["api-bindings", "compilers"]
+rust-version.workspace = true
 
 default-run = "cargo-typify"
 

--- a/typify-impl/Cargo.toml
+++ b/typify-impl/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0"
 description = "typify backend implementation"
 repository = "https://github.com/oxidecomputer/typify"
 readme = "../README.md"
+rust-version.workspace = true
 
 [dependencies]
 heck = { workspace = true }

--- a/typify-macro/Cargo.toml
+++ b/typify-macro/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0"
 description = "typify macro implementation"
 repository = "https://github.com/oxidecomputer/typify"
 readme = "../README.md"
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/typify-test/Cargo.toml
+++ b/typify-test/Cargo.toml
@@ -14,6 +14,6 @@ typify = { path = "../typify" }
 ipnetwork = { workspace = true }
 prettyplease = { workspace = true }
 schemars = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 syn = { workspace = true }

--- a/typify/Cargo.toml
+++ b/typify/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/oxidecomputer/typify"
 readme = "../README.md"
 keywords = ["json", "schema", "proc_macro"]
 categories = ["api-bindings", "compilers"]
+rust-version.workspace = true
 
 [features]
 default = ["macro"]


### PR DESCRIPTION
## Summary

- declare Rust 1.88 as the workspace MSRV;
- apply that declaration to all four published packages;
- add an additive CI job that checks each published package at its declared MSRV;
- enable Serde's derive feature for the build dependency exposed by `--no-dev-deps`.

This PR deliberately keeps `rust-toolchain.toml`, the existing `build-and-test` matrix and job name, and current action versions unchanged. The contributor-toolchain and broader stable/nightly CI policy is split into #1058.

## Validation

```text
cargo hack --workspace --exclude typify-test --exclude example-build --exclude example-macro --no-dev-deps --rust-version check
cargo +1.89.0 fmt --all -- --check
cargo +1.89.0 test --workspace --locked
```

All commands pass locally; the MSRV checks select Rust 1.88 from the declared package metadata.
