### PR TITLE
extend dependabot config for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,13 @@ updates:
     ignore:
       - dependency-name: "schemars"
         versions: [">=0.9.0"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: chore
+      include: scope
+    ignore:
+      - dependency-name: dtolnay/rust-toolchain


### PR DESCRIPTION
the actions are very out of date. this should help.

note this includes config for dtolnay toolchain, even though you're not (yet) using it.
i've done this because it is used in #938, but happy to take a steer on that