### PR TITLE
refactor!: remove non-idiomatic From<&T> for T trait impls

### DIFF
--- a/cargo-typify/README.md
+++ b/cargo-typify/README.md
@@ -72,11 +72,6 @@ pub enum IdOrName {
     Id(uuid::Uuid),
     Name(Name),
 }
-impl From<&IdOrName> for IdOrName {
-    fn from(value: &IdOrName) -> Self {
-        value.clone()
-    }
-}
 impl std::str::FromStr for IdOrName {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
@@ -137,11 +132,6 @@ impl std::ops::Deref for Name {
 impl From<Name> for String {
     fn from(value: Name) -> Self {
         value.0
-    }
-}
-impl From<&Name> for Name {
-    fn from(value: &Name) -> Self {
-        value.clone()
     }
 }
 impl std::str::FromStr for Name {

--- a/cargo-typify/tests/outputs/builder.rs
+++ b/cargo-typify/tests/outputs/builder.rs
@@ -58,11 +58,6 @@ impl ::std::convert::From<Fruit>
         value.0
     }
 }
-impl ::std::convert::From<&Fruit> for Fruit {
-    fn from(value: &Fruit) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::collections::HashMap<::std::string::String, ::std::string::String>>
     for Fruit
 {
@@ -104,11 +99,6 @@ impl ::std::convert::From<::std::collections::HashMap<::std::string::String, ::s
 pub enum FruitOrVeg {
     Veg(Veggie),
     Fruit(Fruit),
-}
-impl ::std::convert::From<&Self> for FruitOrVeg {
-    fn from(value: &FruitOrVeg) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<Veggie> for FruitOrVeg {
     fn from(value: Veggie) -> Self {
@@ -153,11 +143,6 @@ pub struct Veggie {
     #[serde(rename = "veggieName")]
     pub veggie_name: ::std::string::String,
 }
-impl ::std::convert::From<&Veggie> for Veggie {
-    fn from(value: &Veggie) -> Self {
-        value.clone()
-    }
-}
 impl Veggie {
     pub fn builder() -> builder::Veggie {
         Default::default()
@@ -196,11 +181,6 @@ pub struct Veggies {
     pub fruits: ::std::vec::Vec<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub vegetables: ::std::vec::Vec<Veggie>,
-}
-impl ::std::convert::From<&Veggies> for Veggies {
-    fn from(value: &Veggies) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for Veggies {
     fn default() -> Self {

--- a/cargo-typify/tests/outputs/custom_btree_map.rs
+++ b/cargo-typify/tests/outputs/custom_btree_map.rs
@@ -58,11 +58,6 @@ impl ::std::convert::From<Fruit>
         value.0
     }
 }
-impl ::std::convert::From<&Fruit> for Fruit {
-    fn from(value: &Fruit) -> Self {
-        value.clone()
-    }
-}
 impl
     ::std::convert::From<::std::collections::BTreeMap<::std::string::String, ::std::string::String>>
     for Fruit
@@ -105,11 +100,6 @@ impl
 pub enum FruitOrVeg {
     Veg(Veggie),
     Fruit(Fruit),
-}
-impl ::std::convert::From<&Self> for FruitOrVeg {
-    fn from(value: &FruitOrVeg) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<Veggie> for FruitOrVeg {
     fn from(value: Veggie) -> Self {
@@ -154,11 +144,6 @@ pub struct Veggie {
     #[serde(rename = "veggieName")]
     pub veggie_name: ::std::string::String,
 }
-impl ::std::convert::From<&Veggie> for Veggie {
-    fn from(value: &Veggie) -> Self {
-        value.clone()
-    }
-}
 impl Veggie {
     pub fn builder() -> builder::Veggie {
         Default::default()
@@ -197,11 +182,6 @@ pub struct Veggies {
     pub fruits: ::std::vec::Vec<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub vegetables: ::std::vec::Vec<Veggie>,
-}
-impl ::std::convert::From<&Veggies> for Veggies {
-    fn from(value: &Veggies) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for Veggies {
     fn default() -> Self {

--- a/cargo-typify/tests/outputs/derive.rs
+++ b/cargo-typify/tests/outputs/derive.rs
@@ -58,11 +58,6 @@ impl ::std::convert::From<Fruit>
         value.0
     }
 }
-impl ::std::convert::From<&Fruit> for Fruit {
-    fn from(value: &Fruit) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::collections::HashMap<::std::string::String, ::std::string::String>>
     for Fruit
 {
@@ -104,11 +99,6 @@ impl ::std::convert::From<::std::collections::HashMap<::std::string::String, ::s
 pub enum FruitOrVeg {
     Veg(Veggie),
     Fruit(Fruit),
-}
-impl ::std::convert::From<&Self> for FruitOrVeg {
-    fn from(value: &FruitOrVeg) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<Veggie> for FruitOrVeg {
     fn from(value: Veggie) -> Self {
@@ -153,11 +143,6 @@ pub struct Veggie {
     #[serde(rename = "veggieName")]
     pub veggie_name: ::std::string::String,
 }
-impl ::std::convert::From<&Veggie> for Veggie {
-    fn from(value: &Veggie) -> Self {
-        value.clone()
-    }
-}
 #[doc = "A representation of a person, company, organization, or place"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -191,11 +176,6 @@ pub struct Veggies {
     pub fruits: ::std::vec::Vec<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub vegetables: ::std::vec::Vec<Veggie>,
-}
-impl ::std::convert::From<&Veggies> for Veggies {
-    fn from(value: &Veggies) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for Veggies {
     fn default() -> Self {

--- a/cargo-typify/tests/outputs/multi_derive.rs
+++ b/cargo-typify/tests/outputs/multi_derive.rs
@@ -60,11 +60,6 @@ impl ::std::convert::From<Fruit>
         value.0
     }
 }
-impl ::std::convert::From<&Fruit> for Fruit {
-    fn from(value: &Fruit) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::collections::HashMap<::std::string::String, ::std::string::String>>
     for Fruit
 {
@@ -108,11 +103,6 @@ impl ::std::convert::From<::std::collections::HashMap<::std::string::String, ::s
 pub enum FruitOrVeg {
     Veg(Veggie),
     Fruit(Fruit),
-}
-impl ::std::convert::From<&Self> for FruitOrVeg {
-    fn from(value: &FruitOrVeg) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<Veggie> for FruitOrVeg {
     fn from(value: Veggie) -> Self {
@@ -159,11 +149,6 @@ pub struct Veggie {
     #[serde(rename = "veggieName")]
     pub veggie_name: ::std::string::String,
 }
-impl ::std::convert::From<&Veggie> for Veggie {
-    fn from(value: &Veggie) -> Self {
-        value.clone()
-    }
-}
 #[doc = "A representation of a person, company, organization, or place"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -199,11 +184,6 @@ pub struct Veggies {
     pub fruits: ::std::vec::Vec<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub vegetables: ::std::vec::Vec<Veggie>,
-}
-impl ::std::convert::From<&Veggies> for Veggies {
-    fn from(value: &Veggies) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for Veggies {
     fn default() -> Self {

--- a/cargo-typify/tests/outputs/no-builder.rs
+++ b/cargo-typify/tests/outputs/no-builder.rs
@@ -58,11 +58,6 @@ impl ::std::convert::From<Fruit>
         value.0
     }
 }
-impl ::std::convert::From<&Fruit> for Fruit {
-    fn from(value: &Fruit) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::collections::HashMap<::std::string::String, ::std::string::String>>
     for Fruit
 {
@@ -104,11 +99,6 @@ impl ::std::convert::From<::std::collections::HashMap<::std::string::String, ::s
 pub enum FruitOrVeg {
     Veg(Veggie),
     Fruit(Fruit),
-}
-impl ::std::convert::From<&Self> for FruitOrVeg {
-    fn from(value: &FruitOrVeg) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<Veggie> for FruitOrVeg {
     fn from(value: Veggie) -> Self {
@@ -153,11 +143,6 @@ pub struct Veggie {
     #[serde(rename = "veggieName")]
     pub veggie_name: ::std::string::String,
 }
-impl ::std::convert::From<&Veggie> for Veggie {
-    fn from(value: &Veggie) -> Self {
-        value.clone()
-    }
-}
 #[doc = "A representation of a person, company, organization, or place"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -191,11 +176,6 @@ pub struct Veggies {
     pub fruits: ::std::vec::Vec<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub vegetables: ::std::vec::Vec<Veggie>,
-}
-impl ::std::convert::From<&Veggies> for Veggies {
-    fn from(value: &Veggies) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for Veggies {
     fn default() -> Self {

--- a/typify-impl/src/enums.rs
+++ b/typify-impl/src/enums.rs
@@ -1489,12 +1489,6 @@ mod tests {
                 Err(::std::string::String),
             }
 
-            impl ::std::convert::From<&Self> for ResultX {
-                fn from(value: &ResultX) -> Self {
-                    value.clone()
-                }
-            }
-
             impl ::std::convert::From<u32> for ResultX {
                 fn from(value: u32) -> Self {
                     Self::Ok(value)
@@ -1539,12 +1533,6 @@ mod tests {
             pub enum ResultX {
                 Ok(u32),
                 Err(::std::string::String),
-            }
-
-            impl ::std::convert::From<&Self> for ResultX {
-                fn from(value: &ResultX) -> Self {
-                    value.clone()
-                }
             }
 
             impl ::std::convert::From<u32> for ResultX {

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -1082,12 +1082,6 @@ impl TypeEntry {
                 #(#variants_decl)*
             }
 
-            impl ::std::convert::From<&Self> for #type_name {
-                fn from(value: &#type_name) -> Self {
-                    value.clone()
-                }
-            }
-
             #simple_enum_impl
             #default_impl
             #untagged_newtype_from_string_impl
@@ -1203,12 +1197,6 @@ impl TypeEntry {
                         #prop_serde
                         pub #prop_name: #prop_type,
                     )*
-                }
-
-                impl ::std::convert::From<&#type_name> for #type_name {
-                    fn from(value: &#type_name) -> Self {
-                        value.clone()
-                    }
                 }
             },
         );
@@ -1674,12 +1662,6 @@ impl TypeEntry {
             impl ::std::convert::From<#type_name> for #inner_type_name {
                 fn from(value: #type_name) -> Self {
                     value.0
-                }
-            }
-
-            impl ::std::convert::From<&#type_name> for #type_name {
-                fn from(value: &#type_name) -> Self {
-                    value.clone()
                 }
             }
 

--- a/typify-impl/tests/generator.out
+++ b/typify-impl/tests/generator.out
@@ -59,11 +59,6 @@ mod types {
     pub struct AllTheTraits {
         pub ok: ::std::string::String,
     }
-    impl ::std::convert::From<&AllTheTraits> for AllTheTraits {
-        fn from(value: &AllTheTraits) -> Self {
-            value.clone()
-        }
-    }
     impl AllTheTraits {
         pub fn builder() -> builder::AllTheTraits {
             Default::default()
@@ -99,11 +94,6 @@ mod types {
         pub value1: ::std::string::String,
         pub value2: u64,
     }
-    impl ::std::convert::From<&CompoundType> for CompoundType {
-        fn from(value: &CompoundType) -> Self {
-            value.clone()
-        }
-    }
     impl CompoundType {
         pub fn builder() -> builder::CompoundType {
             Default::default()
@@ -136,11 +126,6 @@ mod types {
         pub a: StringEnum,
         #[serde(default = "defaults::pair_b")]
         pub b: StringEnum,
-    }
-    impl ::std::convert::From<&Pair> for Pair {
-        fn from(value: &Pair) -> Self {
-            value.clone()
-        }
     }
     impl ::std::default::Default for Pair {
         fn default() -> Self {
@@ -187,11 +172,6 @@ mod types {
         One,
         Two,
         BuckleMyShoe,
-    }
-    impl ::std::convert::From<&Self> for StringEnum {
-        fn from(value: &StringEnum) -> Self {
-            value.clone()
-        }
     }
     impl ::std::fmt::Display for StringEnum {
         fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {

--- a/typify-impl/tests/github.out
+++ b/typify-impl/tests/github.out
@@ -126,11 +126,6 @@ pub struct AlertInstance {
     #[doc = "State of a code scanning alert."]
     pub state: AlertInstanceState,
 }
-impl ::std::convert::From<&AlertInstance> for AlertInstance {
-    fn from(value: &AlertInstance) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`AlertInstanceLocation`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -173,11 +168,6 @@ pub struct AlertInstanceLocation {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub start_line: ::std::option::Option<i64>,
 }
-impl ::std::convert::From<&AlertInstanceLocation> for AlertInstanceLocation {
-    fn from(value: &AlertInstanceLocation) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for AlertInstanceLocation {
     fn default() -> Self {
         Self {
@@ -210,11 +200,6 @@ impl ::std::default::Default for AlertInstanceLocation {
 pub struct AlertInstanceMessage {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub text: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&AlertInstanceMessage> for AlertInstanceMessage {
-    fn from(value: &AlertInstanceMessage) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for AlertInstanceMessage {
     fn default() -> Self {
@@ -258,11 +243,6 @@ pub enum AlertInstanceState {
     Dismissed,
     #[serde(rename = "fixed")]
     Fixed,
-}
-impl ::std::convert::From<&Self> for AlertInstanceState {
-    fn from(value: &AlertInstanceState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AlertInstanceState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -694,11 +674,6 @@ pub struct App {
     pub slug: ::std::option::Option<::std::string::String>,
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
 }
-impl ::std::convert::From<&App> for App {
-    fn from(value: &App) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`AppEventsItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -856,11 +831,6 @@ pub enum AppEventsItem {
     WorkflowDispatch,
     #[serde(rename = "workflow_run")]
     WorkflowRun,
-}
-impl ::std::convert::From<&Self> for AppEventsItem {
-    fn from(value: &AppEventsItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AppEventsItem {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -1312,11 +1282,6 @@ pub struct AppPermissions {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub workflows: ::std::option::Option<AppPermissionsWorkflows>,
 }
-impl ::std::convert::From<&AppPermissions> for AppPermissions {
-    fn from(value: &AppPermissions) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for AppPermissions {
     fn default() -> Self {
         Self {
@@ -1388,11 +1353,6 @@ pub enum AppPermissionsActions {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for AppPermissionsActions {
-    fn from(value: &AppPermissionsActions) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AppPermissionsActions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -1466,11 +1426,6 @@ pub enum AppPermissionsAdministration {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for AppPermissionsAdministration {
-    fn from(value: &AppPermissionsAdministration) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for AppPermissionsAdministration {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -1542,11 +1497,6 @@ pub enum AppPermissionsChecks {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for AppPermissionsChecks {
-    fn from(value: &AppPermissionsChecks) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AppPermissionsChecks {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -1620,11 +1570,6 @@ pub enum AppPermissionsContentReferences {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for AppPermissionsContentReferences {
-    fn from(value: &AppPermissionsContentReferences) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for AppPermissionsContentReferences {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -1696,11 +1641,6 @@ pub enum AppPermissionsContents {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for AppPermissionsContents {
-    fn from(value: &AppPermissionsContents) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AppPermissionsContents {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -1774,11 +1714,6 @@ pub enum AppPermissionsDeployments {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for AppPermissionsDeployments {
-    fn from(value: &AppPermissionsDeployments) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for AppPermissionsDeployments {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -1850,11 +1785,6 @@ pub enum AppPermissionsDiscussions {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for AppPermissionsDiscussions {
-    fn from(value: &AppPermissionsDiscussions) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AppPermissionsDiscussions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -1928,11 +1858,6 @@ pub enum AppPermissionsEmails {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for AppPermissionsEmails {
-    fn from(value: &AppPermissionsEmails) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for AppPermissionsEmails {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -2004,11 +1929,6 @@ pub enum AppPermissionsEnvironments {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for AppPermissionsEnvironments {
-    fn from(value: &AppPermissionsEnvironments) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AppPermissionsEnvironments {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -2082,11 +2002,6 @@ pub enum AppPermissionsIssues {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for AppPermissionsIssues {
-    fn from(value: &AppPermissionsIssues) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for AppPermissionsIssues {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -2158,11 +2073,6 @@ pub enum AppPermissionsMembers {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for AppPermissionsMembers {
-    fn from(value: &AppPermissionsMembers) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AppPermissionsMembers {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -2236,11 +2146,6 @@ pub enum AppPermissionsMetadata {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for AppPermissionsMetadata {
-    fn from(value: &AppPermissionsMetadata) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for AppPermissionsMetadata {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -2312,11 +2217,6 @@ pub enum AppPermissionsOrganizationAdministration {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for AppPermissionsOrganizationAdministration {
-    fn from(value: &AppPermissionsOrganizationAdministration) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AppPermissionsOrganizationAdministration {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -2390,11 +2290,6 @@ pub enum AppPermissionsOrganizationHooks {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for AppPermissionsOrganizationHooks {
-    fn from(value: &AppPermissionsOrganizationHooks) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for AppPermissionsOrganizationHooks {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -2466,11 +2361,6 @@ pub enum AppPermissionsOrganizationPackages {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for AppPermissionsOrganizationPackages {
-    fn from(value: &AppPermissionsOrganizationPackages) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AppPermissionsOrganizationPackages {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -2544,11 +2434,6 @@ pub enum AppPermissionsOrganizationPlan {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for AppPermissionsOrganizationPlan {
-    fn from(value: &AppPermissionsOrganizationPlan) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for AppPermissionsOrganizationPlan {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -2620,11 +2505,6 @@ pub enum AppPermissionsOrganizationProjects {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for AppPermissionsOrganizationProjects {
-    fn from(value: &AppPermissionsOrganizationProjects) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AppPermissionsOrganizationProjects {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -2698,11 +2578,6 @@ pub enum AppPermissionsOrganizationSecrets {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for AppPermissionsOrganizationSecrets {
-    fn from(value: &AppPermissionsOrganizationSecrets) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for AppPermissionsOrganizationSecrets {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -2774,11 +2649,6 @@ pub enum AppPermissionsOrganizationSelfHostedRunners {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for AppPermissionsOrganizationSelfHostedRunners {
-    fn from(value: &AppPermissionsOrganizationSelfHostedRunners) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AppPermissionsOrganizationSelfHostedRunners {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -2856,11 +2726,6 @@ pub enum AppPermissionsOrganizationUserBlocking {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for AppPermissionsOrganizationUserBlocking {
-    fn from(value: &AppPermissionsOrganizationUserBlocking) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for AppPermissionsOrganizationUserBlocking {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -2932,11 +2797,6 @@ pub enum AppPermissionsPackages {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for AppPermissionsPackages {
-    fn from(value: &AppPermissionsPackages) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AppPermissionsPackages {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -3010,11 +2870,6 @@ pub enum AppPermissionsPages {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for AppPermissionsPages {
-    fn from(value: &AppPermissionsPages) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for AppPermissionsPages {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -3086,11 +2941,6 @@ pub enum AppPermissionsPullRequests {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for AppPermissionsPullRequests {
-    fn from(value: &AppPermissionsPullRequests) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AppPermissionsPullRequests {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -3164,11 +3014,6 @@ pub enum AppPermissionsRepositoryHooks {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for AppPermissionsRepositoryHooks {
-    fn from(value: &AppPermissionsRepositoryHooks) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for AppPermissionsRepositoryHooks {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -3240,11 +3085,6 @@ pub enum AppPermissionsRepositoryProjects {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for AppPermissionsRepositoryProjects {
-    fn from(value: &AppPermissionsRepositoryProjects) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AppPermissionsRepositoryProjects {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -3318,11 +3158,6 @@ pub enum AppPermissionsSecretScanningAlerts {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for AppPermissionsSecretScanningAlerts {
-    fn from(value: &AppPermissionsSecretScanningAlerts) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for AppPermissionsSecretScanningAlerts {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -3394,11 +3229,6 @@ pub enum AppPermissionsSecrets {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for AppPermissionsSecrets {
-    fn from(value: &AppPermissionsSecrets) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AppPermissionsSecrets {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -3472,11 +3302,6 @@ pub enum AppPermissionsSecurityEvents {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for AppPermissionsSecurityEvents {
-    fn from(value: &AppPermissionsSecurityEvents) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for AppPermissionsSecurityEvents {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -3548,11 +3373,6 @@ pub enum AppPermissionsSecurityScanningAlert {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for AppPermissionsSecurityScanningAlert {
-    fn from(value: &AppPermissionsSecurityScanningAlert) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AppPermissionsSecurityScanningAlert {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -3626,11 +3446,6 @@ pub enum AppPermissionsSingleFile {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for AppPermissionsSingleFile {
-    fn from(value: &AppPermissionsSingleFile) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for AppPermissionsSingleFile {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -3702,11 +3517,6 @@ pub enum AppPermissionsStatuses {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for AppPermissionsStatuses {
-    fn from(value: &AppPermissionsStatuses) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AppPermissionsStatuses {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -3780,11 +3590,6 @@ pub enum AppPermissionsTeamDiscussions {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for AppPermissionsTeamDiscussions {
-    fn from(value: &AppPermissionsTeamDiscussions) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for AppPermissionsTeamDiscussions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -3857,11 +3662,6 @@ pub enum AppPermissionsVulnerabilityAlerts {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for AppPermissionsVulnerabilityAlerts {
-    fn from(value: &AppPermissionsVulnerabilityAlerts) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for AppPermissionsVulnerabilityAlerts {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -3933,11 +3733,6 @@ pub enum AppPermissionsWorkflows {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for AppPermissionsWorkflows {
-    fn from(value: &AppPermissionsWorkflows) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AppPermissionsWorkflows {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -4031,11 +3826,6 @@ pub enum AuthorAssociation {
     None,
     #[serde(rename = "OWNER")]
     Owner,
-}
-impl ::std::convert::From<&Self> for AuthorAssociation {
-    fn from(value: &AuthorAssociation) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AuthorAssociation {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -4290,11 +4080,6 @@ pub struct BranchProtectionRule {
     pub strict_required_status_checks_policy: bool,
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
 }
-impl ::std::convert::From<&BranchProtectionRule> for BranchProtectionRule {
-    fn from(value: &BranchProtectionRule) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BranchProtectionRuleAllowDeletionsEnforcementLevel`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -4329,11 +4114,6 @@ pub enum BranchProtectionRuleAllowDeletionsEnforcementLevel {
     NonAdmins,
     #[serde(rename = "everyone")]
     Everyone,
-}
-impl ::std::convert::From<&Self> for BranchProtectionRuleAllowDeletionsEnforcementLevel {
-    fn from(value: &BranchProtectionRuleAllowDeletionsEnforcementLevel) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for BranchProtectionRuleAllowDeletionsEnforcementLevel {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -4415,11 +4195,6 @@ pub enum BranchProtectionRuleAllowForcePushesEnforcementLevel {
     NonAdmins,
     #[serde(rename = "everyone")]
     Everyone,
-}
-impl ::std::convert::From<&Self> for BranchProtectionRuleAllowForcePushesEnforcementLevel {
-    fn from(value: &BranchProtectionRuleAllowForcePushesEnforcementLevel) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for BranchProtectionRuleAllowForcePushesEnforcementLevel {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -4522,11 +4297,6 @@ pub struct BranchProtectionRuleCreated {
     pub rule: BranchProtectionRule,
     pub sender: User,
 }
-impl ::std::convert::From<&BranchProtectionRuleCreated> for BranchProtectionRuleCreated {
-    fn from(value: &BranchProtectionRuleCreated) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BranchProtectionRuleCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -4555,11 +4325,6 @@ impl ::std::convert::From<&BranchProtectionRuleCreated> for BranchProtectionRule
 pub enum BranchProtectionRuleCreatedAction {
     #[serde(rename = "created")]
     Created,
-}
-impl ::std::convert::From<&Self> for BranchProtectionRuleCreatedAction {
-    fn from(value: &BranchProtectionRuleCreatedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for BranchProtectionRuleCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -4654,11 +4419,6 @@ pub struct BranchProtectionRuleDeleted {
     pub rule: BranchProtectionRule,
     pub sender: User,
 }
-impl ::std::convert::From<&BranchProtectionRuleDeleted> for BranchProtectionRuleDeleted {
-    fn from(value: &BranchProtectionRuleDeleted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BranchProtectionRuleDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -4687,11 +4447,6 @@ impl ::std::convert::From<&BranchProtectionRuleDeleted> for BranchProtectionRule
 pub enum BranchProtectionRuleDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
-}
-impl ::std::convert::From<&Self> for BranchProtectionRuleDeletedAction {
-    fn from(value: &BranchProtectionRuleDeletedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for BranchProtectionRuleDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -4822,11 +4577,6 @@ pub struct BranchProtectionRuleEdited {
     pub rule: BranchProtectionRule,
     pub sender: User,
 }
-impl ::std::convert::From<&BranchProtectionRuleEdited> for BranchProtectionRuleEdited {
-    fn from(value: &BranchProtectionRuleEdited) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BranchProtectionRuleEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -4855,11 +4605,6 @@ impl ::std::convert::From<&BranchProtectionRuleEdited> for BranchProtectionRuleE
 pub enum BranchProtectionRuleEditedAction {
     #[serde(rename = "edited")]
     Edited,
-}
-impl ::std::convert::From<&Self> for BranchProtectionRuleEditedAction {
-    fn from(value: &BranchProtectionRuleEditedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for BranchProtectionRuleEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -4950,13 +4695,6 @@ pub struct BranchProtectionRuleEditedChanges {
     pub authorized_actors_only:
         ::std::option::Option<BranchProtectionRuleEditedChangesAuthorizedActorsOnly>,
 }
-impl ::std::convert::From<&BranchProtectionRuleEditedChanges>
-    for BranchProtectionRuleEditedChanges
-{
-    fn from(value: &BranchProtectionRuleEditedChanges) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for BranchProtectionRuleEditedChanges {
     fn default() -> Self {
         Self {
@@ -4992,13 +4730,6 @@ impl ::std::default::Default for BranchProtectionRuleEditedChanges {
 pub struct BranchProtectionRuleEditedChangesAuthorizedActorNames {
     pub from: ::std::vec::Vec<::std::string::String>,
 }
-impl ::std::convert::From<&BranchProtectionRuleEditedChangesAuthorizedActorNames>
-    for BranchProtectionRuleEditedChangesAuthorizedActorNames
-{
-    fn from(value: &BranchProtectionRuleEditedChangesAuthorizedActorNames) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BranchProtectionRuleEditedChangesAuthorizedActorsOnly`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -5022,13 +4753,6 @@ impl ::std::convert::From<&BranchProtectionRuleEditedChangesAuthorizedActorNames
 #[serde(deny_unknown_fields)]
 pub struct BranchProtectionRuleEditedChangesAuthorizedActorsOnly {
     pub from: bool,
-}
-impl ::std::convert::From<&BranchProtectionRuleEditedChangesAuthorizedActorsOnly>
-    for BranchProtectionRuleEditedChangesAuthorizedActorsOnly
-{
-    fn from(value: &BranchProtectionRuleEditedChangesAuthorizedActorsOnly) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`BranchProtectionRuleEvent`"]
 #[doc = r""]
@@ -5056,11 +4780,6 @@ pub enum BranchProtectionRuleEvent {
     Created(BranchProtectionRuleCreated),
     Deleted(BranchProtectionRuleDeleted),
     Edited(BranchProtectionRuleEdited),
-}
-impl ::std::convert::From<&Self> for BranchProtectionRuleEvent {
-    fn from(value: &BranchProtectionRuleEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<BranchProtectionRuleCreated> for BranchProtectionRuleEvent {
     fn from(value: BranchProtectionRuleCreated) -> Self {
@@ -5111,11 +4830,6 @@ pub enum BranchProtectionRuleLinearHistoryRequirementEnforcementLevel {
     NonAdmins,
     #[serde(rename = "everyone")]
     Everyone,
-}
-impl ::std::convert::From<&Self> for BranchProtectionRuleLinearHistoryRequirementEnforcementLevel {
-    fn from(value: &BranchProtectionRuleLinearHistoryRequirementEnforcementLevel) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for BranchProtectionRuleLinearHistoryRequirementEnforcementLevel {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -5200,11 +4914,6 @@ pub enum BranchProtectionRuleMergeQueueEnforcementLevel {
     #[serde(rename = "everyone")]
     Everyone,
 }
-impl ::std::convert::From<&Self> for BranchProtectionRuleMergeQueueEnforcementLevel {
-    fn from(value: &BranchProtectionRuleMergeQueueEnforcementLevel) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for BranchProtectionRuleMergeQueueEnforcementLevel {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -5285,11 +4994,6 @@ pub enum BranchProtectionRulePullRequestReviewsEnforcementLevel {
     NonAdmins,
     #[serde(rename = "everyone")]
     Everyone,
-}
-impl ::std::convert::From<&Self> for BranchProtectionRulePullRequestReviewsEnforcementLevel {
-    fn from(value: &BranchProtectionRulePullRequestReviewsEnforcementLevel) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for BranchProtectionRulePullRequestReviewsEnforcementLevel {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -5372,11 +5076,6 @@ pub enum BranchProtectionRuleRequiredConversationResolutionLevel {
     #[serde(rename = "everyone")]
     Everyone,
 }
-impl ::std::convert::From<&Self> for BranchProtectionRuleRequiredConversationResolutionLevel {
-    fn from(value: &BranchProtectionRuleRequiredConversationResolutionLevel) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for BranchProtectionRuleRequiredConversationResolutionLevel {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -5457,11 +5156,6 @@ pub enum BranchProtectionRuleRequiredDeploymentsEnforcementLevel {
     NonAdmins,
     #[serde(rename = "everyone")]
     Everyone,
-}
-impl ::std::convert::From<&Self> for BranchProtectionRuleRequiredDeploymentsEnforcementLevel {
-    fn from(value: &BranchProtectionRuleRequiredDeploymentsEnforcementLevel) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for BranchProtectionRuleRequiredDeploymentsEnforcementLevel {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -5544,11 +5238,6 @@ pub enum BranchProtectionRuleRequiredStatusChecksEnforcementLevel {
     #[serde(rename = "everyone")]
     Everyone,
 }
-impl ::std::convert::From<&Self> for BranchProtectionRuleRequiredStatusChecksEnforcementLevel {
-    fn from(value: &BranchProtectionRuleRequiredStatusChecksEnforcementLevel) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for BranchProtectionRuleRequiredStatusChecksEnforcementLevel {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -5629,11 +5318,6 @@ pub enum BranchProtectionRuleSignatureRequirementEnforcementLevel {
     NonAdmins,
     #[serde(rename = "everyone")]
     Everyone,
-}
-impl ::std::convert::From<&Self> for BranchProtectionRuleSignatureRequirementEnforcementLevel {
-    fn from(value: &BranchProtectionRuleSignatureRequirementEnforcementLevel) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for BranchProtectionRuleSignatureRequirementEnforcementLevel {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -5979,11 +5663,6 @@ pub struct CheckRunCompleted {
     pub requested_action: ::std::option::Option<CheckRunCompletedRequestedAction>,
     pub sender: User,
 }
-impl ::std::convert::From<&CheckRunCompleted> for CheckRunCompleted {
-    fn from(value: &CheckRunCompleted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CheckRunCompletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -6012,11 +5691,6 @@ impl ::std::convert::From<&CheckRunCompleted> for CheckRunCompleted {
 pub enum CheckRunCompletedAction {
     #[serde(rename = "completed")]
     Completed,
-}
-impl ::std::convert::From<&Self> for CheckRunCompletedAction {
-    fn from(value: &CheckRunCompletedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckRunCompletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -6322,11 +5996,6 @@ pub struct CheckRunCompletedCheckRun {
     pub status: CheckRunCompletedCheckRunStatus,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&CheckRunCompletedCheckRun> for CheckRunCompletedCheckRun {
-    fn from(value: &CheckRunCompletedCheckRun) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CheckRunCompletedCheckRunCheckSuite`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -6455,13 +6124,6 @@ pub struct CheckRunCompletedCheckRunCheckSuite {
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&CheckRunCompletedCheckRunCheckSuite>
-    for CheckRunCompletedCheckRunCheckSuite
-{
-    fn from(value: &CheckRunCompletedCheckRunCheckSuite) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CheckRunCompletedCheckRunCheckSuiteConclusion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -6508,11 +6170,6 @@ pub enum CheckRunCompletedCheckRunCheckSuiteConclusion {
     ActionRequired,
     #[serde(rename = "stale")]
     Stale,
-}
-impl ::std::convert::From<&Self> for CheckRunCompletedCheckRunCheckSuiteConclusion {
-    fn from(value: &CheckRunCompletedCheckRunCheckSuiteConclusion) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckRunCompletedCheckRunCheckSuiteConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -6602,11 +6259,6 @@ pub enum CheckRunCompletedCheckRunCheckSuiteStatus {
     Completed,
     #[serde(rename = "queued")]
     Queued,
-}
-impl ::std::convert::From<&Self> for CheckRunCompletedCheckRunCheckSuiteStatus {
-    fn from(value: &CheckRunCompletedCheckRunCheckSuiteStatus) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckRunCompletedCheckRunCheckSuiteStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -6700,11 +6352,6 @@ pub enum CheckRunCompletedCheckRunConclusion {
     Stale,
     #[serde(rename = "skipped")]
     Skipped,
-}
-impl ::std::convert::From<&Self> for CheckRunCompletedCheckRunConclusion {
-    fn from(value: &CheckRunCompletedCheckRunConclusion) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckRunCompletedCheckRunConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -6812,11 +6459,6 @@ pub struct CheckRunCompletedCheckRunOutput {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&CheckRunCompletedCheckRunOutput> for CheckRunCompletedCheckRunOutput {
-    fn from(value: &CheckRunCompletedCheckRunOutput) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The current status of the check run. Can be `queued`, `in_progress`, or `completed`."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -6846,11 +6488,6 @@ impl ::std::convert::From<&CheckRunCompletedCheckRunOutput> for CheckRunComplete
 pub enum CheckRunCompletedCheckRunStatus {
     #[serde(rename = "completed")]
     Completed,
-}
-impl ::std::convert::From<&Self> for CheckRunCompletedCheckRunStatus {
-    fn from(value: &CheckRunCompletedCheckRunStatus) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckRunCompletedCheckRunStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -6914,11 +6551,6 @@ pub struct CheckRunCompletedRequestedAction {
     #[doc = "The integrator reference of the action requested by the user."]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub identifier: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&CheckRunCompletedRequestedAction> for CheckRunCompletedRequestedAction {
-    fn from(value: &CheckRunCompletedRequestedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for CheckRunCompletedRequestedAction {
     fn default() -> Self {
@@ -7230,11 +6862,6 @@ pub struct CheckRunCreated {
     pub requested_action: ::std::option::Option<CheckRunCreatedRequestedAction>,
     pub sender: User,
 }
-impl ::std::convert::From<&CheckRunCreated> for CheckRunCreated {
-    fn from(value: &CheckRunCreated) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CheckRunCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -7263,11 +6890,6 @@ impl ::std::convert::From<&CheckRunCreated> for CheckRunCreated {
 pub enum CheckRunCreatedAction {
     #[serde(rename = "created")]
     Created,
-}
-impl ::std::convert::From<&Self> for CheckRunCreatedAction {
-    fn from(value: &CheckRunCreatedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckRunCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -7578,11 +7200,6 @@ pub struct CheckRunCreatedCheckRun {
     pub status: CheckRunCreatedCheckRunStatus,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&CheckRunCreatedCheckRun> for CheckRunCreatedCheckRun {
-    fn from(value: &CheckRunCreatedCheckRun) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CheckRunCreatedCheckRunCheckSuite`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -7711,13 +7328,6 @@ pub struct CheckRunCreatedCheckRunCheckSuite {
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&CheckRunCreatedCheckRunCheckSuite>
-    for CheckRunCreatedCheckRunCheckSuite
-{
-    fn from(value: &CheckRunCreatedCheckRunCheckSuite) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CheckRunCreatedCheckRunCheckSuiteConclusion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -7764,11 +7374,6 @@ pub enum CheckRunCreatedCheckRunCheckSuiteConclusion {
     ActionRequired,
     #[serde(rename = "stale")]
     Stale,
-}
-impl ::std::convert::From<&Self> for CheckRunCreatedCheckRunCheckSuiteConclusion {
-    fn from(value: &CheckRunCreatedCheckRunCheckSuiteConclusion) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckRunCreatedCheckRunCheckSuiteConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -7858,11 +7463,6 @@ pub enum CheckRunCreatedCheckRunCheckSuiteStatus {
     InProgress,
     #[serde(rename = "completed")]
     Completed,
-}
-impl ::std::convert::From<&Self> for CheckRunCreatedCheckRunCheckSuiteStatus {
-    fn from(value: &CheckRunCreatedCheckRunCheckSuiteStatus) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckRunCreatedCheckRunCheckSuiteStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -7956,11 +7556,6 @@ pub enum CheckRunCreatedCheckRunConclusion {
     Stale,
     #[serde(rename = "skipped")]
     Skipped,
-}
-impl ::std::convert::From<&Self> for CheckRunCreatedCheckRunConclusion {
-    fn from(value: &CheckRunCreatedCheckRunConclusion) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckRunCreatedCheckRunConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -8068,11 +7663,6 @@ pub struct CheckRunCreatedCheckRunOutput {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&CheckRunCreatedCheckRunOutput> for CheckRunCreatedCheckRunOutput {
-    fn from(value: &CheckRunCreatedCheckRunOutput) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The current status of the check run. Can be `queued`, `in_progress`, or `completed`."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -8108,11 +7698,6 @@ pub enum CheckRunCreatedCheckRunStatus {
     InProgress,
     #[serde(rename = "completed")]
     Completed,
-}
-impl ::std::convert::From<&Self> for CheckRunCreatedCheckRunStatus {
-    fn from(value: &CheckRunCreatedCheckRunStatus) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckRunCreatedCheckRunStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -8180,11 +7765,6 @@ pub struct CheckRunCreatedRequestedAction {
     #[doc = "The integrator reference of the action requested by the user."]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub identifier: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&CheckRunCreatedRequestedAction> for CheckRunCreatedRequestedAction {
-    fn from(value: &CheckRunCreatedRequestedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for CheckRunCreatedRequestedAction {
     fn default() -> Self {
@@ -8278,11 +7858,6 @@ pub struct CheckRunDeployment {
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&CheckRunDeployment> for CheckRunDeployment {
-    fn from(value: &CheckRunDeployment) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CheckRunEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -8313,11 +7888,6 @@ pub enum CheckRunEvent {
     Created(CheckRunCreated),
     RequestedAction(CheckRunRequestedAction),
     Rerequested(CheckRunRerequested),
-}
-impl ::std::convert::From<&Self> for CheckRunEvent {
-    fn from(value: &CheckRunEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<CheckRunCompleted> for CheckRunEvent {
     fn from(value: CheckRunCompleted) -> Self {
@@ -8420,11 +7990,6 @@ pub struct CheckRunPullRequest {
     pub number: i64,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&CheckRunPullRequest> for CheckRunPullRequest {
-    fn from(value: &CheckRunPullRequest) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CheckRunPullRequestBase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -8460,11 +8025,6 @@ pub struct CheckRunPullRequestBase {
     pub repo: RepoRef,
     pub sha: ::std::string::String,
 }
-impl ::std::convert::From<&CheckRunPullRequestBase> for CheckRunPullRequestBase {
-    fn from(value: &CheckRunPullRequestBase) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CheckRunPullRequestHead`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -8499,11 +8059,6 @@ pub struct CheckRunPullRequestHead {
     pub ref_: ::std::string::String,
     pub repo: RepoRef,
     pub sha: ::std::string::String,
-}
-impl ::std::convert::From<&CheckRunPullRequestHead> for CheckRunPullRequestHead {
-    fn from(value: &CheckRunPullRequestHead) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`CheckRunRequestedAction`"]
 #[doc = r""]
@@ -8804,11 +8359,6 @@ pub struct CheckRunRequestedAction {
     pub requested_action: CheckRunRequestedActionRequestedAction,
     pub sender: User,
 }
-impl ::std::convert::From<&CheckRunRequestedAction> for CheckRunRequestedAction {
-    fn from(value: &CheckRunRequestedAction) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CheckRunRequestedActionAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -8837,11 +8387,6 @@ impl ::std::convert::From<&CheckRunRequestedAction> for CheckRunRequestedAction 
 pub enum CheckRunRequestedActionAction {
     #[serde(rename = "requested_action")]
     RequestedAction,
-}
-impl ::std::convert::From<&Self> for CheckRunRequestedActionAction {
-    fn from(value: &CheckRunRequestedActionAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckRunRequestedActionAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -9152,11 +8697,6 @@ pub struct CheckRunRequestedActionCheckRun {
     pub status: CheckRunRequestedActionCheckRunStatus,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&CheckRunRequestedActionCheckRun> for CheckRunRequestedActionCheckRun {
-    fn from(value: &CheckRunRequestedActionCheckRun) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CheckRunRequestedActionCheckRunCheckSuite`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -9285,13 +8825,6 @@ pub struct CheckRunRequestedActionCheckRunCheckSuite {
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&CheckRunRequestedActionCheckRunCheckSuite>
-    for CheckRunRequestedActionCheckRunCheckSuite
-{
-    fn from(value: &CheckRunRequestedActionCheckRunCheckSuite) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CheckRunRequestedActionCheckRunCheckSuiteConclusion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -9338,11 +8871,6 @@ pub enum CheckRunRequestedActionCheckRunCheckSuiteConclusion {
     ActionRequired,
     #[serde(rename = "stale")]
     Stale,
-}
-impl ::std::convert::From<&Self> for CheckRunRequestedActionCheckRunCheckSuiteConclusion {
-    fn from(value: &CheckRunRequestedActionCheckRunCheckSuiteConclusion) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckRunRequestedActionCheckRunCheckSuiteConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -9432,11 +8960,6 @@ pub enum CheckRunRequestedActionCheckRunCheckSuiteStatus {
     InProgress,
     #[serde(rename = "completed")]
     Completed,
-}
-impl ::std::convert::From<&Self> for CheckRunRequestedActionCheckRunCheckSuiteStatus {
-    fn from(value: &CheckRunRequestedActionCheckRunCheckSuiteStatus) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckRunRequestedActionCheckRunCheckSuiteStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -9534,11 +9057,6 @@ pub enum CheckRunRequestedActionCheckRunConclusion {
     Stale,
     #[serde(rename = "skipped")]
     Skipped,
-}
-impl ::std::convert::From<&Self> for CheckRunRequestedActionCheckRunConclusion {
-    fn from(value: &CheckRunRequestedActionCheckRunConclusion) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckRunRequestedActionCheckRunConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -9646,13 +9164,6 @@ pub struct CheckRunRequestedActionCheckRunOutput {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&CheckRunRequestedActionCheckRunOutput>
-    for CheckRunRequestedActionCheckRunOutput
-{
-    fn from(value: &CheckRunRequestedActionCheckRunOutput) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The current status of the check run. Can be `queued`, `in_progress`, or `completed`."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -9688,11 +9199,6 @@ pub enum CheckRunRequestedActionCheckRunStatus {
     InProgress,
     #[serde(rename = "completed")]
     Completed,
-}
-impl ::std::convert::From<&Self> for CheckRunRequestedActionCheckRunStatus {
-    fn from(value: &CheckRunRequestedActionCheckRunStatus) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckRunRequestedActionCheckRunStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -9760,13 +9266,6 @@ pub struct CheckRunRequestedActionRequestedAction {
     #[doc = "The integrator reference of the action requested by the user."]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub identifier: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&CheckRunRequestedActionRequestedAction>
-    for CheckRunRequestedActionRequestedAction
-{
-    fn from(value: &CheckRunRequestedActionRequestedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for CheckRunRequestedActionRequestedAction {
     fn default() -> Self {
@@ -10067,11 +9566,6 @@ pub struct CheckRunRerequested {
     pub requested_action: ::std::option::Option<CheckRunRerequestedRequestedAction>,
     pub sender: User,
 }
-impl ::std::convert::From<&CheckRunRerequested> for CheckRunRerequested {
-    fn from(value: &CheckRunRerequested) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CheckRunRerequestedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -10100,11 +9594,6 @@ impl ::std::convert::From<&CheckRunRerequested> for CheckRunRerequested {
 pub enum CheckRunRerequestedAction {
     #[serde(rename = "rerequested")]
     Rerequested,
-}
-impl ::std::convert::From<&Self> for CheckRunRerequestedAction {
-    fn from(value: &CheckRunRerequestedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckRunRerequestedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -10404,11 +9893,6 @@ pub struct CheckRunRerequestedCheckRun {
     pub status: CheckRunRerequestedCheckRunStatus,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&CheckRunRerequestedCheckRun> for CheckRunRerequestedCheckRun {
-    fn from(value: &CheckRunRerequestedCheckRun) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CheckRunRerequestedCheckRunCheckSuite`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -10531,13 +10015,6 @@ pub struct CheckRunRerequestedCheckRunCheckSuite {
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&CheckRunRerequestedCheckRunCheckSuite>
-    for CheckRunRerequestedCheckRunCheckSuite
-{
-    fn from(value: &CheckRunRerequestedCheckRunCheckSuite) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CheckRunRerequestedCheckRunCheckSuiteConclusion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -10584,11 +10061,6 @@ pub enum CheckRunRerequestedCheckRunCheckSuiteConclusion {
     ActionRequired,
     #[serde(rename = "stale")]
     Stale,
-}
-impl ::std::convert::From<&Self> for CheckRunRerequestedCheckRunCheckSuiteConclusion {
-    fn from(value: &CheckRunRerequestedCheckRunCheckSuiteConclusion) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckRunRerequestedCheckRunCheckSuiteConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -10672,11 +10144,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum CheckRunRerequestedCheckRunCheckSuiteStatus {
     #[serde(rename = "completed")]
     Completed,
-}
-impl ::std::convert::From<&Self> for CheckRunRerequestedCheckRunCheckSuiteStatus {
-    fn from(value: &CheckRunRerequestedCheckRunCheckSuiteStatus) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckRunRerequestedCheckRunCheckSuiteStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -10770,11 +10237,6 @@ pub enum CheckRunRerequestedCheckRunConclusion {
     Stale,
     #[serde(rename = "skipped")]
     Skipped,
-}
-impl ::std::convert::From<&Self> for CheckRunRerequestedCheckRunConclusion {
-    fn from(value: &CheckRunRerequestedCheckRunConclusion) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckRunRerequestedCheckRunConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -10882,13 +10344,6 @@ pub struct CheckRunRerequestedCheckRunOutput {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&CheckRunRerequestedCheckRunOutput>
-    for CheckRunRerequestedCheckRunOutput
-{
-    fn from(value: &CheckRunRerequestedCheckRunOutput) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The phase of the lifecycle that the check is currently in."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -10918,11 +10373,6 @@ impl ::std::convert::From<&CheckRunRerequestedCheckRunOutput>
 pub enum CheckRunRerequestedCheckRunStatus {
     #[serde(rename = "completed")]
     Completed,
-}
-impl ::std::convert::From<&Self> for CheckRunRerequestedCheckRunStatus {
-    fn from(value: &CheckRunRerequestedCheckRunStatus) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckRunRerequestedCheckRunStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -10986,13 +10436,6 @@ pub struct CheckRunRerequestedRequestedAction {
     #[doc = "The integrator reference of the action requested by the user."]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub identifier: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&CheckRunRerequestedRequestedAction>
-    for CheckRunRerequestedRequestedAction
-{
-    fn from(value: &CheckRunRerequestedRequestedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for CheckRunRerequestedRequestedAction {
     fn default() -> Self {
@@ -11167,11 +10610,6 @@ pub struct CheckSuiteCompleted {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&CheckSuiteCompleted> for CheckSuiteCompleted {
-    fn from(value: &CheckSuiteCompleted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CheckSuiteCompletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -11200,11 +10638,6 @@ impl ::std::convert::From<&CheckSuiteCompleted> for CheckSuiteCompleted {
 pub enum CheckSuiteCompletedAction {
     #[serde(rename = "completed")]
     Completed,
-}
-impl ::std::convert::From<&Self> for CheckSuiteCompletedAction {
-    fn from(value: &CheckSuiteCompletedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckSuiteCompletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -11392,11 +10825,6 @@ pub struct CheckSuiteCompletedCheckSuite {
     #[doc = "URL that points to the check suite API resource."]
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&CheckSuiteCompletedCheckSuite> for CheckSuiteCompletedCheckSuite {
-    fn from(value: &CheckSuiteCompletedCheckSuite) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The summary conclusion for all check runs that are part of the check suite. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has `completed`."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -11444,11 +10872,6 @@ pub enum CheckSuiteCompletedCheckSuiteConclusion {
     ActionRequired,
     #[serde(rename = "stale")]
     Stale,
-}
-impl ::std::convert::From<&Self> for CheckSuiteCompletedCheckSuiteConclusion {
-    fn from(value: &CheckSuiteCompletedCheckSuiteConclusion) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckSuiteCompletedCheckSuiteConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -11539,11 +10962,6 @@ pub enum CheckSuiteCompletedCheckSuiteStatus {
     #[serde(rename = "queued")]
     Queued,
 }
-impl ::std::convert::From<&Self> for CheckSuiteCompletedCheckSuiteStatus {
-    fn from(value: &CheckSuiteCompletedCheckSuiteStatus) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for CheckSuiteCompletedCheckSuiteStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -11614,11 +11032,6 @@ pub enum CheckSuiteEvent {
     Completed(CheckSuiteCompleted),
     Requested(CheckSuiteRequested),
     Rerequested(CheckSuiteRerequested),
-}
-impl ::std::convert::From<&Self> for CheckSuiteEvent {
-    fn from(value: &CheckSuiteEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<CheckSuiteCompleted> for CheckSuiteEvent {
     fn from(value: CheckSuiteCompleted) -> Self {
@@ -11801,11 +11214,6 @@ pub struct CheckSuiteRequested {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&CheckSuiteRequested> for CheckSuiteRequested {
-    fn from(value: &CheckSuiteRequested) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CheckSuiteRequestedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -11834,11 +11242,6 @@ impl ::std::convert::From<&CheckSuiteRequested> for CheckSuiteRequested {
 pub enum CheckSuiteRequestedAction {
     #[serde(rename = "requested")]
     Requested,
-}
-impl ::std::convert::From<&Self> for CheckSuiteRequestedAction {
-    fn from(value: &CheckSuiteRequestedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckSuiteRequestedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -12026,11 +11429,6 @@ pub struct CheckSuiteRequestedCheckSuite {
     #[doc = "URL that points to the check suite API resource."]
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&CheckSuiteRequestedCheckSuite> for CheckSuiteRequestedCheckSuite {
-    fn from(value: &CheckSuiteRequestedCheckSuite) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The summary conclusion for all check runs that are part of the check suite. Can be one of `success`, `failure`,` neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -12078,11 +11476,6 @@ pub enum CheckSuiteRequestedCheckSuiteConclusion {
     ActionRequired,
     #[serde(rename = "stale")]
     Stale,
-}
-impl ::std::convert::From<&Self> for CheckSuiteRequestedCheckSuiteConclusion {
-    fn from(value: &CheckSuiteRequestedCheckSuiteConclusion) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckSuiteRequestedCheckSuiteConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -12172,11 +11565,6 @@ pub enum CheckSuiteRequestedCheckSuiteStatus {
     Completed,
     #[serde(rename = "queued")]
     Queued,
-}
-impl ::std::convert::From<&Self> for CheckSuiteRequestedCheckSuiteStatus {
-    fn from(value: &CheckSuiteRequestedCheckSuiteStatus) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckSuiteRequestedCheckSuiteStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -12388,11 +11776,6 @@ pub struct CheckSuiteRerequested {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&CheckSuiteRerequested> for CheckSuiteRerequested {
-    fn from(value: &CheckSuiteRerequested) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CheckSuiteRerequestedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -12421,11 +11804,6 @@ impl ::std::convert::From<&CheckSuiteRerequested> for CheckSuiteRerequested {
 pub enum CheckSuiteRerequestedAction {
     #[serde(rename = "rerequested")]
     Rerequested,
-}
-impl ::std::convert::From<&Self> for CheckSuiteRerequestedAction {
-    fn from(value: &CheckSuiteRerequestedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckSuiteRerequestedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -12613,11 +11991,6 @@ pub struct CheckSuiteRerequestedCheckSuite {
     #[doc = "URL that points to the check suite API resource."]
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&CheckSuiteRerequestedCheckSuite> for CheckSuiteRerequestedCheckSuite {
-    fn from(value: &CheckSuiteRerequestedCheckSuite) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The summary conclusion for all check runs that are part of the check suite. Can be one of `success`, `failure`,` neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -12665,11 +12038,6 @@ pub enum CheckSuiteRerequestedCheckSuiteConclusion {
     ActionRequired,
     #[serde(rename = "stale")]
     Stale,
-}
-impl ::std::convert::From<&Self> for CheckSuiteRerequestedCheckSuiteConclusion {
-    fn from(value: &CheckSuiteRerequestedCheckSuiteConclusion) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckSuiteRerequestedCheckSuiteConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -12759,11 +12127,6 @@ pub enum CheckSuiteRerequestedCheckSuiteStatus {
     Completed,
     #[serde(rename = "queued")]
     Queued,
-}
-impl ::std::convert::From<&Self> for CheckSuiteRerequestedCheckSuiteStatus {
-    fn from(value: &CheckSuiteRerequestedCheckSuiteStatus) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CheckSuiteRerequestedCheckSuiteStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -13016,13 +12379,6 @@ pub struct CodeScanningAlertAppearedInBranch {
     pub repository: Repository,
     pub sender: GithubOrg,
 }
-impl ::std::convert::From<&CodeScanningAlertAppearedInBranch>
-    for CodeScanningAlertAppearedInBranch
-{
-    fn from(value: &CodeScanningAlertAppearedInBranch) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CodeScanningAlertAppearedInBranchAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -13051,11 +12407,6 @@ impl ::std::convert::From<&CodeScanningAlertAppearedInBranch>
 pub enum CodeScanningAlertAppearedInBranchAction {
     #[serde(rename = "appeared_in_branch")]
     AppearedInBranch,
-}
-impl ::std::convert::From<&Self> for CodeScanningAlertAppearedInBranchAction {
-    fn from(value: &CodeScanningAlertAppearedInBranchAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CodeScanningAlertAppearedInBranchAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -13267,13 +12618,6 @@ pub struct CodeScanningAlertAppearedInBranchAlert {
     pub tool: CodeScanningAlertAppearedInBranchAlertTool,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&CodeScanningAlertAppearedInBranchAlert>
-    for CodeScanningAlertAppearedInBranchAlert
-{
-    fn from(value: &CodeScanningAlertAppearedInBranchAlert) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -13309,11 +12653,6 @@ pub enum CodeScanningAlertAppearedInBranchAlertDismissedReason {
     WontFix,
     #[serde(rename = "used in tests")]
     UsedInTests,
-}
-impl ::std::convert::From<&Self> for CodeScanningAlertAppearedInBranchAlertDismissedReason {
-    fn from(value: &CodeScanningAlertAppearedInBranchAlertDismissedReason) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CodeScanningAlertAppearedInBranchAlertDismissedReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -13411,13 +12750,6 @@ pub struct CodeScanningAlertAppearedInBranchAlertRule {
     #[doc = "The severity of the alert."]
     pub severity: ::std::option::Option<CodeScanningAlertAppearedInBranchAlertRuleSeverity>,
 }
-impl ::std::convert::From<&CodeScanningAlertAppearedInBranchAlertRule>
-    for CodeScanningAlertAppearedInBranchAlertRule
-{
-    fn from(value: &CodeScanningAlertAppearedInBranchAlertRule) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The severity of the alert."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -13456,11 +12788,6 @@ pub enum CodeScanningAlertAppearedInBranchAlertRuleSeverity {
     Warning,
     #[serde(rename = "error")]
     Error,
-}
-impl ::std::convert::From<&Self> for CodeScanningAlertAppearedInBranchAlertRuleSeverity {
-    fn from(value: &CodeScanningAlertAppearedInBranchAlertRuleSeverity) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CodeScanningAlertAppearedInBranchAlertRuleSeverity {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -13546,11 +12873,6 @@ pub enum CodeScanningAlertAppearedInBranchAlertState {
     #[serde(rename = "fixed")]
     Fixed,
 }
-impl ::std::convert::From<&Self> for CodeScanningAlertAppearedInBranchAlertState {
-    fn from(value: &CodeScanningAlertAppearedInBranchAlertState) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for CodeScanningAlertAppearedInBranchAlertState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -13632,13 +12954,6 @@ pub struct CodeScanningAlertAppearedInBranchAlertTool {
     pub name: ::std::string::String,
     #[doc = "The version of the tool used to detect the alert."]
     pub version: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&CodeScanningAlertAppearedInBranchAlertTool>
-    for CodeScanningAlertAppearedInBranchAlertTool
-{
-    fn from(value: &CodeScanningAlertAppearedInBranchAlertTool) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`CodeScanningAlertClosedByUser`"]
 #[doc = r""]
@@ -13869,11 +13184,6 @@ pub struct CodeScanningAlertClosedByUser {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&CodeScanningAlertClosedByUser> for CodeScanningAlertClosedByUser {
-    fn from(value: &CodeScanningAlertClosedByUser) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CodeScanningAlertClosedByUserAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -13902,11 +13212,6 @@ impl ::std::convert::From<&CodeScanningAlertClosedByUser> for CodeScanningAlertC
 pub enum CodeScanningAlertClosedByUserAction {
     #[serde(rename = "closed_by_user")]
     ClosedByUser,
-}
-impl ::std::convert::From<&Self> for CodeScanningAlertClosedByUserAction {
-    fn from(value: &CodeScanningAlertClosedByUserAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CodeScanningAlertClosedByUserAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -14139,13 +13444,6 @@ pub struct CodeScanningAlertClosedByUserAlert {
     pub tool: CodeScanningAlertClosedByUserAlertTool,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&CodeScanningAlertClosedByUserAlert>
-    for CodeScanningAlertClosedByUserAlert
-{
-    fn from(value: &CodeScanningAlertClosedByUserAlert) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -14182,11 +13480,6 @@ pub enum CodeScanningAlertClosedByUserAlertDismissedReason {
     WontFix,
     #[serde(rename = "used in tests")]
     UsedInTests,
-}
-impl ::std::convert::From<&Self> for CodeScanningAlertClosedByUserAlertDismissedReason {
-    fn from(value: &CodeScanningAlertClosedByUserAlertDismissedReason) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CodeScanningAlertClosedByUserAlertDismissedReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -14283,13 +13576,6 @@ pub struct CodeScanningAlertClosedByUserAlertInstancesItem {
     pub ref_: ::std::string::String,
     pub state: CodeScanningAlertClosedByUserAlertInstancesItemState,
 }
-impl ::std::convert::From<&CodeScanningAlertClosedByUserAlertInstancesItem>
-    for CodeScanningAlertClosedByUserAlertInstancesItem
-{
-    fn from(value: &CodeScanningAlertClosedByUserAlertInstancesItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CodeScanningAlertClosedByUserAlertInstancesItemLocation`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -14332,13 +13618,6 @@ pub struct CodeScanningAlertClosedByUserAlertInstancesItemLocation {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub start_line: ::std::option::Option<i64>,
 }
-impl ::std::convert::From<&CodeScanningAlertClosedByUserAlertInstancesItemLocation>
-    for CodeScanningAlertClosedByUserAlertInstancesItemLocation
-{
-    fn from(value: &CodeScanningAlertClosedByUserAlertInstancesItemLocation) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for CodeScanningAlertClosedByUserAlertInstancesItemLocation {
     fn default() -> Self {
         Self {
@@ -14371,13 +13650,6 @@ impl ::std::default::Default for CodeScanningAlertClosedByUserAlertInstancesItem
 pub struct CodeScanningAlertClosedByUserAlertInstancesItemMessage {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub text: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&CodeScanningAlertClosedByUserAlertInstancesItemMessage>
-    for CodeScanningAlertClosedByUserAlertInstancesItemMessage
-{
-    fn from(value: &CodeScanningAlertClosedByUserAlertInstancesItemMessage) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for CodeScanningAlertClosedByUserAlertInstancesItemMessage {
     fn default() -> Self {
@@ -14414,11 +13686,6 @@ impl ::std::default::Default for CodeScanningAlertClosedByUserAlertInstancesItem
 pub enum CodeScanningAlertClosedByUserAlertInstancesItemState {
     #[serde(rename = "dismissed")]
     Dismissed,
-}
-impl ::std::convert::From<&Self> for CodeScanningAlertClosedByUserAlertInstancesItemState {
-    fn from(value: &CodeScanningAlertClosedByUserAlertInstancesItemState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CodeScanningAlertClosedByUserAlertInstancesItemState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -14532,13 +13799,6 @@ pub struct CodeScanningAlertClosedByUserAlertRule {
     #[serde(default)]
     pub tags: (),
 }
-impl ::std::convert::From<&CodeScanningAlertClosedByUserAlertRule>
-    for CodeScanningAlertClosedByUserAlertRule
-{
-    fn from(value: &CodeScanningAlertClosedByUserAlertRule) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The severity of the alert."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -14577,11 +13837,6 @@ pub enum CodeScanningAlertClosedByUserAlertRuleSeverity {
     Warning,
     #[serde(rename = "error")]
     Error,
-}
-impl ::std::convert::From<&Self> for CodeScanningAlertClosedByUserAlertRuleSeverity {
-    fn from(value: &CodeScanningAlertClosedByUserAlertRuleSeverity) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CodeScanningAlertClosedByUserAlertRuleSeverity {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -14660,11 +13915,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum CodeScanningAlertClosedByUserAlertState {
     #[serde(rename = "dismissed")]
     Dismissed,
-}
-impl ::std::convert::From<&Self> for CodeScanningAlertClosedByUserAlertState {
-    fn from(value: &CodeScanningAlertClosedByUserAlertState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CodeScanningAlertClosedByUserAlertState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -14747,13 +13997,6 @@ pub struct CodeScanningAlertClosedByUserAlertTool {
     pub name: ::std::string::String,
     #[doc = "The version of the tool used to detect the alert."]
     pub version: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&CodeScanningAlertClosedByUserAlertTool>
-    for CodeScanningAlertClosedByUserAlertTool
-{
-    fn from(value: &CodeScanningAlertClosedByUserAlertTool) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`CodeScanningAlertCreated`"]
 #[doc = r""]
@@ -14979,11 +14222,6 @@ pub struct CodeScanningAlertCreated {
     pub repository: Repository,
     pub sender: GithubOrg,
 }
-impl ::std::convert::From<&CodeScanningAlertCreated> for CodeScanningAlertCreated {
-    fn from(value: &CodeScanningAlertCreated) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CodeScanningAlertCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -15012,11 +14250,6 @@ impl ::std::convert::From<&CodeScanningAlertCreated> for CodeScanningAlertCreate
 pub enum CodeScanningAlertCreatedAction {
     #[serde(rename = "created")]
     Created,
-}
-impl ::std::convert::From<&Self> for CodeScanningAlertCreatedAction {
-    fn from(value: &CodeScanningAlertCreatedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CodeScanningAlertCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -15244,11 +14477,6 @@ pub struct CodeScanningAlertCreatedAlert {
     pub tool: CodeScanningAlertCreatedAlertTool,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&CodeScanningAlertCreatedAlert> for CodeScanningAlertCreatedAlert {
-    fn from(value: &CodeScanningAlertCreatedAlert) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CodeScanningAlertCreatedAlertInstancesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -15299,13 +14527,6 @@ pub struct CodeScanningAlertCreatedAlertInstancesItem {
     pub ref_: ::std::string::String,
     pub state: CodeScanningAlertCreatedAlertInstancesItemState,
 }
-impl ::std::convert::From<&CodeScanningAlertCreatedAlertInstancesItem>
-    for CodeScanningAlertCreatedAlertInstancesItem
-{
-    fn from(value: &CodeScanningAlertCreatedAlertInstancesItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CodeScanningAlertCreatedAlertInstancesItemLocation`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -15348,13 +14569,6 @@ pub struct CodeScanningAlertCreatedAlertInstancesItemLocation {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub start_line: ::std::option::Option<i64>,
 }
-impl ::std::convert::From<&CodeScanningAlertCreatedAlertInstancesItemLocation>
-    for CodeScanningAlertCreatedAlertInstancesItemLocation
-{
-    fn from(value: &CodeScanningAlertCreatedAlertInstancesItemLocation) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for CodeScanningAlertCreatedAlertInstancesItemLocation {
     fn default() -> Self {
         Self {
@@ -15387,13 +14601,6 @@ impl ::std::default::Default for CodeScanningAlertCreatedAlertInstancesItemLocat
 pub struct CodeScanningAlertCreatedAlertInstancesItemMessage {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub text: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&CodeScanningAlertCreatedAlertInstancesItemMessage>
-    for CodeScanningAlertCreatedAlertInstancesItemMessage
-{
-    fn from(value: &CodeScanningAlertCreatedAlertInstancesItemMessage) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for CodeScanningAlertCreatedAlertInstancesItemMessage {
     fn default() -> Self {
@@ -15433,11 +14640,6 @@ pub enum CodeScanningAlertCreatedAlertInstancesItemState {
     Open,
     #[serde(rename = "dismissed")]
     Dismissed,
-}
-impl ::std::convert::From<&Self> for CodeScanningAlertCreatedAlertInstancesItemState {
-    fn from(value: &CodeScanningAlertCreatedAlertInstancesItemState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CodeScanningAlertCreatedAlertInstancesItemState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -15553,13 +14755,6 @@ pub struct CodeScanningAlertCreatedAlertRule {
     #[serde(default)]
     pub tags: (),
 }
-impl ::std::convert::From<&CodeScanningAlertCreatedAlertRule>
-    for CodeScanningAlertCreatedAlertRule
-{
-    fn from(value: &CodeScanningAlertCreatedAlertRule) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The severity of the alert."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -15598,11 +14793,6 @@ pub enum CodeScanningAlertCreatedAlertRuleSeverity {
     Warning,
     #[serde(rename = "error")]
     Error,
-}
-impl ::std::convert::From<&Self> for CodeScanningAlertCreatedAlertRuleSeverity {
-    fn from(value: &CodeScanningAlertCreatedAlertRuleSeverity) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CodeScanningAlertCreatedAlertRuleSeverity {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -15680,11 +14870,6 @@ pub enum CodeScanningAlertCreatedAlertState {
     Open,
     #[serde(rename = "dismissed")]
     Dismissed,
-}
-impl ::std::convert::From<&Self> for CodeScanningAlertCreatedAlertState {
-    fn from(value: &CodeScanningAlertCreatedAlertState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CodeScanningAlertCreatedAlertState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -15770,13 +14955,6 @@ pub struct CodeScanningAlertCreatedAlertTool {
     #[doc = "The version of the tool used to detect the alert."]
     pub version: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&CodeScanningAlertCreatedAlertTool>
-    for CodeScanningAlertCreatedAlertTool
-{
-    fn from(value: &CodeScanningAlertCreatedAlertTool) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CodeScanningAlertEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -15815,11 +14993,6 @@ pub enum CodeScanningAlertEvent {
     Fixed(CodeScanningAlertFixed),
     Reopened(CodeScanningAlertReopened),
     ReopenedByUser(CodeScanningAlertReopenedByUser),
-}
-impl ::std::convert::From<&Self> for CodeScanningAlertEvent {
-    fn from(value: &CodeScanningAlertEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<CodeScanningAlertAppearedInBranch> for CodeScanningAlertEvent {
     fn from(value: CodeScanningAlertAppearedInBranch) -> Self {
@@ -16097,11 +15270,6 @@ pub struct CodeScanningAlertFixed {
     pub repository: Repository,
     pub sender: GithubOrg,
 }
-impl ::std::convert::From<&CodeScanningAlertFixed> for CodeScanningAlertFixed {
-    fn from(value: &CodeScanningAlertFixed) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CodeScanningAlertFixedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -16130,11 +15298,6 @@ impl ::std::convert::From<&CodeScanningAlertFixed> for CodeScanningAlertFixed {
 pub enum CodeScanningAlertFixedAction {
     #[serde(rename = "fixed")]
     Fixed,
-}
-impl ::std::convert::From<&Self> for CodeScanningAlertFixedAction {
-    fn from(value: &CodeScanningAlertFixedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CodeScanningAlertFixedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -16386,11 +15549,6 @@ pub struct CodeScanningAlertFixedAlert {
     pub tool: CodeScanningAlertFixedAlertTool,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&CodeScanningAlertFixedAlert> for CodeScanningAlertFixedAlert {
-    fn from(value: &CodeScanningAlertFixedAlert) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -16426,11 +15584,6 @@ pub enum CodeScanningAlertFixedAlertDismissedReason {
     WontFix,
     #[serde(rename = "used in tests")]
     UsedInTests,
-}
-impl ::std::convert::From<&Self> for CodeScanningAlertFixedAlertDismissedReason {
-    fn from(value: &CodeScanningAlertFixedAlertDismissedReason) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CodeScanningAlertFixedAlertDismissedReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -16525,13 +15678,6 @@ pub struct CodeScanningAlertFixedAlertInstancesItem {
     pub ref_: ::std::string::String,
     pub state: CodeScanningAlertFixedAlertInstancesItemState,
 }
-impl ::std::convert::From<&CodeScanningAlertFixedAlertInstancesItem>
-    for CodeScanningAlertFixedAlertInstancesItem
-{
-    fn from(value: &CodeScanningAlertFixedAlertInstancesItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CodeScanningAlertFixedAlertInstancesItemLocation`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -16574,13 +15720,6 @@ pub struct CodeScanningAlertFixedAlertInstancesItemLocation {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub start_line: ::std::option::Option<i64>,
 }
-impl ::std::convert::From<&CodeScanningAlertFixedAlertInstancesItemLocation>
-    for CodeScanningAlertFixedAlertInstancesItemLocation
-{
-    fn from(value: &CodeScanningAlertFixedAlertInstancesItemLocation) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for CodeScanningAlertFixedAlertInstancesItemLocation {
     fn default() -> Self {
         Self {
@@ -16613,13 +15752,6 @@ impl ::std::default::Default for CodeScanningAlertFixedAlertInstancesItemLocatio
 pub struct CodeScanningAlertFixedAlertInstancesItemMessage {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub text: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&CodeScanningAlertFixedAlertInstancesItemMessage>
-    for CodeScanningAlertFixedAlertInstancesItemMessage
-{
-    fn from(value: &CodeScanningAlertFixedAlertInstancesItemMessage) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for CodeScanningAlertFixedAlertInstancesItemMessage {
     fn default() -> Self {
@@ -16656,11 +15788,6 @@ impl ::std::default::Default for CodeScanningAlertFixedAlertInstancesItemMessage
 pub enum CodeScanningAlertFixedAlertInstancesItemState {
     #[serde(rename = "fixed")]
     Fixed,
-}
-impl ::std::convert::From<&Self> for CodeScanningAlertFixedAlertInstancesItemState {
-    fn from(value: &CodeScanningAlertFixedAlertInstancesItemState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CodeScanningAlertFixedAlertInstancesItemState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -16774,11 +15901,6 @@ pub struct CodeScanningAlertFixedAlertRule {
     #[serde(default)]
     pub tags: (),
 }
-impl ::std::convert::From<&CodeScanningAlertFixedAlertRule> for CodeScanningAlertFixedAlertRule {
-    fn from(value: &CodeScanningAlertFixedAlertRule) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The severity of the alert."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -16817,11 +15939,6 @@ pub enum CodeScanningAlertFixedAlertRuleSeverity {
     Warning,
     #[serde(rename = "error")]
     Error,
-}
-impl ::std::convert::From<&Self> for CodeScanningAlertFixedAlertRuleSeverity {
-    fn from(value: &CodeScanningAlertFixedAlertRuleSeverity) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CodeScanningAlertFixedAlertRuleSeverity {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -16896,11 +16013,6 @@ impl ::std::convert::TryFrom<::std::string::String> for CodeScanningAlertFixedAl
 pub enum CodeScanningAlertFixedAlertState {
     #[serde(rename = "fixed")]
     Fixed,
-}
-impl ::std::convert::From<&Self> for CodeScanningAlertFixedAlertState {
-    fn from(value: &CodeScanningAlertFixedAlertState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CodeScanningAlertFixedAlertState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -16983,11 +16095,6 @@ pub struct CodeScanningAlertFixedAlertTool {
     pub name: ::std::string::String,
     #[doc = "The version of the tool used to detect the alert."]
     pub version: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&CodeScanningAlertFixedAlertTool> for CodeScanningAlertFixedAlertTool {
-    fn from(value: &CodeScanningAlertFixedAlertTool) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`CodeScanningAlertReopened`"]
 #[doc = r""]
@@ -17213,11 +16320,6 @@ pub struct CodeScanningAlertReopened {
     pub repository: Repository,
     pub sender: GithubOrg,
 }
-impl ::std::convert::From<&CodeScanningAlertReopened> for CodeScanningAlertReopened {
-    fn from(value: &CodeScanningAlertReopened) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CodeScanningAlertReopenedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -17246,11 +16348,6 @@ impl ::std::convert::From<&CodeScanningAlertReopened> for CodeScanningAlertReope
 pub enum CodeScanningAlertReopenedAction {
     #[serde(rename = "reopened")]
     Reopened,
-}
-impl ::std::convert::From<&Self> for CodeScanningAlertReopenedAction {
-    fn from(value: &CodeScanningAlertReopenedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CodeScanningAlertReopenedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -17478,11 +16575,6 @@ pub struct CodeScanningAlertReopenedAlert {
     pub tool: CodeScanningAlertReopenedAlertTool,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&CodeScanningAlertReopenedAlert> for CodeScanningAlertReopenedAlert {
-    fn from(value: &CodeScanningAlertReopenedAlert) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CodeScanningAlertReopenedAlertInstancesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -17532,13 +16624,6 @@ pub struct CodeScanningAlertReopenedAlertInstancesItem {
     pub ref_: ::std::string::String,
     pub state: CodeScanningAlertReopenedAlertInstancesItemState,
 }
-impl ::std::convert::From<&CodeScanningAlertReopenedAlertInstancesItem>
-    for CodeScanningAlertReopenedAlertInstancesItem
-{
-    fn from(value: &CodeScanningAlertReopenedAlertInstancesItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CodeScanningAlertReopenedAlertInstancesItemLocation`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -17581,13 +16666,6 @@ pub struct CodeScanningAlertReopenedAlertInstancesItemLocation {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub start_line: ::std::option::Option<i64>,
 }
-impl ::std::convert::From<&CodeScanningAlertReopenedAlertInstancesItemLocation>
-    for CodeScanningAlertReopenedAlertInstancesItemLocation
-{
-    fn from(value: &CodeScanningAlertReopenedAlertInstancesItemLocation) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for CodeScanningAlertReopenedAlertInstancesItemLocation {
     fn default() -> Self {
         Self {
@@ -17620,13 +16698,6 @@ impl ::std::default::Default for CodeScanningAlertReopenedAlertInstancesItemLoca
 pub struct CodeScanningAlertReopenedAlertInstancesItemMessage {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub text: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&CodeScanningAlertReopenedAlertInstancesItemMessage>
-    for CodeScanningAlertReopenedAlertInstancesItemMessage
-{
-    fn from(value: &CodeScanningAlertReopenedAlertInstancesItemMessage) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for CodeScanningAlertReopenedAlertInstancesItemMessage {
     fn default() -> Self {
@@ -17663,11 +16734,6 @@ impl ::std::default::Default for CodeScanningAlertReopenedAlertInstancesItemMess
 pub enum CodeScanningAlertReopenedAlertInstancesItemState {
     #[serde(rename = "open")]
     Open,
-}
-impl ::std::convert::From<&Self> for CodeScanningAlertReopenedAlertInstancesItemState {
-    fn from(value: &CodeScanningAlertReopenedAlertInstancesItemState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CodeScanningAlertReopenedAlertInstancesItemState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -17781,13 +16847,6 @@ pub struct CodeScanningAlertReopenedAlertRule {
     #[serde(default)]
     pub tags: (),
 }
-impl ::std::convert::From<&CodeScanningAlertReopenedAlertRule>
-    for CodeScanningAlertReopenedAlertRule
-{
-    fn from(value: &CodeScanningAlertReopenedAlertRule) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The severity of the alert."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -17826,11 +16885,6 @@ pub enum CodeScanningAlertReopenedAlertRuleSeverity {
     Warning,
     #[serde(rename = "error")]
     Error,
-}
-impl ::std::convert::From<&Self> for CodeScanningAlertReopenedAlertRuleSeverity {
-    fn from(value: &CodeScanningAlertReopenedAlertRuleSeverity) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CodeScanningAlertReopenedAlertRuleSeverity {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -17913,11 +16967,6 @@ pub enum CodeScanningAlertReopenedAlertState {
     Dismissed,
     #[serde(rename = "fixed")]
     Fixed,
-}
-impl ::std::convert::From<&Self> for CodeScanningAlertReopenedAlertState {
-    fn from(value: &CodeScanningAlertReopenedAlertState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CodeScanningAlertReopenedAlertState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -18004,13 +17053,6 @@ pub struct CodeScanningAlertReopenedAlertTool {
     pub name: ::std::string::String,
     #[doc = "The version of the tool used to detect the alert."]
     pub version: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&CodeScanningAlertReopenedAlertTool>
-    for CodeScanningAlertReopenedAlertTool
-{
-    fn from(value: &CodeScanningAlertReopenedAlertTool) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`CodeScanningAlertReopenedByUser`"]
 #[doc = r""]
@@ -18216,11 +17258,6 @@ pub struct CodeScanningAlertReopenedByUser {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&CodeScanningAlertReopenedByUser> for CodeScanningAlertReopenedByUser {
-    fn from(value: &CodeScanningAlertReopenedByUser) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CodeScanningAlertReopenedByUserAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -18249,11 +17286,6 @@ impl ::std::convert::From<&CodeScanningAlertReopenedByUser> for CodeScanningAler
 pub enum CodeScanningAlertReopenedByUserAction {
     #[serde(rename = "reopened_by_user")]
     ReopenedByUser,
-}
-impl ::std::convert::From<&Self> for CodeScanningAlertReopenedByUserAction {
-    fn from(value: &CodeScanningAlertReopenedByUserAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CodeScanningAlertReopenedByUserAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -18461,13 +17493,6 @@ pub struct CodeScanningAlertReopenedByUserAlert {
     pub tool: CodeScanningAlertReopenedByUserAlertTool,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&CodeScanningAlertReopenedByUserAlert>
-    for CodeScanningAlertReopenedByUserAlert
-{
-    fn from(value: &CodeScanningAlertReopenedByUserAlert) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CodeScanningAlertReopenedByUserAlertInstancesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -18517,13 +17542,6 @@ pub struct CodeScanningAlertReopenedByUserAlertInstancesItem {
     pub ref_: ::std::string::String,
     pub state: CodeScanningAlertReopenedByUserAlertInstancesItemState,
 }
-impl ::std::convert::From<&CodeScanningAlertReopenedByUserAlertInstancesItem>
-    for CodeScanningAlertReopenedByUserAlertInstancesItem
-{
-    fn from(value: &CodeScanningAlertReopenedByUserAlertInstancesItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CodeScanningAlertReopenedByUserAlertInstancesItemLocation`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -18566,13 +17584,6 @@ pub struct CodeScanningAlertReopenedByUserAlertInstancesItemLocation {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub start_line: ::std::option::Option<i64>,
 }
-impl ::std::convert::From<&CodeScanningAlertReopenedByUserAlertInstancesItemLocation>
-    for CodeScanningAlertReopenedByUserAlertInstancesItemLocation
-{
-    fn from(value: &CodeScanningAlertReopenedByUserAlertInstancesItemLocation) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for CodeScanningAlertReopenedByUserAlertInstancesItemLocation {
     fn default() -> Self {
         Self {
@@ -18605,13 +17616,6 @@ impl ::std::default::Default for CodeScanningAlertReopenedByUserAlertInstancesIt
 pub struct CodeScanningAlertReopenedByUserAlertInstancesItemMessage {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub text: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&CodeScanningAlertReopenedByUserAlertInstancesItemMessage>
-    for CodeScanningAlertReopenedByUserAlertInstancesItemMessage
-{
-    fn from(value: &CodeScanningAlertReopenedByUserAlertInstancesItemMessage) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for CodeScanningAlertReopenedByUserAlertInstancesItemMessage {
     fn default() -> Self {
@@ -18648,11 +17652,6 @@ impl ::std::default::Default for CodeScanningAlertReopenedByUserAlertInstancesIt
 pub enum CodeScanningAlertReopenedByUserAlertInstancesItemState {
     #[serde(rename = "open")]
     Open,
-}
-impl ::std::convert::From<&Self> for CodeScanningAlertReopenedByUserAlertInstancesItemState {
-    fn from(value: &CodeScanningAlertReopenedByUserAlertInstancesItemState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CodeScanningAlertReopenedByUserAlertInstancesItemState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -18746,13 +17745,6 @@ pub struct CodeScanningAlertReopenedByUserAlertRule {
     #[doc = "The severity of the alert."]
     pub severity: ::std::option::Option<CodeScanningAlertReopenedByUserAlertRuleSeverity>,
 }
-impl ::std::convert::From<&CodeScanningAlertReopenedByUserAlertRule>
-    for CodeScanningAlertReopenedByUserAlertRule
-{
-    fn from(value: &CodeScanningAlertReopenedByUserAlertRule) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The severity of the alert."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -18791,11 +17783,6 @@ pub enum CodeScanningAlertReopenedByUserAlertRuleSeverity {
     Warning,
     #[serde(rename = "error")]
     Error,
-}
-impl ::std::convert::From<&Self> for CodeScanningAlertReopenedByUserAlertRuleSeverity {
-    fn from(value: &CodeScanningAlertReopenedByUserAlertRuleSeverity) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CodeScanningAlertReopenedByUserAlertRuleSeverity {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -18875,11 +17862,6 @@ pub enum CodeScanningAlertReopenedByUserAlertState {
     #[serde(rename = "open")]
     Open,
 }
-impl ::std::convert::From<&Self> for CodeScanningAlertReopenedByUserAlertState {
-    fn from(value: &CodeScanningAlertReopenedByUserAlertState) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for CodeScanningAlertReopenedByUserAlertState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -18953,13 +17935,6 @@ pub struct CodeScanningAlertReopenedByUserAlertTool {
     pub name: ::std::string::String,
     #[doc = "The version of the tool used to detect the alert."]
     pub version: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&CodeScanningAlertReopenedByUserAlertTool>
-    for CodeScanningAlertReopenedByUserAlertTool
-{
-    fn from(value: &CodeScanningAlertReopenedByUserAlertTool) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`Commit`"]
 #[doc = r""]
@@ -19060,11 +18035,6 @@ pub struct Commit {
     pub tree_id: ::std::string::String,
     #[doc = "URL that points to the commit API resource."]
     pub url: ::std::string::String,
-}
-impl ::std::convert::From<&Commit> for Commit {
-    fn from(value: &Commit) -> Self {
-        value.clone()
-    }
 }
 #[doc = "A commit comment is created. The type of activity is specified in the `action` property. "]
 #[doc = r""]
@@ -19199,11 +18169,6 @@ pub struct CommitCommentCreated {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&CommitCommentCreated> for CommitCommentCreated {
-    fn from(value: &CommitCommentCreated) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The action performed. Can be `created`."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -19233,11 +18198,6 @@ impl ::std::convert::From<&CommitCommentCreated> for CommitCommentCreated {
 pub enum CommitCommentCreatedAction {
     #[serde(rename = "created")]
     Created,
-}
-impl ::std::convert::From<&Self> for CommitCommentCreatedAction {
-    fn from(value: &CommitCommentCreatedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CommitCommentCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -19387,11 +18347,6 @@ pub struct CommitCommentCreatedComment {
     pub url: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&CommitCommentCreatedComment> for CommitCommentCreatedComment {
-    fn from(value: &CommitCommentCreatedComment) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CommitCommentEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -19418,11 +18373,6 @@ impl ::std::ops::Deref for CommitCommentEvent {
 impl ::std::convert::From<CommitCommentEvent> for CommitCommentCreated {
     fn from(value: CommitCommentEvent) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&CommitCommentEvent> for CommitCommentEvent {
-    fn from(value: &CommitCommentEvent) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<CommitCommentCreated> for CommitCommentEvent {
@@ -19481,11 +18431,6 @@ pub struct CommitSimple {
     pub timestamp: ::std::string::String,
     pub tree_id: ::std::string::String,
 }
-impl ::std::convert::From<&CommitSimple> for CommitSimple {
-    fn from(value: &CommitSimple) -> Self {
-        value.clone()
-    }
-}
 #[doc = "Metaproperties for Git author/committer information."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -19540,11 +18485,6 @@ pub struct Committer {
     pub name: ::std::string::String,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub username: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&Committer> for Committer {
-    fn from(value: &Committer) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`ContentReferenceCreated`"]
 #[doc = r""]
@@ -19618,11 +18558,6 @@ pub struct ContentReferenceCreated {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&ContentReferenceCreated> for ContentReferenceCreated {
-    fn from(value: &ContentReferenceCreated) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ContentReferenceCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -19651,11 +18586,6 @@ impl ::std::convert::From<&ContentReferenceCreated> for ContentReferenceCreated 
 pub enum ContentReferenceCreatedAction {
     #[serde(rename = "created")]
     Created,
-}
-impl ::std::convert::From<&Self> for ContentReferenceCreatedAction {
-    fn from(value: &ContentReferenceCreatedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ContentReferenceCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -19730,13 +18660,6 @@ pub struct ContentReferenceCreatedContentReference {
     pub node_id: ::std::string::String,
     pub reference: ::std::string::String,
 }
-impl ::std::convert::From<&ContentReferenceCreatedContentReference>
-    for ContentReferenceCreatedContentReference
-{
-    fn from(value: &ContentReferenceCreatedContentReference) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ContentReferenceEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -19763,11 +18686,6 @@ impl ::std::ops::Deref for ContentReferenceEvent {
 impl ::std::convert::From<ContentReferenceEvent> for ContentReferenceCreated {
     fn from(value: ContentReferenceEvent) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&ContentReferenceEvent> for ContentReferenceEvent {
-    fn from(value: &ContentReferenceEvent) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<ContentReferenceCreated> for ContentReferenceEvent {
@@ -19860,11 +18778,6 @@ pub struct CreateEvent {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&CreateEvent> for CreateEvent {
-    fn from(value: &CreateEvent) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The type of Git ref object created in the repository. Can be either `branch` or `tag`."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -19897,11 +18810,6 @@ pub enum CreateEventRefType {
     Tag,
     #[serde(rename = "branch")]
     Branch,
-}
-impl ::std::convert::From<&Self> for CreateEventRefType {
-    fn from(value: &CreateEventRefType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CreateEventRefType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -20011,11 +18919,6 @@ pub struct DeleteEvent {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&DeleteEvent> for DeleteEvent {
-    fn from(value: &DeleteEvent) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The type of Git ref object deleted in the repository. Can be either `branch` or `tag`."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -20048,11 +18951,6 @@ pub enum DeleteEventRefType {
     Tag,
     #[serde(rename = "branch")]
     Branch,
-}
-impl ::std::convert::From<&Self> for DeleteEventRefType {
-    fn from(value: &DeleteEventRefType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DeleteEventRefType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -20183,11 +19081,6 @@ pub struct DeployKeyCreated {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&DeployKeyCreated> for DeployKeyCreated {
-    fn from(value: &DeployKeyCreated) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DeployKeyCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -20216,11 +19109,6 @@ impl ::std::convert::From<&DeployKeyCreated> for DeployKeyCreated {
 pub enum DeployKeyCreatedAction {
     #[serde(rename = "created")]
     Created,
-}
-impl ::std::convert::From<&Self> for DeployKeyCreatedAction {
-    fn from(value: &DeployKeyCreatedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DeployKeyCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -20316,11 +19204,6 @@ pub struct DeployKeyCreatedKey {
     pub url: ::std::string::String,
     pub verified: bool,
 }
-impl ::std::convert::From<&DeployKeyCreatedKey> for DeployKeyCreatedKey {
-    fn from(value: &DeployKeyCreatedKey) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DeployKeyDeleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -20410,11 +19293,6 @@ pub struct DeployKeyDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&DeployKeyDeleted> for DeployKeyDeleted {
-    fn from(value: &DeployKeyDeleted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DeployKeyDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -20443,11 +19321,6 @@ impl ::std::convert::From<&DeployKeyDeleted> for DeployKeyDeleted {
 pub enum DeployKeyDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
-}
-impl ::std::convert::From<&Self> for DeployKeyDeletedAction {
-    fn from(value: &DeployKeyDeletedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DeployKeyDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -20543,11 +19416,6 @@ pub struct DeployKeyDeletedKey {
     pub url: ::std::string::String,
     pub verified: bool,
 }
-impl ::std::convert::From<&DeployKeyDeletedKey> for DeployKeyDeletedKey {
-    fn from(value: &DeployKeyDeletedKey) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DeployKeyEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -20570,11 +19438,6 @@ impl ::std::convert::From<&DeployKeyDeletedKey> for DeployKeyDeletedKey {
 pub enum DeployKeyEvent {
     Created(DeployKeyCreated),
     Deleted(DeployKeyDeleted),
-}
-impl ::std::convert::From<&Self> for DeployKeyEvent {
-    fn from(value: &DeployKeyEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<DeployKeyCreated> for DeployKeyEvent {
     fn from(value: DeployKeyCreated) -> Self {
@@ -20730,11 +19593,6 @@ pub struct DeploymentCreated {
     pub workflow: (),
     pub workflow_run: (),
 }
-impl ::std::convert::From<&DeploymentCreated> for DeploymentCreated {
-    fn from(value: &DeploymentCreated) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DeploymentCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -20763,11 +19621,6 @@ impl ::std::convert::From<&DeploymentCreated> for DeploymentCreated {
 pub enum DeploymentCreatedAction {
     #[serde(rename = "created")]
     Created,
-}
-impl ::std::convert::From<&Self> for DeploymentCreatedAction {
-    fn from(value: &DeploymentCreatedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DeploymentCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -20919,11 +19772,6 @@ pub struct DeploymentCreatedDeployment {
     pub updated_at: ::std::string::String,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&DeploymentCreatedDeployment> for DeploymentCreatedDeployment {
-    fn from(value: &DeploymentCreatedDeployment) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DeploymentCreatedDeploymentPayload`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -20938,13 +19786,6 @@ impl ::std::convert::From<&DeploymentCreatedDeployment> for DeploymentCreatedDep
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct DeploymentCreatedDeploymentPayload {}
-impl ::std::convert::From<&DeploymentCreatedDeploymentPayload>
-    for DeploymentCreatedDeploymentPayload
-{
-    fn from(value: &DeploymentCreatedDeploymentPayload) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for DeploymentCreatedDeploymentPayload {
     fn default() -> Self {
         Self {}
@@ -20976,11 +19817,6 @@ impl ::std::ops::Deref for DeploymentEvent {
 impl ::std::convert::From<DeploymentEvent> for DeploymentCreated {
     fn from(value: DeploymentEvent) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&DeploymentEvent> for DeploymentEvent {
-    fn from(value: &DeploymentEvent) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<DeploymentCreated> for DeploymentEvent {
@@ -21198,11 +20034,6 @@ pub struct DeploymentStatusCreated {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&DeploymentStatusCreated> for DeploymentStatusCreated {
-    fn from(value: &DeploymentStatusCreated) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DeploymentStatusCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -21231,11 +20062,6 @@ impl ::std::convert::From<&DeploymentStatusCreated> for DeploymentStatusCreated 
 pub enum DeploymentStatusCreatedAction {
     #[serde(rename = "created")]
     Created,
-}
-impl ::std::convert::From<&Self> for DeploymentStatusCreatedAction {
-    fn from(value: &DeploymentStatusCreatedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DeploymentStatusCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -21387,13 +20213,6 @@ pub struct DeploymentStatusCreatedDeployment {
     pub updated_at: ::std::string::String,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&DeploymentStatusCreatedDeployment>
-    for DeploymentStatusCreatedDeployment
-{
-    fn from(value: &DeploymentStatusCreatedDeployment) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DeploymentStatusCreatedDeploymentPayload`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -21408,13 +20227,6 @@ impl ::std::convert::From<&DeploymentStatusCreatedDeployment>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct DeploymentStatusCreatedDeploymentPayload {}
-impl ::std::convert::From<&DeploymentStatusCreatedDeploymentPayload>
-    for DeploymentStatusCreatedDeploymentPayload
-{
-    fn from(value: &DeploymentStatusCreatedDeploymentPayload) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for DeploymentStatusCreatedDeploymentPayload {
     fn default() -> Self {
         Self {}
@@ -21521,13 +20333,6 @@ pub struct DeploymentStatusCreatedDeploymentStatus {
     pub updated_at: ::std::string::String,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&DeploymentStatusCreatedDeploymentStatus>
-    for DeploymentStatusCreatedDeploymentStatus
-{
-    fn from(value: &DeploymentStatusCreatedDeploymentStatus) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DeploymentStatusEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -21554,11 +20359,6 @@ impl ::std::ops::Deref for DeploymentStatusEvent {
 impl ::std::convert::From<DeploymentStatusEvent> for DeploymentStatusCreated {
     fn from(value: DeploymentStatusEvent) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&DeploymentStatusEvent> for DeploymentStatusEvent {
-    fn from(value: &DeploymentStatusEvent) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<DeploymentStatusCreated> for DeploymentStatusEvent {
@@ -21747,11 +20547,6 @@ pub struct Discussion {
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub user: User,
 }
-impl ::std::convert::From<&Discussion> for Discussion {
-    fn from(value: &Discussion) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionAnswered`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -21908,11 +20703,6 @@ pub struct DiscussionAnswered {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&DiscussionAnswered> for DiscussionAnswered {
-    fn from(value: &DiscussionAnswered) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionAnsweredAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -21941,11 +20731,6 @@ impl ::std::convert::From<&DiscussionAnswered> for DiscussionAnswered {
 pub enum DiscussionAnsweredAction {
     #[serde(rename = "answered")]
     Answered,
-}
-impl ::std::convert::From<&Self> for DiscussionAnsweredAction {
-    fn from(value: &DiscussionAnsweredAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DiscussionAnsweredAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -22066,11 +20851,6 @@ pub struct DiscussionAnsweredAnswer {
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub user: User,
 }
-impl ::std::convert::From<&DiscussionAnsweredAnswer> for DiscussionAnsweredAnswer {
-    fn from(value: &DiscussionAnsweredAnswer) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionAnsweredDiscussion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -22145,11 +20925,6 @@ pub struct DiscussionAnsweredDiscussion {
     pub title: ::std::string::String,
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub user: User,
-}
-impl ::std::convert::From<&DiscussionAnsweredDiscussion> for DiscussionAnsweredDiscussion {
-    fn from(value: &DiscussionAnsweredDiscussion) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`DiscussionAnsweredDiscussionAnswerChosenBy`"]
 #[doc = r""]
@@ -22303,13 +21078,6 @@ pub struct DiscussionAnsweredDiscussionAnswerChosenBy {
     pub type_: DiscussionAnsweredDiscussionAnswerChosenByType,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&DiscussionAnsweredDiscussionAnswerChosenBy>
-    for DiscussionAnsweredDiscussionAnswerChosenBy
-{
-    fn from(value: &DiscussionAnsweredDiscussionAnswerChosenBy) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionAnsweredDiscussionAnswerChosenByType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -22341,11 +21109,6 @@ pub enum DiscussionAnsweredDiscussionAnswerChosenByType {
     Bot,
     User,
     Organization,
-}
-impl ::std::convert::From<&Self> for DiscussionAnsweredDiscussionAnswerChosenByType {
-    fn from(value: &DiscussionAnsweredDiscussionAnswerChosenByType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DiscussionAnsweredDiscussionAnswerChosenByType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -22461,13 +21224,6 @@ pub struct DiscussionAnsweredDiscussionCategory {
     pub slug: ::std::string::String,
     pub updated_at: ::std::string::String,
 }
-impl ::std::convert::From<&DiscussionAnsweredDiscussionCategory>
-    for DiscussionAnsweredDiscussionCategory
-{
-    fn from(value: &DiscussionAnsweredDiscussionCategory) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionAnsweredDiscussionState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -22502,11 +21258,6 @@ pub enum DiscussionAnsweredDiscussionState {
     Locked,
     #[serde(rename = "converting")]
     Converting,
-}
-impl ::std::convert::From<&Self> for DiscussionAnsweredDiscussionState {
-    fn from(value: &DiscussionAnsweredDiscussionState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DiscussionAnsweredDiscussionState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -22614,11 +21365,6 @@ pub struct DiscussionCategory {
     pub repository_id: i64,
     pub slug: ::std::string::String,
     pub updated_at: ::std::string::String,
-}
-impl ::std::convert::From<&DiscussionCategory> for DiscussionCategory {
-    fn from(value: &DiscussionCategory) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`DiscussionCategoryChanged`"]
 #[doc = r""]
@@ -22739,11 +21485,6 @@ pub struct DiscussionCategoryChanged {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&DiscussionCategoryChanged> for DiscussionCategoryChanged {
-    fn from(value: &DiscussionCategoryChanged) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionCategoryChangedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -22772,11 +21513,6 @@ impl ::std::convert::From<&DiscussionCategoryChanged> for DiscussionCategoryChan
 pub enum DiscussionCategoryChangedAction {
     #[serde(rename = "category_changed")]
     CategoryChanged,
-}
-impl ::std::convert::From<&Self> for DiscussionCategoryChangedAction {
-    fn from(value: &DiscussionCategoryChangedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DiscussionCategoryChangedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -22891,11 +21627,6 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionCategoryChange
 pub struct DiscussionCategoryChangedChanges {
     pub category: DiscussionCategoryChangedChangesCategory,
 }
-impl ::std::convert::From<&DiscussionCategoryChangedChanges> for DiscussionCategoryChangedChanges {
-    fn from(value: &DiscussionCategoryChangedChanges) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionCategoryChangedChangesCategory`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -22962,13 +21693,6 @@ impl ::std::convert::From<&DiscussionCategoryChangedChanges> for DiscussionCateg
 pub struct DiscussionCategoryChangedChangesCategory {
     pub from: DiscussionCategoryChangedChangesCategoryFrom,
 }
-impl ::std::convert::From<&DiscussionCategoryChangedChangesCategory>
-    for DiscussionCategoryChangedChangesCategory
-{
-    fn from(value: &DiscussionCategoryChangedChangesCategory) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionCategoryChangedChangesCategoryFrom`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -23033,13 +21757,6 @@ pub struct DiscussionCategoryChangedChangesCategoryFrom {
     pub repository_id: i64,
     pub slug: ::std::string::String,
     pub updated_at: ::std::string::String,
-}
-impl ::std::convert::From<&DiscussionCategoryChangedChangesCategoryFrom>
-    for DiscussionCategoryChangedChangesCategoryFrom
-{
-    fn from(value: &DiscussionCategoryChangedChangesCategoryFrom) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`DiscussionCommentCreated`"]
 #[doc = r""]
@@ -23156,11 +21873,6 @@ pub struct DiscussionCommentCreated {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&DiscussionCommentCreated> for DiscussionCommentCreated {
-    fn from(value: &DiscussionCommentCreated) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionCommentCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -23189,11 +21901,6 @@ impl ::std::convert::From<&DiscussionCommentCreated> for DiscussionCommentCreate
 pub enum DiscussionCommentCreatedAction {
     #[serde(rename = "created")]
     Created,
-}
-impl ::std::convert::From<&Self> for DiscussionCommentCreatedAction {
-    fn from(value: &DiscussionCommentCreatedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DiscussionCommentCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -23315,11 +22022,6 @@ pub struct DiscussionCommentCreatedComment {
     pub updated_at: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&DiscussionCommentCreatedComment> for DiscussionCommentCreatedComment {
-    fn from(value: &DiscussionCommentCreatedComment) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionCommentDeleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -23435,11 +22137,6 @@ pub struct DiscussionCommentDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&DiscussionCommentDeleted> for DiscussionCommentDeleted {
-    fn from(value: &DiscussionCommentDeleted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionCommentDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -23468,11 +22165,6 @@ impl ::std::convert::From<&DiscussionCommentDeleted> for DiscussionCommentDelete
 pub enum DiscussionCommentDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
-}
-impl ::std::convert::From<&Self> for DiscussionCommentDeletedAction {
-    fn from(value: &DiscussionCommentDeletedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DiscussionCommentDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -23593,11 +22285,6 @@ pub struct DiscussionCommentDeletedComment {
     pub repository_url: ::std::string::String,
     pub updated_at: ::std::string::String,
     pub user: User,
-}
-impl ::std::convert::From<&DiscussionCommentDeletedComment> for DiscussionCommentDeletedComment {
-    fn from(value: &DiscussionCommentDeletedComment) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`DiscussionCommentEdited`"]
 #[doc = r""]
@@ -23737,11 +22424,6 @@ pub struct DiscussionCommentEdited {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&DiscussionCommentEdited> for DiscussionCommentEdited {
-    fn from(value: &DiscussionCommentEdited) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionCommentEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -23770,11 +22452,6 @@ impl ::std::convert::From<&DiscussionCommentEdited> for DiscussionCommentEdited 
 pub enum DiscussionCommentEditedAction {
     #[serde(rename = "edited")]
     Edited,
-}
-impl ::std::convert::From<&Self> for DiscussionCommentEditedAction {
-    fn from(value: &DiscussionCommentEditedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DiscussionCommentEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -23847,11 +22524,6 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionCommentEditedA
 pub struct DiscussionCommentEditedChanges {
     pub body: DiscussionCommentEditedChangesBody,
 }
-impl ::std::convert::From<&DiscussionCommentEditedChanges> for DiscussionCommentEditedChanges {
-    fn from(value: &DiscussionCommentEditedChanges) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionCommentEditedChangesBody`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -23875,13 +22547,6 @@ impl ::std::convert::From<&DiscussionCommentEditedChanges> for DiscussionComment
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCommentEditedChangesBody {
     pub from: ::std::string::String,
-}
-impl ::std::convert::From<&DiscussionCommentEditedChangesBody>
-    for DiscussionCommentEditedChangesBody
-{
-    fn from(value: &DiscussionCommentEditedChangesBody) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`DiscussionCommentEditedComment`"]
 #[doc = r""]
@@ -23965,11 +22630,6 @@ pub struct DiscussionCommentEditedComment {
     pub updated_at: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&DiscussionCommentEditedComment> for DiscussionCommentEditedComment {
-    fn from(value: &DiscussionCommentEditedComment) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionCommentEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -23996,11 +22656,6 @@ pub enum DiscussionCommentEvent {
     Created(DiscussionCommentCreated),
     Deleted(DiscussionCommentDeleted),
     Edited(DiscussionCommentEdited),
-}
-impl ::std::convert::From<&Self> for DiscussionCommentEvent {
-    fn from(value: &DiscussionCommentEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<DiscussionCommentCreated> for DiscussionCommentEvent {
     fn from(value: DiscussionCommentCreated) -> Self {
@@ -24110,11 +22765,6 @@ pub struct DiscussionCreated {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&DiscussionCreated> for DiscussionCreated {
-    fn from(value: &DiscussionCreated) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -24143,11 +22793,6 @@ impl ::std::convert::From<&DiscussionCreated> for DiscussionCreated {
 pub enum DiscussionCreatedAction {
     #[serde(rename = "created")]
     Created,
-}
-impl ::std::convert::From<&Self> for DiscussionCreatedAction {
-    fn from(value: &DiscussionCreatedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DiscussionCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -24259,11 +22904,6 @@ pub struct DiscussionCreatedDiscussion {
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub user: User,
 }
-impl ::std::convert::From<&DiscussionCreatedDiscussion> for DiscussionCreatedDiscussion {
-    fn from(value: &DiscussionCreatedDiscussion) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionCreatedDiscussionCategory`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -24329,13 +22969,6 @@ pub struct DiscussionCreatedDiscussionCategory {
     pub slug: ::std::string::String,
     pub updated_at: ::std::string::String,
 }
-impl ::std::convert::From<&DiscussionCreatedDiscussionCategory>
-    for DiscussionCreatedDiscussionCategory
-{
-    fn from(value: &DiscussionCreatedDiscussionCategory) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionCreatedDiscussionState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -24367,11 +23000,6 @@ pub enum DiscussionCreatedDiscussionState {
     Open,
     #[serde(rename = "converting")]
     Converting,
-}
-impl ::std::convert::From<&Self> for DiscussionCreatedDiscussionState {
-    fn from(value: &DiscussionCreatedDiscussionState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DiscussionCreatedDiscussionState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -24467,11 +23095,6 @@ pub struct DiscussionDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&DiscussionDeleted> for DiscussionDeleted {
-    fn from(value: &DiscussionDeleted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -24500,11 +23123,6 @@ impl ::std::convert::From<&DiscussionDeleted> for DiscussionDeleted {
 pub enum DiscussionDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
-}
-impl ::std::convert::From<&Self> for DiscussionDeletedAction {
-    fn from(value: &DiscussionDeletedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DiscussionDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -24630,11 +23248,6 @@ pub struct DiscussionEdited {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&DiscussionEdited> for DiscussionEdited {
-    fn from(value: &DiscussionEdited) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -24663,11 +23276,6 @@ impl ::std::convert::From<&DiscussionEdited> for DiscussionEdited {
 pub enum DiscussionEditedAction {
     #[serde(rename = "edited")]
     Edited,
-}
-impl ::std::convert::From<&Self> for DiscussionEditedAction {
-    fn from(value: &DiscussionEditedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DiscussionEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -24752,11 +23360,6 @@ pub struct DiscussionEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<DiscussionEditedChangesTitle>,
 }
-impl ::std::convert::From<&DiscussionEditedChanges> for DiscussionEditedChanges {
-    fn from(value: &DiscussionEditedChanges) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for DiscussionEditedChanges {
     fn default() -> Self {
         Self {
@@ -24789,11 +23392,6 @@ impl ::std::default::Default for DiscussionEditedChanges {
 pub struct DiscussionEditedChangesBody {
     pub from: ::std::string::String,
 }
-impl ::std::convert::From<&DiscussionEditedChangesBody> for DiscussionEditedChangesBody {
-    fn from(value: &DiscussionEditedChangesBody) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionEditedChangesTitle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -24817,11 +23415,6 @@ impl ::std::convert::From<&DiscussionEditedChangesBody> for DiscussionEditedChan
 #[serde(deny_unknown_fields)]
 pub struct DiscussionEditedChangesTitle {
     pub from: ::std::string::String,
-}
-impl ::std::convert::From<&DiscussionEditedChangesTitle> for DiscussionEditedChangesTitle {
-    fn from(value: &DiscussionEditedChangesTitle) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`DiscussionEvent`"]
 #[doc = r""]
@@ -24889,11 +23482,6 @@ pub enum DiscussionEvent {
     Unlabeled(DiscussionUnlabeled),
     Unlocked(DiscussionUnlocked),
     Unpinned(DiscussionUnpinned),
-}
-impl ::std::convert::From<&Self> for DiscussionEvent {
-    fn from(value: &DiscussionEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<DiscussionAnswered> for DiscussionEvent {
     fn from(value: DiscussionAnswered) -> Self {
@@ -25019,11 +23607,6 @@ pub struct DiscussionLabeled {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&DiscussionLabeled> for DiscussionLabeled {
-    fn from(value: &DiscussionLabeled) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionLabeledAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -25052,11 +23635,6 @@ impl ::std::convert::From<&DiscussionLabeled> for DiscussionLabeled {
 pub enum DiscussionLabeledAction {
     #[serde(rename = "labeled")]
     Labeled,
-}
-impl ::std::convert::From<&Self> for DiscussionLabeledAction {
-    fn from(value: &DiscussionLabeledAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DiscussionLabeledAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -25176,11 +23754,6 @@ pub struct DiscussionLocked {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&DiscussionLocked> for DiscussionLocked {
-    fn from(value: &DiscussionLocked) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionLockedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -25209,11 +23782,6 @@ impl ::std::convert::From<&DiscussionLocked> for DiscussionLocked {
 pub enum DiscussionLockedAction {
     #[serde(rename = "locked")]
     Locked,
-}
-impl ::std::convert::From<&Self> for DiscussionLockedAction {
-    fn from(value: &DiscussionLockedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DiscussionLockedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -25312,11 +23880,6 @@ pub struct DiscussionLockedDiscussion {
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub user: User,
 }
-impl ::std::convert::From<&DiscussionLockedDiscussion> for DiscussionLockedDiscussion {
-    fn from(value: &DiscussionLockedDiscussion) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionLockedDiscussionCategory`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -25382,13 +23945,6 @@ pub struct DiscussionLockedDiscussionCategory {
     pub slug: ::std::string::String,
     pub updated_at: ::std::string::String,
 }
-impl ::std::convert::From<&DiscussionLockedDiscussionCategory>
-    for DiscussionLockedDiscussionCategory
-{
-    fn from(value: &DiscussionLockedDiscussionCategory) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionLockedDiscussionState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -25417,11 +23973,6 @@ impl ::std::convert::From<&DiscussionLockedDiscussionCategory>
 pub enum DiscussionLockedDiscussionState {
     #[serde(rename = "locked")]
     Locked,
-}
-impl ::std::convert::From<&Self> for DiscussionLockedDiscussionState {
-    fn from(value: &DiscussionLockedDiscussionState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DiscussionLockedDiscussionState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -25515,11 +24066,6 @@ pub struct DiscussionPinned {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&DiscussionPinned> for DiscussionPinned {
-    fn from(value: &DiscussionPinned) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionPinnedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -25548,11 +24094,6 @@ impl ::std::convert::From<&DiscussionPinned> for DiscussionPinned {
 pub enum DiscussionPinnedAction {
     #[serde(rename = "pinned")]
     Pinned,
-}
-impl ::std::convert::From<&Self> for DiscussionPinnedAction {
-    fn from(value: &DiscussionPinnedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DiscussionPinnedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -25626,11 +24167,6 @@ pub enum DiscussionState {
     Locked,
     #[serde(rename = "converting")]
     Converting,
-}
-impl ::std::convert::From<&Self> for DiscussionState {
-    fn from(value: &DiscussionState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DiscussionState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -25746,11 +24282,6 @@ pub struct DiscussionTransferred {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&DiscussionTransferred> for DiscussionTransferred {
-    fn from(value: &DiscussionTransferred) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionTransferredAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -25779,11 +24310,6 @@ impl ::std::convert::From<&DiscussionTransferred> for DiscussionTransferred {
 pub enum DiscussionTransferredAction {
     #[serde(rename = "transferred")]
     Transferred,
-}
-impl ::std::convert::From<&Self> for DiscussionTransferredAction {
-    fn from(value: &DiscussionTransferredAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DiscussionTransferredAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -25851,11 +24377,6 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionTransferredAct
 pub struct DiscussionTransferredChanges {
     pub new_discussion: Discussion,
     pub new_repository: Repository,
-}
-impl ::std::convert::From<&DiscussionTransferredChanges> for DiscussionTransferredChanges {
-    fn from(value: &DiscussionTransferredChanges) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`DiscussionUnanswered`"]
 #[doc = r""]
@@ -26011,11 +24532,6 @@ pub struct DiscussionUnanswered {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&DiscussionUnanswered> for DiscussionUnanswered {
-    fn from(value: &DiscussionUnanswered) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionUnansweredAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -26044,11 +24560,6 @@ impl ::std::convert::From<&DiscussionUnanswered> for DiscussionUnanswered {
 pub enum DiscussionUnansweredAction {
     #[serde(rename = "unanswered")]
     Unanswered,
-}
-impl ::std::convert::From<&Self> for DiscussionUnansweredAction {
-    fn from(value: &DiscussionUnansweredAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DiscussionUnansweredAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -26161,11 +24672,6 @@ pub struct DiscussionUnansweredDiscussion {
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub user: User,
 }
-impl ::std::convert::From<&DiscussionUnansweredDiscussion> for DiscussionUnansweredDiscussion {
-    fn from(value: &DiscussionUnansweredDiscussion) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionUnansweredDiscussionCategory`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -26234,13 +24740,6 @@ pub struct DiscussionUnansweredDiscussionCategory {
     pub slug: ::std::string::String,
     pub updated_at: ::std::string::String,
 }
-impl ::std::convert::From<&DiscussionUnansweredDiscussionCategory>
-    for DiscussionUnansweredDiscussionCategory
-{
-    fn from(value: &DiscussionUnansweredDiscussionCategory) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionUnansweredDiscussionState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -26275,11 +24774,6 @@ pub enum DiscussionUnansweredDiscussionState {
     Locked,
     #[serde(rename = "converting")]
     Converting,
-}
-impl ::std::convert::From<&Self> for DiscussionUnansweredDiscussionState {
-    fn from(value: &DiscussionUnansweredDiscussionState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DiscussionUnansweredDiscussionState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -26404,11 +24898,6 @@ pub struct DiscussionUnansweredOldAnswer {
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub user: User,
 }
-impl ::std::convert::From<&DiscussionUnansweredOldAnswer> for DiscussionUnansweredOldAnswer {
-    fn from(value: &DiscussionUnansweredOldAnswer) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionUnlabeled`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -26468,11 +24957,6 @@ pub struct DiscussionUnlabeled {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&DiscussionUnlabeled> for DiscussionUnlabeled {
-    fn from(value: &DiscussionUnlabeled) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionUnlabeledAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -26501,11 +24985,6 @@ impl ::std::convert::From<&DiscussionUnlabeled> for DiscussionUnlabeled {
 pub enum DiscussionUnlabeledAction {
     #[serde(rename = "unlabeled")]
     Unlabeled,
-}
-impl ::std::convert::From<&Self> for DiscussionUnlabeledAction {
-    fn from(value: &DiscussionUnlabeledAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DiscussionUnlabeledAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -26625,11 +25104,6 @@ pub struct DiscussionUnlocked {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&DiscussionUnlocked> for DiscussionUnlocked {
-    fn from(value: &DiscussionUnlocked) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionUnlockedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -26658,11 +25132,6 @@ impl ::std::convert::From<&DiscussionUnlocked> for DiscussionUnlocked {
 pub enum DiscussionUnlockedAction {
     #[serde(rename = "unlocked")]
     Unlocked,
-}
-impl ::std::convert::From<&Self> for DiscussionUnlockedAction {
-    fn from(value: &DiscussionUnlockedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DiscussionUnlockedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -26761,11 +25230,6 @@ pub struct DiscussionUnlockedDiscussion {
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub user: User,
 }
-impl ::std::convert::From<&DiscussionUnlockedDiscussion> for DiscussionUnlockedDiscussion {
-    fn from(value: &DiscussionUnlockedDiscussion) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionUnlockedDiscussionCategory`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -26831,13 +25295,6 @@ pub struct DiscussionUnlockedDiscussionCategory {
     pub slug: ::std::string::String,
     pub updated_at: ::std::string::String,
 }
-impl ::std::convert::From<&DiscussionUnlockedDiscussionCategory>
-    for DiscussionUnlockedDiscussionCategory
-{
-    fn from(value: &DiscussionUnlockedDiscussionCategory) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionUnlockedDiscussionState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -26866,11 +25323,6 @@ impl ::std::convert::From<&DiscussionUnlockedDiscussionCategory>
 pub enum DiscussionUnlockedDiscussionState {
     #[serde(rename = "open")]
     Open,
-}
-impl ::std::convert::From<&Self> for DiscussionUnlockedDiscussionState {
-    fn from(value: &DiscussionUnlockedDiscussionState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DiscussionUnlockedDiscussionState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -26964,11 +25416,6 @@ pub struct DiscussionUnpinned {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&DiscussionUnpinned> for DiscussionUnpinned {
-    fn from(value: &DiscussionUnpinned) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DiscussionUnpinnedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -26997,11 +25444,6 @@ impl ::std::convert::From<&DiscussionUnpinned> for DiscussionUnpinned {
 pub enum DiscussionUnpinnedAction {
     #[serde(rename = "unpinned")]
     Unpinned,
-}
-impl ::std::convert::From<&Self> for DiscussionUnpinnedAction {
-    fn from(value: &DiscussionUnpinnedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DiscussionUnpinnedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -27276,11 +25718,6 @@ pub enum Everything {
     WorkflowDispatchEvent(WorkflowDispatchEvent),
     WorkflowJobEvent(WorkflowJobEvent),
     WorkflowRunEvent(WorkflowRunEvent),
-}
-impl ::std::convert::From<&Self> for Everything {
-    fn from(value: &Everything) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<BranchProtectionRuleEvent> for Everything {
     fn from(value: BranchProtectionRuleEvent) -> Self {
@@ -27620,11 +26057,6 @@ pub struct ForkEvent {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&ForkEvent> for ForkEvent {
-    fn from(value: &ForkEvent) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The created [`repository`](https://docs.github.com/en/rest/reference/repos#get-a-repository) resource."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -27767,11 +26199,6 @@ pub struct ForkEventForkee {
     pub watchers: i64,
     pub watchers_count: i64,
 }
-impl ::std::convert::From<&ForkEventForkee> for ForkEventForkee {
-    fn from(value: &ForkEventForkee) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ForkEventForkeeCreatedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -27795,11 +26222,6 @@ impl ::std::convert::From<&ForkEventForkee> for ForkEventForkee {
 pub enum ForkEventForkeeCreatedAt {
     Integer(i64),
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
-}
-impl ::std::convert::From<&Self> for ForkEventForkeeCreatedAt {
-    fn from(value: &ForkEventForkeeCreatedAt) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for ForkEventForkeeCreatedAt {
     type Err = self::error::ConversionError;
@@ -27897,11 +26319,6 @@ pub struct ForkEventForkeePermissions {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub triage: ::std::option::Option<bool>,
 }
-impl ::std::convert::From<&ForkEventForkeePermissions> for ForkEventForkeePermissions {
-    fn from(value: &ForkEventForkeePermissions) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ForkEventForkeePushedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -27929,11 +26346,6 @@ pub enum ForkEventForkeePushedAt {
     Integer(i64),
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
     Null,
-}
-impl ::std::convert::From<&Self> for ForkEventForkeePushedAt {
-    fn from(value: &ForkEventForkeePushedAt) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<i64> for ForkEventForkeePushedAt {
     fn from(value: i64) -> Self {
@@ -27971,11 +26383,6 @@ impl ::std::ops::Deref for GithubAppAuthorizationEvent {
 impl ::std::convert::From<GithubAppAuthorizationEvent> for GithubAppAuthorizationRevoked {
     fn from(value: GithubAppAuthorizationEvent) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&GithubAppAuthorizationEvent> for GithubAppAuthorizationEvent {
-    fn from(value: &GithubAppAuthorizationEvent) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<GithubAppAuthorizationRevoked> for GithubAppAuthorizationEvent {
@@ -28017,11 +26424,6 @@ pub struct GithubAppAuthorizationRevoked {
     pub action: GithubAppAuthorizationRevokedAction,
     pub sender: User,
 }
-impl ::std::convert::From<&GithubAppAuthorizationRevoked> for GithubAppAuthorizationRevoked {
-    fn from(value: &GithubAppAuthorizationRevoked) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`GithubAppAuthorizationRevokedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -28050,11 +26452,6 @@ impl ::std::convert::From<&GithubAppAuthorizationRevoked> for GithubAppAuthoriza
 pub enum GithubAppAuthorizationRevokedAction {
     #[serde(rename = "revoked")]
     Revoked,
-}
-impl ::std::convert::From<&Self> for GithubAppAuthorizationRevokedAction {
-    fn from(value: &GithubAppAuthorizationRevokedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for GithubAppAuthorizationRevokedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -28247,11 +26644,6 @@ pub struct GithubOrg {
     pub type_: ::std::string::String,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&GithubOrg> for GithubOrg {
-    fn from(value: &GithubOrg) -> Self {
-        value.clone()
-    }
-}
 #[doc = "A wiki page is created or updated."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -28343,11 +26735,6 @@ pub struct GollumEvent {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&GollumEvent> for GollumEvent {
-    fn from(value: &GollumEvent) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`GollumEventPagesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -28412,11 +26799,6 @@ pub struct GollumEventPagesItem {
     #[doc = "The current page title."]
     pub title: ::std::string::String,
 }
-impl ::std::convert::From<&GollumEventPagesItem> for GollumEventPagesItem {
-    fn from(value: &GollumEventPagesItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The action that was performed on the page. Can be `created` or `edited`."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -28449,11 +26831,6 @@ pub enum GollumEventPagesItemAction {
     Created,
     #[serde(rename = "edited")]
     Edited,
-}
-impl ::std::convert::From<&Self> for GollumEventPagesItemAction {
-    fn from(value: &GollumEventPagesItemAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for GollumEventPagesItemAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -28960,11 +27337,6 @@ pub struct Installation {
     pub target_type: InstallationTargetType,
     pub updated_at: InstallationUpdatedAt,
 }
-impl ::std::convert::From<&Installation> for Installation {
-    fn from(value: &Installation) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`InstallationCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -29047,11 +27419,6 @@ pub struct InstallationCreated {
     pub requester: ::std::option::Option<User>,
     pub sender: User,
 }
-impl ::std::convert::From<&InstallationCreated> for InstallationCreated {
-    fn from(value: &InstallationCreated) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`InstallationCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -29080,11 +27447,6 @@ impl ::std::convert::From<&InstallationCreated> for InstallationCreated {
 pub enum InstallationCreatedAction {
     #[serde(rename = "created")]
     Created,
-}
-impl ::std::convert::From<&Self> for InstallationCreatedAction {
-    fn from(value: &InstallationCreatedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -29147,11 +27509,6 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationCreatedActio
 pub enum InstallationCreatedAt {
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
     Integer(i64),
-}
-impl ::std::convert::From<&Self> for InstallationCreatedAt {
-    fn from(value: &InstallationCreatedAt) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for InstallationCreatedAt {
     type Err = self::error::ConversionError;
@@ -29255,13 +27612,6 @@ pub struct InstallationCreatedRepositoriesItem {
     #[doc = "Whether the repository is private or public."]
     pub private: bool,
 }
-impl ::std::convert::From<&InstallationCreatedRepositoriesItem>
-    for InstallationCreatedRepositoriesItem
-{
-    fn from(value: &InstallationCreatedRepositoriesItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`InstallationDeleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -29344,11 +27694,6 @@ pub struct InstallationDeleted {
     pub requester: (),
     pub sender: User,
 }
-impl ::std::convert::From<&InstallationDeleted> for InstallationDeleted {
-    fn from(value: &InstallationDeleted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`InstallationDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -29377,11 +27722,6 @@ impl ::std::convert::From<&InstallationDeleted> for InstallationDeleted {
 pub enum InstallationDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
-}
-impl ::std::convert::From<&Self> for InstallationDeletedAction {
-    fn from(value: &InstallationDeletedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -29471,13 +27811,6 @@ pub struct InstallationDeletedRepositoriesItem {
     #[doc = "Whether the repository is private or public."]
     pub private: bool,
 }
-impl ::std::convert::From<&InstallationDeletedRepositoriesItem>
-    for InstallationDeletedRepositoriesItem
-{
-    fn from(value: &InstallationDeletedRepositoriesItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`InstallationEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -29512,11 +27845,6 @@ pub enum InstallationEvent {
     NewPermissionsAccepted(InstallationNewPermissionsAccepted),
     Suspend(InstallationSuspend),
     Unsuspend(InstallationUnsuspend),
-}
-impl ::std::convert::From<&Self> for InstallationEvent {
-    fn from(value: &InstallationEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<InstallationCreated> for InstallationEvent {
     fn from(value: InstallationCreated) -> Self {
@@ -29704,11 +28032,6 @@ pub enum InstallationEventsItem {
     #[serde(rename = "workflow_run")]
     WorkflowRun,
 }
-impl ::std::convert::From<&Self> for InstallationEventsItem {
-    fn from(value: &InstallationEventsItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationEventsItem {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -29869,11 +28192,6 @@ pub struct InstallationLite {
     pub id: i64,
     pub node_id: ::std::string::String,
 }
-impl ::std::convert::From<&InstallationLite> for InstallationLite {
-    fn from(value: &InstallationLite) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`InstallationNewPermissionsAccepted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -29956,13 +28274,6 @@ pub struct InstallationNewPermissionsAccepted {
     pub requester: (),
     pub sender: User,
 }
-impl ::std::convert::From<&InstallationNewPermissionsAccepted>
-    for InstallationNewPermissionsAccepted
-{
-    fn from(value: &InstallationNewPermissionsAccepted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`InstallationNewPermissionsAcceptedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -29991,11 +28302,6 @@ impl ::std::convert::From<&InstallationNewPermissionsAccepted>
 pub enum InstallationNewPermissionsAcceptedAction {
     #[serde(rename = "new_permissions_accepted")]
     NewPermissionsAccepted,
-}
-impl ::std::convert::From<&Self> for InstallationNewPermissionsAcceptedAction {
-    fn from(value: &InstallationNewPermissionsAcceptedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationNewPermissionsAcceptedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -30084,13 +28390,6 @@ pub struct InstallationNewPermissionsAcceptedRepositoriesItem {
     pub node_id: ::std::string::String,
     #[doc = "Whether the repository is private or public."]
     pub private: bool,
-}
-impl ::std::convert::From<&InstallationNewPermissionsAcceptedRepositoriesItem>
-    for InstallationNewPermissionsAcceptedRepositoriesItem
-{
-    fn from(value: &InstallationNewPermissionsAcceptedRepositoriesItem) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`InstallationPermissions`"]
 #[doc = r""]
@@ -30428,11 +28727,6 @@ pub struct InstallationPermissions {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub workflows: ::std::option::Option<InstallationPermissionsWorkflows>,
 }
-impl ::std::convert::From<&InstallationPermissions> for InstallationPermissions {
-    fn from(value: &InstallationPermissions) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for InstallationPermissions {
     fn default() -> Self {
         Self {
@@ -30506,11 +28800,6 @@ pub enum InstallationPermissionsActions {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationPermissionsActions {
-    fn from(value: &InstallationPermissionsActions) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationPermissionsActions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -30582,11 +28871,6 @@ pub enum InstallationPermissionsAdministration {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationPermissionsAdministration {
-    fn from(value: &InstallationPermissionsAdministration) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationPermissionsAdministration {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -30660,11 +28944,6 @@ pub enum InstallationPermissionsChecks {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationPermissionsChecks {
-    fn from(value: &InstallationPermissionsChecks) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationPermissionsChecks {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -30736,11 +29015,6 @@ pub enum InstallationPermissionsContentReferences {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationPermissionsContentReferences {
-    fn from(value: &InstallationPermissionsContentReferences) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationPermissionsContentReferences {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -30814,11 +29088,6 @@ pub enum InstallationPermissionsContents {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationPermissionsContents {
-    fn from(value: &InstallationPermissionsContents) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationPermissionsContents {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -30890,11 +29159,6 @@ pub enum InstallationPermissionsDeployments {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationPermissionsDeployments {
-    fn from(value: &InstallationPermissionsDeployments) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationPermissionsDeployments {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -30968,11 +29232,6 @@ pub enum InstallationPermissionsDiscussions {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationPermissionsDiscussions {
-    fn from(value: &InstallationPermissionsDiscussions) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationPermissionsDiscussions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -31044,11 +29303,6 @@ pub enum InstallationPermissionsEmails {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationPermissionsEmails {
-    fn from(value: &InstallationPermissionsEmails) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationPermissionsEmails {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -31122,11 +29376,6 @@ pub enum InstallationPermissionsEnvironments {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationPermissionsEnvironments {
-    fn from(value: &InstallationPermissionsEnvironments) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationPermissionsEnvironments {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -31198,11 +29447,6 @@ pub enum InstallationPermissionsIssues {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationPermissionsIssues {
-    fn from(value: &InstallationPermissionsIssues) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationPermissionsIssues {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -31276,11 +29520,6 @@ pub enum InstallationPermissionsMembers {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationPermissionsMembers {
-    fn from(value: &InstallationPermissionsMembers) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationPermissionsMembers {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -31353,11 +29592,6 @@ pub enum InstallationPermissionsMetadata {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationPermissionsMetadata {
-    fn from(value: &InstallationPermissionsMetadata) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationPermissionsMetadata {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -31429,11 +29663,6 @@ pub enum InstallationPermissionsOrganizationAdministration {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationPermissionsOrganizationAdministration {
-    fn from(value: &InstallationPermissionsOrganizationAdministration) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationPermissionsOrganizationAdministration {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -31511,11 +29740,6 @@ pub enum InstallationPermissionsOrganizationEvents {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationPermissionsOrganizationEvents {
-    fn from(value: &InstallationPermissionsOrganizationEvents) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationPermissionsOrganizationEvents {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -31588,11 +29812,6 @@ pub enum InstallationPermissionsOrganizationHooks {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationPermissionsOrganizationHooks {
-    fn from(value: &InstallationPermissionsOrganizationHooks) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationPermissionsOrganizationHooks {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -31664,11 +29883,6 @@ pub enum InstallationPermissionsOrganizationPackages {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationPermissionsOrganizationPackages {
-    fn from(value: &InstallationPermissionsOrganizationPackages) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationPermissionsOrganizationPackages {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -31746,11 +29960,6 @@ pub enum InstallationPermissionsOrganizationPlan {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationPermissionsOrganizationPlan {
-    fn from(value: &InstallationPermissionsOrganizationPlan) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationPermissionsOrganizationPlan {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -31822,11 +30031,6 @@ pub enum InstallationPermissionsOrganizationProjects {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationPermissionsOrganizationProjects {
-    fn from(value: &InstallationPermissionsOrganizationProjects) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationPermissionsOrganizationProjects {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -31904,11 +30108,6 @@ pub enum InstallationPermissionsOrganizationSecrets {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationPermissionsOrganizationSecrets {
-    fn from(value: &InstallationPermissionsOrganizationSecrets) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationPermissionsOrganizationSecrets {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -31982,11 +30181,6 @@ pub enum InstallationPermissionsOrganizationSelfHostedRunners {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationPermissionsOrganizationSelfHostedRunners {
-    fn from(value: &InstallationPermissionsOrganizationSelfHostedRunners) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationPermissionsOrganizationSelfHostedRunners {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -32064,11 +30258,6 @@ pub enum InstallationPermissionsOrganizationUserBlocking {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationPermissionsOrganizationUserBlocking {
-    fn from(value: &InstallationPermissionsOrganizationUserBlocking) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationPermissionsOrganizationUserBlocking {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -32145,11 +30334,6 @@ pub enum InstallationPermissionsPackages {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationPermissionsPackages {
-    fn from(value: &InstallationPermissionsPackages) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationPermissionsPackages {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -32221,11 +30405,6 @@ pub enum InstallationPermissionsPages {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationPermissionsPages {
-    fn from(value: &InstallationPermissionsPages) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationPermissionsPages {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -32299,11 +30478,6 @@ pub enum InstallationPermissionsPullRequests {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationPermissionsPullRequests {
-    fn from(value: &InstallationPermissionsPullRequests) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationPermissionsPullRequests {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -32375,11 +30549,6 @@ pub enum InstallationPermissionsRepositoryHooks {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationPermissionsRepositoryHooks {
-    fn from(value: &InstallationPermissionsRepositoryHooks) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationPermissionsRepositoryHooks {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -32453,11 +30622,6 @@ pub enum InstallationPermissionsRepositoryProjects {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationPermissionsRepositoryProjects {
-    fn from(value: &InstallationPermissionsRepositoryProjects) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationPermissionsRepositoryProjects {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -32529,11 +30693,6 @@ pub enum InstallationPermissionsSecretScanningAlerts {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationPermissionsSecretScanningAlerts {
-    fn from(value: &InstallationPermissionsSecretScanningAlerts) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationPermissionsSecretScanningAlerts {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -32611,11 +30770,6 @@ pub enum InstallationPermissionsSecrets {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationPermissionsSecrets {
-    fn from(value: &InstallationPermissionsSecrets) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationPermissionsSecrets {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -32688,11 +30842,6 @@ pub enum InstallationPermissionsSecurityEvents {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationPermissionsSecurityEvents {
-    fn from(value: &InstallationPermissionsSecurityEvents) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationPermissionsSecurityEvents {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -32764,11 +30913,6 @@ pub enum InstallationPermissionsSecurityScanningAlert {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationPermissionsSecurityScanningAlert {
-    fn from(value: &InstallationPermissionsSecurityScanningAlert) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationPermissionsSecurityScanningAlert {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -32846,11 +30990,6 @@ pub enum InstallationPermissionsSingleFile {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationPermissionsSingleFile {
-    fn from(value: &InstallationPermissionsSingleFile) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationPermissionsSingleFile {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -32922,11 +31061,6 @@ pub enum InstallationPermissionsStatuses {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationPermissionsStatuses {
-    fn from(value: &InstallationPermissionsStatuses) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationPermissionsStatuses {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -33000,11 +31134,6 @@ pub enum InstallationPermissionsTeamDiscussions {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationPermissionsTeamDiscussions {
-    fn from(value: &InstallationPermissionsTeamDiscussions) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationPermissionsTeamDiscussions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -33076,11 +31205,6 @@ pub enum InstallationPermissionsVulnerabilityAlerts {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationPermissionsVulnerabilityAlerts {
-    fn from(value: &InstallationPermissionsVulnerabilityAlerts) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationPermissionsVulnerabilityAlerts {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -33155,11 +31279,6 @@ pub enum InstallationPermissionsWorkflows {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationPermissionsWorkflows {
-    fn from(value: &InstallationPermissionsWorkflows) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationPermissionsWorkflows {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -33333,11 +31452,6 @@ pub struct InstallationRepositoriesAdded {
     pub requester: ::std::option::Option<User>,
     pub sender: User,
 }
-impl ::std::convert::From<&InstallationRepositoriesAdded> for InstallationRepositoriesAdded {
-    fn from(value: &InstallationRepositoriesAdded) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`InstallationRepositoriesAddedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -33366,11 +31480,6 @@ impl ::std::convert::From<&InstallationRepositoriesAdded> for InstallationReposi
 pub enum InstallationRepositoriesAddedAction {
     #[serde(rename = "added")]
     Added,
-}
-impl ::std::convert::From<&Self> for InstallationRepositoriesAddedAction {
-    fn from(value: &InstallationRepositoriesAddedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationRepositoriesAddedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -33460,13 +31569,6 @@ pub struct InstallationRepositoriesAddedRepositoriesAddedItem {
     #[doc = "Whether the repository is private or public."]
     pub private: bool,
 }
-impl ::std::convert::From<&InstallationRepositoriesAddedRepositoriesAddedItem>
-    for InstallationRepositoriesAddedRepositoriesAddedItem
-{
-    fn from(value: &InstallationRepositoriesAddedRepositoriesAddedItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`InstallationRepositoriesAddedRepositoriesRemovedItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -33515,13 +31617,6 @@ pub struct InstallationRepositoriesAddedRepositoriesRemovedItem {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub private: ::std::option::Option<bool>,
 }
-impl ::std::convert::From<&InstallationRepositoriesAddedRepositoriesRemovedItem>
-    for InstallationRepositoriesAddedRepositoriesRemovedItem
-{
-    fn from(value: &InstallationRepositoriesAddedRepositoriesRemovedItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for InstallationRepositoriesAddedRepositoriesRemovedItem {
     fn default() -> Self {
         Self {
@@ -33565,11 +31660,6 @@ pub enum InstallationRepositoriesAddedRepositorySelection {
     All,
     #[serde(rename = "selected")]
     Selected,
-}
-impl ::std::convert::From<&Self> for InstallationRepositoriesAddedRepositorySelection {
-    fn from(value: &InstallationRepositoriesAddedRepositorySelection) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationRepositoriesAddedRepositorySelection {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -33637,11 +31727,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum InstallationRepositoriesEvent {
     Added(InstallationRepositoriesAdded),
     Removed(InstallationRepositoriesRemoved),
-}
-impl ::std::convert::From<&Self> for InstallationRepositoriesEvent {
-    fn from(value: &InstallationRepositoriesEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<InstallationRepositoriesAdded> for InstallationRepositoriesEvent {
     fn from(value: InstallationRepositoriesAdded) -> Self {
@@ -33793,11 +31878,6 @@ pub struct InstallationRepositoriesRemoved {
     pub requester: ::std::option::Option<User>,
     pub sender: User,
 }
-impl ::std::convert::From<&InstallationRepositoriesRemoved> for InstallationRepositoriesRemoved {
-    fn from(value: &InstallationRepositoriesRemoved) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`InstallationRepositoriesRemovedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -33826,11 +31906,6 @@ impl ::std::convert::From<&InstallationRepositoriesRemoved> for InstallationRepo
 pub enum InstallationRepositoriesRemovedAction {
     #[serde(rename = "removed")]
     Removed,
-}
-impl ::std::convert::From<&Self> for InstallationRepositoriesRemovedAction {
-    fn from(value: &InstallationRepositoriesRemovedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationRepositoriesRemovedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -33920,13 +31995,6 @@ pub struct InstallationRepositoriesRemovedRepositoriesAddedItem {
     #[doc = "Whether the repository is private or public."]
     pub private: bool,
 }
-impl ::std::convert::From<&InstallationRepositoriesRemovedRepositoriesAddedItem>
-    for InstallationRepositoriesRemovedRepositoriesAddedItem
-{
-    fn from(value: &InstallationRepositoriesRemovedRepositoriesAddedItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`InstallationRepositoriesRemovedRepositoriesRemovedItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -33977,13 +32045,6 @@ pub struct InstallationRepositoriesRemovedRepositoriesRemovedItem {
     #[doc = "Whether the repository is private or public."]
     pub private: bool,
 }
-impl ::std::convert::From<&InstallationRepositoriesRemovedRepositoriesRemovedItem>
-    for InstallationRepositoriesRemovedRepositoriesRemovedItem
-{
-    fn from(value: &InstallationRepositoriesRemovedRepositoriesRemovedItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "Describe whether all repositories have been selected or there's a selection involved"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -34016,11 +32077,6 @@ pub enum InstallationRepositoriesRemovedRepositorySelection {
     All,
     #[serde(rename = "selected")]
     Selected,
-}
-impl ::std::convert::From<&Self> for InstallationRepositoriesRemovedRepositorySelection {
-    fn from(value: &InstallationRepositoriesRemovedRepositorySelection) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationRepositoriesRemovedRepositorySelection {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -34098,11 +32154,6 @@ pub enum InstallationRepositorySelection {
     All,
     #[serde(rename = "selected")]
     Selected,
-}
-impl ::std::convert::From<&Self> for InstallationRepositorySelection {
-    fn from(value: &InstallationRepositorySelection) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationRepositorySelection {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -34247,11 +32298,6 @@ pub struct InstallationSuspend {
     pub requester: (),
     pub sender: User,
 }
-impl ::std::convert::From<&InstallationSuspend> for InstallationSuspend {
-    fn from(value: &InstallationSuspend) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`InstallationSuspendAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -34280,11 +32326,6 @@ impl ::std::convert::From<&InstallationSuspend> for InstallationSuspend {
 pub enum InstallationSuspendAction {
     #[serde(rename = "suspend")]
     Suspend,
-}
-impl ::std::convert::From<&Self> for InstallationSuspendAction {
-    fn from(value: &InstallationSuspendAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationSuspendAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -34384,11 +32425,6 @@ pub struct InstallationSuspendInstallation {
     pub target_type: InstallationSuspendInstallationTargetType,
     pub updated_at: InstallationSuspendInstallationUpdatedAt,
 }
-impl ::std::convert::From<&InstallationSuspendInstallation> for InstallationSuspendInstallation {
-    fn from(value: &InstallationSuspendInstallation) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`InstallationSuspendInstallationCreatedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -34412,11 +32448,6 @@ impl ::std::convert::From<&InstallationSuspendInstallation> for InstallationSusp
 pub enum InstallationSuspendInstallationCreatedAt {
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
     Integer(i64),
-}
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationCreatedAt {
-    fn from(value: &InstallationSuspendInstallationCreatedAt) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for InstallationSuspendInstallationCreatedAt {
     type Err = self::error::ConversionError;
@@ -34632,11 +32663,6 @@ pub enum InstallationSuspendInstallationEventsItem {
     WorkflowDispatch,
     #[serde(rename = "workflow_run")]
     WorkflowRun,
-}
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationEventsItem {
-    fn from(value: &InstallationSuspendInstallationEventsItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationSuspendInstallationEventsItem {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -35116,13 +33142,6 @@ pub struct InstallationSuspendInstallationPermissions {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub workflows: ::std::option::Option<InstallationSuspendInstallationPermissionsWorkflows>,
 }
-impl ::std::convert::From<&InstallationSuspendInstallationPermissions>
-    for InstallationSuspendInstallationPermissions
-{
-    fn from(value: &InstallationSuspendInstallationPermissions) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for InstallationSuspendInstallationPermissions {
     fn default() -> Self {
         Self {
@@ -35195,11 +33214,6 @@ pub enum InstallationSuspendInstallationPermissionsActions {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsActions {
-    fn from(value: &InstallationSuspendInstallationPermissionsActions) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsActions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -35277,11 +33291,6 @@ pub enum InstallationSuspendInstallationPermissionsAdministration {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsAdministration {
-    fn from(value: &InstallationSuspendInstallationPermissionsAdministration) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsAdministration {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -35357,11 +33366,6 @@ pub enum InstallationSuspendInstallationPermissionsChecks {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsChecks {
-    fn from(value: &InstallationSuspendInstallationPermissionsChecks) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsChecks {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -35439,11 +33443,6 @@ pub enum InstallationSuspendInstallationPermissionsContentReferences {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsContentReferences {
-    fn from(value: &InstallationSuspendInstallationPermissionsContentReferences) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsContentReferences {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -35519,11 +33518,6 @@ pub enum InstallationSuspendInstallationPermissionsContents {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsContents {
-    fn from(value: &InstallationSuspendInstallationPermissionsContents) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsContents {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -35601,11 +33595,6 @@ pub enum InstallationSuspendInstallationPermissionsDeployments {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsDeployments {
-    fn from(value: &InstallationSuspendInstallationPermissionsDeployments) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsDeployments {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -35681,11 +33670,6 @@ pub enum InstallationSuspendInstallationPermissionsDiscussions {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsDiscussions {
-    fn from(value: &InstallationSuspendInstallationPermissionsDiscussions) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsDiscussions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -35763,11 +33747,6 @@ pub enum InstallationSuspendInstallationPermissionsEmails {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsEmails {
-    fn from(value: &InstallationSuspendInstallationPermissionsEmails) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsEmails {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -35843,11 +33822,6 @@ pub enum InstallationSuspendInstallationPermissionsEnvironments {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsEnvironments {
-    fn from(value: &InstallationSuspendInstallationPermissionsEnvironments) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsEnvironments {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -35925,11 +33899,6 @@ pub enum InstallationSuspendInstallationPermissionsIssues {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsIssues {
-    fn from(value: &InstallationSuspendInstallationPermissionsIssues) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsIssues {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -36005,11 +33974,6 @@ pub enum InstallationSuspendInstallationPermissionsMembers {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsMembers {
-    fn from(value: &InstallationSuspendInstallationPermissionsMembers) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsMembers {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -36087,11 +34051,6 @@ pub enum InstallationSuspendInstallationPermissionsMetadata {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsMetadata {
-    fn from(value: &InstallationSuspendInstallationPermissionsMetadata) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsMetadata {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -36167,13 +34126,6 @@ pub enum InstallationSuspendInstallationPermissionsOrganizationAdministration {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self>
-    for InstallationSuspendInstallationPermissionsOrganizationAdministration
-{
-    fn from(value: &InstallationSuspendInstallationPermissionsOrganizationAdministration) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsOrganizationAdministration {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -36253,11 +34205,6 @@ pub enum InstallationSuspendInstallationPermissionsOrganizationEvents {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsOrganizationEvents {
-    fn from(value: &InstallationSuspendInstallationPermissionsOrganizationEvents) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsOrganizationEvents {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -36336,11 +34283,6 @@ pub enum InstallationSuspendInstallationPermissionsOrganizationHooks {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsOrganizationHooks {
-    fn from(value: &InstallationSuspendInstallationPermissionsOrganizationHooks) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsOrganizationHooks {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -36416,13 +34358,6 @@ pub enum InstallationSuspendInstallationPermissionsOrganizationPackages {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self>
-    for InstallationSuspendInstallationPermissionsOrganizationPackages
-{
-    fn from(value: &InstallationSuspendInstallationPermissionsOrganizationPackages) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsOrganizationPackages {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -36502,11 +34437,6 @@ pub enum InstallationSuspendInstallationPermissionsOrganizationPlan {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsOrganizationPlan {
-    fn from(value: &InstallationSuspendInstallationPermissionsOrganizationPlan) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsOrganizationPlan {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -36582,13 +34512,6 @@ pub enum InstallationSuspendInstallationPermissionsOrganizationProjects {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self>
-    for InstallationSuspendInstallationPermissionsOrganizationProjects
-{
-    fn from(value: &InstallationSuspendInstallationPermissionsOrganizationProjects) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsOrganizationProjects {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -36668,11 +34591,6 @@ pub enum InstallationSuspendInstallationPermissionsOrganizationSecrets {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsOrganizationSecrets {
-    fn from(value: &InstallationSuspendInstallationPermissionsOrganizationSecrets) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsOrganizationSecrets {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -36750,15 +34668,6 @@ pub enum InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunners
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self>
-    for InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunners
-{
-    fn from(
-        value: &InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunners,
-    ) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display
     for InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunners
@@ -36842,13 +34751,6 @@ pub enum InstallationSuspendInstallationPermissionsOrganizationUserBlocking {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self>
-    for InstallationSuspendInstallationPermissionsOrganizationUserBlocking
-{
-    fn from(value: &InstallationSuspendInstallationPermissionsOrganizationUserBlocking) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsOrganizationUserBlocking {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -36927,11 +34829,6 @@ pub enum InstallationSuspendInstallationPermissionsPackages {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsPackages {
-    fn from(value: &InstallationSuspendInstallationPermissionsPackages) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsPackages {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -37007,11 +34904,6 @@ pub enum InstallationSuspendInstallationPermissionsPages {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsPages {
-    fn from(value: &InstallationSuspendInstallationPermissionsPages) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsPages {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -37089,11 +34981,6 @@ pub enum InstallationSuspendInstallationPermissionsPullRequests {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsPullRequests {
-    fn from(value: &InstallationSuspendInstallationPermissionsPullRequests) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsPullRequests {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -37170,11 +35057,6 @@ pub enum InstallationSuspendInstallationPermissionsRepositoryHooks {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsRepositoryHooks {
-    fn from(value: &InstallationSuspendInstallationPermissionsRepositoryHooks) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsRepositoryHooks {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -37250,11 +35132,6 @@ pub enum InstallationSuspendInstallationPermissionsRepositoryProjects {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsRepositoryProjects {
-    fn from(value: &InstallationSuspendInstallationPermissionsRepositoryProjects) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsRepositoryProjects {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -37334,13 +35211,6 @@ pub enum InstallationSuspendInstallationPermissionsSecretScanningAlerts {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self>
-    for InstallationSuspendInstallationPermissionsSecretScanningAlerts
-{
-    fn from(value: &InstallationSuspendInstallationPermissionsSecretScanningAlerts) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsSecretScanningAlerts {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -37419,11 +35289,6 @@ pub enum InstallationSuspendInstallationPermissionsSecrets {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsSecrets {
-    fn from(value: &InstallationSuspendInstallationPermissionsSecrets) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsSecrets {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -37500,11 +35365,6 @@ pub enum InstallationSuspendInstallationPermissionsSecurityEvents {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsSecurityEvents {
-    fn from(value: &InstallationSuspendInstallationPermissionsSecurityEvents) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsSecurityEvents {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -37580,13 +35440,6 @@ pub enum InstallationSuspendInstallationPermissionsSecurityScanningAlert {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self>
-    for InstallationSuspendInstallationPermissionsSecurityScanningAlert
-{
-    fn from(value: &InstallationSuspendInstallationPermissionsSecurityScanningAlert) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsSecurityScanningAlert {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -37666,11 +35519,6 @@ pub enum InstallationSuspendInstallationPermissionsSingleFile {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsSingleFile {
-    fn from(value: &InstallationSuspendInstallationPermissionsSingleFile) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsSingleFile {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -37746,11 +35594,6 @@ pub enum InstallationSuspendInstallationPermissionsStatuses {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsStatuses {
-    fn from(value: &InstallationSuspendInstallationPermissionsStatuses) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsStatuses {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -37828,11 +35671,6 @@ pub enum InstallationSuspendInstallationPermissionsTeamDiscussions {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsTeamDiscussions {
-    fn from(value: &InstallationSuspendInstallationPermissionsTeamDiscussions) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsTeamDiscussions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -37908,11 +35746,6 @@ pub enum InstallationSuspendInstallationPermissionsVulnerabilityAlerts {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsVulnerabilityAlerts {
-    fn from(value: &InstallationSuspendInstallationPermissionsVulnerabilityAlerts) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsVulnerabilityAlerts {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -37992,11 +35825,6 @@ pub enum InstallationSuspendInstallationPermissionsWorkflows {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationPermissionsWorkflows {
-    fn from(value: &InstallationSuspendInstallationPermissionsWorkflows) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationSuspendInstallationPermissionsWorkflows {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -38073,11 +35901,6 @@ pub enum InstallationSuspendInstallationRepositorySelection {
     All,
     #[serde(rename = "selected")]
     Selected,
-}
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationRepositorySelection {
-    fn from(value: &InstallationSuspendInstallationRepositorySelection) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationSuspendInstallationRepositorySelection {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -38275,13 +36098,6 @@ pub struct InstallationSuspendInstallationSuspendedBy {
     pub type_: InstallationSuspendInstallationSuspendedByType,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&InstallationSuspendInstallationSuspendedBy>
-    for InstallationSuspendInstallationSuspendedBy
-{
-    fn from(value: &InstallationSuspendInstallationSuspendedBy) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`InstallationSuspendInstallationSuspendedByType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -38313,11 +36129,6 @@ pub enum InstallationSuspendInstallationSuspendedByType {
     Bot,
     User,
     Organization,
-}
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationSuspendedByType {
-    fn from(value: &InstallationSuspendInstallationSuspendedByType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationSuspendInstallationSuspendedByType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -38395,11 +36206,6 @@ pub enum InstallationSuspendInstallationTargetType {
     User,
     Organization,
 }
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationTargetType {
-    fn from(value: &InstallationSuspendInstallationTargetType) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationSuspendInstallationTargetType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -38463,11 +36269,6 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationSuspendInsta
 pub enum InstallationSuspendInstallationUpdatedAt {
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
     Integer(i64),
-}
-impl ::std::convert::From<&Self> for InstallationSuspendInstallationUpdatedAt {
-    fn from(value: &InstallationSuspendInstallationUpdatedAt) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for InstallationSuspendInstallationUpdatedAt {
     type Err = self::error::ConversionError;
@@ -38573,13 +36374,6 @@ pub struct InstallationSuspendRepositoriesItem {
     #[doc = "Whether the repository is private or public."]
     pub private: bool,
 }
-impl ::std::convert::From<&InstallationSuspendRepositoriesItem>
-    for InstallationSuspendRepositoriesItem
-{
-    fn from(value: &InstallationSuspendRepositoriesItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`InstallationTargetType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -38609,11 +36403,6 @@ impl ::std::convert::From<&InstallationSuspendRepositoriesItem>
 pub enum InstallationTargetType {
     User,
     Organization,
-}
-impl ::std::convert::From<&Self> for InstallationTargetType {
-    fn from(value: &InstallationTargetType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationTargetType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -38757,11 +36546,6 @@ pub struct InstallationUnsuspend {
     pub requester: (),
     pub sender: User,
 }
-impl ::std::convert::From<&InstallationUnsuspend> for InstallationUnsuspend {
-    fn from(value: &InstallationUnsuspend) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`InstallationUnsuspendAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -38790,11 +36574,6 @@ impl ::std::convert::From<&InstallationUnsuspend> for InstallationUnsuspend {
 pub enum InstallationUnsuspendAction {
     #[serde(rename = "unsuspend")]
     Unsuspend,
-}
-impl ::std::convert::From<&Self> for InstallationUnsuspendAction {
-    fn from(value: &InstallationUnsuspendAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationUnsuspendAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -38893,13 +36672,6 @@ pub struct InstallationUnsuspendInstallation {
     pub target_type: InstallationUnsuspendInstallationTargetType,
     pub updated_at: InstallationUnsuspendInstallationUpdatedAt,
 }
-impl ::std::convert::From<&InstallationUnsuspendInstallation>
-    for InstallationUnsuspendInstallation
-{
-    fn from(value: &InstallationUnsuspendInstallation) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`InstallationUnsuspendInstallationCreatedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -38923,11 +36695,6 @@ impl ::std::convert::From<&InstallationUnsuspendInstallation>
 pub enum InstallationUnsuspendInstallationCreatedAt {
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
     Integer(i64),
-}
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationCreatedAt {
-    fn from(value: &InstallationUnsuspendInstallationCreatedAt) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for InstallationUnsuspendInstallationCreatedAt {
     type Err = self::error::ConversionError;
@@ -39145,11 +36912,6 @@ pub enum InstallationUnsuspendInstallationEventsItem {
     WorkflowDispatch,
     #[serde(rename = "workflow_run")]
     WorkflowRun,
-}
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationEventsItem {
-    fn from(value: &InstallationUnsuspendInstallationEventsItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationUnsuspendInstallationEventsItem {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -39635,13 +37397,6 @@ pub struct InstallationUnsuspendInstallationPermissions {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub workflows: ::std::option::Option<InstallationUnsuspendInstallationPermissionsWorkflows>,
 }
-impl ::std::convert::From<&InstallationUnsuspendInstallationPermissions>
-    for InstallationUnsuspendInstallationPermissions
-{
-    fn from(value: &InstallationUnsuspendInstallationPermissions) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for InstallationUnsuspendInstallationPermissions {
     fn default() -> Self {
         Self {
@@ -39714,11 +37469,6 @@ pub enum InstallationUnsuspendInstallationPermissionsActions {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermissionsActions {
-    fn from(value: &InstallationUnsuspendInstallationPermissionsActions) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsActions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -39796,11 +37546,6 @@ pub enum InstallationUnsuspendInstallationPermissionsAdministration {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermissionsAdministration {
-    fn from(value: &InstallationUnsuspendInstallationPermissionsAdministration) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsAdministration {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -39877,11 +37622,6 @@ pub enum InstallationUnsuspendInstallationPermissionsChecks {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermissionsChecks {
-    fn from(value: &InstallationUnsuspendInstallationPermissionsChecks) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsChecks {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -39957,11 +37697,6 @@ pub enum InstallationUnsuspendInstallationPermissionsContentReferences {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermissionsContentReferences {
-    fn from(value: &InstallationUnsuspendInstallationPermissionsContentReferences) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsContentReferences {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -40041,11 +37776,6 @@ pub enum InstallationUnsuspendInstallationPermissionsContents {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermissionsContents {
-    fn from(value: &InstallationUnsuspendInstallationPermissionsContents) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsContents {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -40121,11 +37851,6 @@ pub enum InstallationUnsuspendInstallationPermissionsDeployments {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermissionsDeployments {
-    fn from(value: &InstallationUnsuspendInstallationPermissionsDeployments) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsDeployments {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -40203,11 +37928,6 @@ pub enum InstallationUnsuspendInstallationPermissionsDiscussions {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermissionsDiscussions {
-    fn from(value: &InstallationUnsuspendInstallationPermissionsDiscussions) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsDiscussions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -40283,11 +38003,6 @@ pub enum InstallationUnsuspendInstallationPermissionsEmails {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermissionsEmails {
-    fn from(value: &InstallationUnsuspendInstallationPermissionsEmails) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsEmails {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -40365,11 +38080,6 @@ pub enum InstallationUnsuspendInstallationPermissionsEnvironments {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermissionsEnvironments {
-    fn from(value: &InstallationUnsuspendInstallationPermissionsEnvironments) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsEnvironments {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -40445,11 +38155,6 @@ pub enum InstallationUnsuspendInstallationPermissionsIssues {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermissionsIssues {
-    fn from(value: &InstallationUnsuspendInstallationPermissionsIssues) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsIssues {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -40527,11 +38232,6 @@ pub enum InstallationUnsuspendInstallationPermissionsMembers {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermissionsMembers {
-    fn from(value: &InstallationUnsuspendInstallationPermissionsMembers) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsMembers {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -40608,11 +38308,6 @@ pub enum InstallationUnsuspendInstallationPermissionsMetadata {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermissionsMetadata {
-    fn from(value: &InstallationUnsuspendInstallationPermissionsMetadata) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsMetadata {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -40688,15 +38383,6 @@ pub enum InstallationUnsuspendInstallationPermissionsOrganizationAdministration 
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self>
-    for InstallationUnsuspendInstallationPermissionsOrganizationAdministration
-{
-    fn from(
-        value: &InstallationUnsuspendInstallationPermissionsOrganizationAdministration,
-    ) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display
     for InstallationUnsuspendInstallationPermissionsOrganizationAdministration
@@ -40780,13 +38466,6 @@ pub enum InstallationUnsuspendInstallationPermissionsOrganizationEvents {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self>
-    for InstallationUnsuspendInstallationPermissionsOrganizationEvents
-{
-    fn from(value: &InstallationUnsuspendInstallationPermissionsOrganizationEvents) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsOrganizationEvents {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -40864,11 +38543,6 @@ pub enum InstallationUnsuspendInstallationPermissionsOrganizationHooks {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermissionsOrganizationHooks {
-    fn from(value: &InstallationUnsuspendInstallationPermissionsOrganizationHooks) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsOrganizationHooks {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -40948,13 +38622,6 @@ pub enum InstallationUnsuspendInstallationPermissionsOrganizationPackages {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self>
-    for InstallationUnsuspendInstallationPermissionsOrganizationPackages
-{
-    fn from(value: &InstallationUnsuspendInstallationPermissionsOrganizationPackages) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsOrganizationPackages {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -41032,11 +38699,6 @@ pub enum InstallationUnsuspendInstallationPermissionsOrganizationPlan {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermissionsOrganizationPlan {
-    fn from(value: &InstallationUnsuspendInstallationPermissionsOrganizationPlan) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsOrganizationPlan {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -41116,13 +38778,6 @@ pub enum InstallationUnsuspendInstallationPermissionsOrganizationProjects {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self>
-    for InstallationUnsuspendInstallationPermissionsOrganizationProjects
-{
-    fn from(value: &InstallationUnsuspendInstallationPermissionsOrganizationProjects) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsOrganizationProjects {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -41201,13 +38856,6 @@ pub enum InstallationUnsuspendInstallationPermissionsOrganizationSecrets {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self>
-    for InstallationUnsuspendInstallationPermissionsOrganizationSecrets
-{
-    fn from(value: &InstallationUnsuspendInstallationPermissionsOrganizationSecrets) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsOrganizationSecrets {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -41285,15 +38933,6 @@ pub enum InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRunne
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self>
-    for InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRunners
-{
-    fn from(
-        value: &InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRunners,
-    ) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display
     for InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRunners
@@ -41377,13 +39016,6 @@ pub enum InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self>
-    for InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking
-{
-    fn from(value: &InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -41462,11 +39094,6 @@ pub enum InstallationUnsuspendInstallationPermissionsPackages {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermissionsPackages {
-    fn from(value: &InstallationUnsuspendInstallationPermissionsPackages) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsPackages {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -41542,11 +39169,6 @@ pub enum InstallationUnsuspendInstallationPermissionsPages {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermissionsPages {
-    fn from(value: &InstallationUnsuspendInstallationPermissionsPages) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsPages {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -41624,11 +39246,6 @@ pub enum InstallationUnsuspendInstallationPermissionsPullRequests {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermissionsPullRequests {
-    fn from(value: &InstallationUnsuspendInstallationPermissionsPullRequests) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsPullRequests {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -41705,11 +39322,6 @@ pub enum InstallationUnsuspendInstallationPermissionsRepositoryHooks {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermissionsRepositoryHooks {
-    fn from(value: &InstallationUnsuspendInstallationPermissionsRepositoryHooks) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsRepositoryHooks {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -41785,13 +39397,6 @@ pub enum InstallationUnsuspendInstallationPermissionsRepositoryProjects {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self>
-    for InstallationUnsuspendInstallationPermissionsRepositoryProjects
-{
-    fn from(value: &InstallationUnsuspendInstallationPermissionsRepositoryProjects) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsRepositoryProjects {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -41871,13 +39476,6 @@ pub enum InstallationUnsuspendInstallationPermissionsSecretScanningAlerts {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self>
-    for InstallationUnsuspendInstallationPermissionsSecretScanningAlerts
-{
-    fn from(value: &InstallationUnsuspendInstallationPermissionsSecretScanningAlerts) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsSecretScanningAlerts {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -41956,11 +39554,6 @@ pub enum InstallationUnsuspendInstallationPermissionsSecrets {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermissionsSecrets {
-    fn from(value: &InstallationUnsuspendInstallationPermissionsSecrets) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsSecrets {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -42037,11 +39630,6 @@ pub enum InstallationUnsuspendInstallationPermissionsSecurityEvents {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermissionsSecurityEvents {
-    fn from(value: &InstallationUnsuspendInstallationPermissionsSecurityEvents) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsSecurityEvents {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -42117,13 +39705,6 @@ pub enum InstallationUnsuspendInstallationPermissionsSecurityScanningAlert {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self>
-    for InstallationUnsuspendInstallationPermissionsSecurityScanningAlert
-{
-    fn from(value: &InstallationUnsuspendInstallationPermissionsSecurityScanningAlert) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsSecurityScanningAlert {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -42203,11 +39784,6 @@ pub enum InstallationUnsuspendInstallationPermissionsSingleFile {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermissionsSingleFile {
-    fn from(value: &InstallationUnsuspendInstallationPermissionsSingleFile) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsSingleFile {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -42283,11 +39859,6 @@ pub enum InstallationUnsuspendInstallationPermissionsStatuses {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermissionsStatuses {
-    fn from(value: &InstallationUnsuspendInstallationPermissionsStatuses) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsStatuses {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -42365,11 +39936,6 @@ pub enum InstallationUnsuspendInstallationPermissionsTeamDiscussions {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermissionsTeamDiscussions {
-    fn from(value: &InstallationUnsuspendInstallationPermissionsTeamDiscussions) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsTeamDiscussions {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -42445,13 +40011,6 @@ pub enum InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts {
     Read,
     #[serde(rename = "write")]
     Write,
-}
-impl ::std::convert::From<&Self>
-    for InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts
-{
-    fn from(value: &InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -42531,11 +40090,6 @@ pub enum InstallationUnsuspendInstallationPermissionsWorkflows {
     #[serde(rename = "write")]
     Write,
 }
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationPermissionsWorkflows {
-    fn from(value: &InstallationUnsuspendInstallationPermissionsWorkflows) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationUnsuspendInstallationPermissionsWorkflows {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -42613,11 +40167,6 @@ pub enum InstallationUnsuspendInstallationRepositorySelection {
     #[serde(rename = "selected")]
     Selected,
 }
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationRepositorySelection {
-    fn from(value: &InstallationUnsuspendInstallationRepositorySelection) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationUnsuspendInstallationRepositorySelection {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -42692,11 +40241,6 @@ pub enum InstallationUnsuspendInstallationTargetType {
     User,
     Organization,
 }
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationTargetType {
-    fn from(value: &InstallationUnsuspendInstallationTargetType) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for InstallationUnsuspendInstallationTargetType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -42764,11 +40308,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum InstallationUnsuspendInstallationUpdatedAt {
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
     Integer(i64),
-}
-impl ::std::convert::From<&Self> for InstallationUnsuspendInstallationUpdatedAt {
-    fn from(value: &InstallationUnsuspendInstallationUpdatedAt) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for InstallationUnsuspendInstallationUpdatedAt {
     type Err = self::error::ConversionError;
@@ -42876,13 +40415,6 @@ pub struct InstallationUnsuspendRepositoriesItem {
     #[doc = "Whether the repository is private or public."]
     pub private: bool,
 }
-impl ::std::convert::From<&InstallationUnsuspendRepositoriesItem>
-    for InstallationUnsuspendRepositoriesItem
-{
-    fn from(value: &InstallationUnsuspendRepositoriesItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`InstallationUpdatedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -42906,11 +40438,6 @@ impl ::std::convert::From<&InstallationUnsuspendRepositoriesItem>
 pub enum InstallationUpdatedAt {
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
     Integer(i64),
-}
-impl ::std::convert::From<&Self> for InstallationUpdatedAt {
-    fn from(value: &InstallationUpdatedAt) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for InstallationUpdatedAt {
     type Err = self::error::ConversionError;
@@ -43199,11 +40726,6 @@ pub struct Issue {
     pub url: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&Issue> for Issue {
-    fn from(value: &Issue) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssueActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -43241,11 +40763,6 @@ pub enum IssueActiveLockReason {
     TooHeated,
     #[serde(rename = "spam")]
     Spam,
-}
-impl ::std::convert::From<&Self> for IssueActiveLockReason {
-    fn from(value: &IssueActiveLockReason) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssueActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -43386,11 +40903,6 @@ pub struct IssueComment {
     pub url: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&IssueComment> for IssueComment {
-    fn from(value: &IssueComment) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssueCommentCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -43522,11 +41034,6 @@ pub struct IssueCommentCreated {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&IssueCommentCreated> for IssueCommentCreated {
-    fn from(value: &IssueCommentCreated) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssueCommentCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -43555,11 +41062,6 @@ impl ::std::convert::From<&IssueCommentCreated> for IssueCommentCreated {
 pub enum IssueCommentCreatedAction {
     #[serde(rename = "created")]
     Created,
-}
-impl ::std::convert::From<&Self> for IssueCommentCreatedAction {
-    fn from(value: &IssueCommentCreatedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssueCommentCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -43716,11 +41218,6 @@ pub struct IssueCommentCreatedIssue {
     pub url: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&IssueCommentCreatedIssue> for IssueCommentCreatedIssue {
-    fn from(value: &IssueCommentCreatedIssue) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssueCommentCreatedIssueActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -43758,11 +41255,6 @@ pub enum IssueCommentCreatedIssueActiveLockReason {
     TooHeated,
     #[serde(rename = "spam")]
     Spam,
-}
-impl ::std::convert::From<&Self> for IssueCommentCreatedIssueActiveLockReason {
-    fn from(value: &IssueCommentCreatedIssueActiveLockReason) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssueCommentCreatedIssueActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -43864,11 +41356,6 @@ pub struct IssueCommentCreatedIssueAssignee {
     pub type_: IssueCommentCreatedIssueAssigneeType,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&IssueCommentCreatedIssueAssignee> for IssueCommentCreatedIssueAssignee {
-    fn from(value: &IssueCommentCreatedIssueAssignee) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssueCommentCreatedIssueAssigneeType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -43900,11 +41387,6 @@ pub enum IssueCommentCreatedIssueAssigneeType {
     Bot,
     User,
     Organization,
-}
-impl ::std::convert::From<&Self> for IssueCommentCreatedIssueAssigneeType {
-    fn from(value: &IssueCommentCreatedIssueAssigneeType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssueCommentCreatedIssueAssigneeType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -43991,13 +41473,6 @@ pub struct IssueCommentCreatedIssuePullRequest {
     pub patch_url: ::std::string::String,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&IssueCommentCreatedIssuePullRequest>
-    for IssueCommentCreatedIssuePullRequest
-{
-    fn from(value: &IssueCommentCreatedIssuePullRequest) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssueCommentCreatedIssueState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -44029,11 +41504,6 @@ pub enum IssueCommentCreatedIssueState {
     Open,
     #[serde(rename = "closed")]
     Closed,
-}
-impl ::std::convert::From<&Self> for IssueCommentCreatedIssueState {
-    fn from(value: &IssueCommentCreatedIssueState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssueCommentCreatedIssueState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -44206,11 +41676,6 @@ pub struct IssueCommentDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&IssueCommentDeleted> for IssueCommentDeleted {
-    fn from(value: &IssueCommentDeleted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssueCommentDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -44239,11 +41704,6 @@ impl ::std::convert::From<&IssueCommentDeleted> for IssueCommentDeleted {
 pub enum IssueCommentDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
-}
-impl ::std::convert::From<&Self> for IssueCommentDeletedAction {
-    fn from(value: &IssueCommentDeletedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssueCommentDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -44400,11 +41860,6 @@ pub struct IssueCommentDeletedIssue {
     pub url: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&IssueCommentDeletedIssue> for IssueCommentDeletedIssue {
-    fn from(value: &IssueCommentDeletedIssue) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssueCommentDeletedIssueActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -44442,11 +41897,6 @@ pub enum IssueCommentDeletedIssueActiveLockReason {
     TooHeated,
     #[serde(rename = "spam")]
     Spam,
-}
-impl ::std::convert::From<&Self> for IssueCommentDeletedIssueActiveLockReason {
-    fn from(value: &IssueCommentDeletedIssueActiveLockReason) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssueCommentDeletedIssueActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -44548,11 +41998,6 @@ pub struct IssueCommentDeletedIssueAssignee {
     pub type_: IssueCommentDeletedIssueAssigneeType,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&IssueCommentDeletedIssueAssignee> for IssueCommentDeletedIssueAssignee {
-    fn from(value: &IssueCommentDeletedIssueAssignee) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssueCommentDeletedIssueAssigneeType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -44584,11 +42029,6 @@ pub enum IssueCommentDeletedIssueAssigneeType {
     Bot,
     User,
     Organization,
-}
-impl ::std::convert::From<&Self> for IssueCommentDeletedIssueAssigneeType {
-    fn from(value: &IssueCommentDeletedIssueAssigneeType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssueCommentDeletedIssueAssigneeType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -44675,13 +42115,6 @@ pub struct IssueCommentDeletedIssuePullRequest {
     pub patch_url: ::std::string::String,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&IssueCommentDeletedIssuePullRequest>
-    for IssueCommentDeletedIssuePullRequest
-{
-    fn from(value: &IssueCommentDeletedIssuePullRequest) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssueCommentDeletedIssueState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -44713,11 +42146,6 @@ pub enum IssueCommentDeletedIssueState {
     Open,
     #[serde(rename = "closed")]
     Closed,
-}
-impl ::std::convert::From<&Self> for IssueCommentDeletedIssueState {
-    fn from(value: &IssueCommentDeletedIssueState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssueCommentDeletedIssueState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -44912,11 +42340,6 @@ pub struct IssueCommentEdited {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&IssueCommentEdited> for IssueCommentEdited {
-    fn from(value: &IssueCommentEdited) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssueCommentEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -44945,11 +42368,6 @@ impl ::std::convert::From<&IssueCommentEdited> for IssueCommentEdited {
 pub enum IssueCommentEditedAction {
     #[serde(rename = "edited")]
     Edited,
-}
-impl ::std::convert::From<&Self> for IssueCommentEditedAction {
-    fn from(value: &IssueCommentEditedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssueCommentEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -45022,11 +42440,6 @@ pub struct IssueCommentEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub body: ::std::option::Option<IssueCommentEditedChangesBody>,
 }
-impl ::std::convert::From<&IssueCommentEditedChanges> for IssueCommentEditedChanges {
-    fn from(value: &IssueCommentEditedChanges) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for IssueCommentEditedChanges {
     fn default() -> Self {
         Self {
@@ -45059,11 +42472,6 @@ impl ::std::default::Default for IssueCommentEditedChanges {
 pub struct IssueCommentEditedChangesBody {
     #[doc = "The previous version of the body."]
     pub from: ::std::string::String,
-}
-impl ::std::convert::From<&IssueCommentEditedChangesBody> for IssueCommentEditedChangesBody {
-    fn from(value: &IssueCommentEditedChangesBody) -> Self {
-        value.clone()
-    }
 }
 #[doc = "The [issue](https://docs.github.com/en/rest/reference/issues) the comment belongs to."]
 #[doc = r""]
@@ -45182,11 +42590,6 @@ pub struct IssueCommentEditedIssue {
     pub url: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&IssueCommentEditedIssue> for IssueCommentEditedIssue {
-    fn from(value: &IssueCommentEditedIssue) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssueCommentEditedIssueActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -45224,11 +42627,6 @@ pub enum IssueCommentEditedIssueActiveLockReason {
     TooHeated,
     #[serde(rename = "spam")]
     Spam,
-}
-impl ::std::convert::From<&Self> for IssueCommentEditedIssueActiveLockReason {
-    fn from(value: &IssueCommentEditedIssueActiveLockReason) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssueCommentEditedIssueActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -45330,11 +42728,6 @@ pub struct IssueCommentEditedIssueAssignee {
     pub type_: IssueCommentEditedIssueAssigneeType,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&IssueCommentEditedIssueAssignee> for IssueCommentEditedIssueAssignee {
-    fn from(value: &IssueCommentEditedIssueAssignee) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssueCommentEditedIssueAssigneeType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -45366,11 +42759,6 @@ pub enum IssueCommentEditedIssueAssigneeType {
     Bot,
     User,
     Organization,
-}
-impl ::std::convert::From<&Self> for IssueCommentEditedIssueAssigneeType {
-    fn from(value: &IssueCommentEditedIssueAssigneeType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssueCommentEditedIssueAssigneeType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -45457,13 +42845,6 @@ pub struct IssueCommentEditedIssuePullRequest {
     pub patch_url: ::std::string::String,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&IssueCommentEditedIssuePullRequest>
-    for IssueCommentEditedIssuePullRequest
-{
-    fn from(value: &IssueCommentEditedIssuePullRequest) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssueCommentEditedIssueState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -45495,11 +42876,6 @@ pub enum IssueCommentEditedIssueState {
     Open,
     #[serde(rename = "closed")]
     Closed,
-}
-impl ::std::convert::From<&Self> for IssueCommentEditedIssueState {
-    fn from(value: &IssueCommentEditedIssueState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssueCommentEditedIssueState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -45568,11 +42944,6 @@ pub enum IssueCommentEvent {
     Deleted(IssueCommentDeleted),
     Edited(IssueCommentEdited),
 }
-impl ::std::convert::From<&Self> for IssueCommentEvent {
-    fn from(value: &IssueCommentEvent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<IssueCommentCreated> for IssueCommentEvent {
     fn from(value: IssueCommentCreated) -> Self {
         Self::Created(value)
@@ -45629,11 +43000,6 @@ pub struct IssuePullRequest {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub url: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&IssuePullRequest> for IssuePullRequest {
-    fn from(value: &IssuePullRequest) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for IssuePullRequest {
     fn default() -> Self {
         Self {
@@ -45676,11 +43042,6 @@ pub enum IssueState {
     Open,
     #[serde(rename = "closed")]
     Closed,
-}
-impl ::std::convert::From<&Self> for IssueState {
-    fn from(value: &IssueState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssueState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -45793,11 +43154,6 @@ pub struct IssuesAssigned {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&IssuesAssigned> for IssuesAssigned {
-    fn from(value: &IssuesAssigned) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The action that was performed."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -45827,11 +43183,6 @@ impl ::std::convert::From<&IssuesAssigned> for IssuesAssigned {
 pub enum IssuesAssignedAction {
     #[serde(rename = "assigned")]
     Assigned,
-}
-impl ::std::convert::From<&Self> for IssuesAssignedAction {
-    fn from(value: &IssuesAssignedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesAssignedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -45951,11 +43302,6 @@ pub struct IssuesClosed {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&IssuesClosed> for IssuesClosed {
-    fn from(value: &IssuesClosed) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The action that was performed."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -45985,11 +43331,6 @@ impl ::std::convert::From<&IssuesClosed> for IssuesClosed {
 pub enum IssuesClosedAction {
     #[serde(rename = "closed")]
     Closed,
-}
-impl ::std::convert::From<&Self> for IssuesClosedAction {
-    fn from(value: &IssuesClosedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesClosedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -46101,11 +43442,6 @@ pub struct IssuesClosedIssue {
     pub url: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&IssuesClosedIssue> for IssuesClosedIssue {
-    fn from(value: &IssuesClosedIssue) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssuesClosedIssueActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -46143,11 +43479,6 @@ pub enum IssuesClosedIssueActiveLockReason {
     TooHeated,
     #[serde(rename = "spam")]
     Spam,
-}
-impl ::std::convert::From<&Self> for IssuesClosedIssueActiveLockReason {
-    fn from(value: &IssuesClosedIssueActiveLockReason) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesClosedIssueActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -46234,11 +43565,6 @@ pub struct IssuesClosedIssuePullRequest {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub url: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&IssuesClosedIssuePullRequest> for IssuesClosedIssuePullRequest {
-    fn from(value: &IssuesClosedIssuePullRequest) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for IssuesClosedIssuePullRequest {
     fn default() -> Self {
         Self {
@@ -46277,11 +43603,6 @@ impl ::std::default::Default for IssuesClosedIssuePullRequest {
 pub enum IssuesClosedIssueState {
     #[serde(rename = "closed")]
     Closed,
-}
-impl ::std::convert::From<&Self> for IssuesClosedIssueState {
-    fn from(value: &IssuesClosedIssueState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesClosedIssueState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -46375,11 +43696,6 @@ pub struct IssuesDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&IssuesDeleted> for IssuesDeleted {
-    fn from(value: &IssuesDeleted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssuesDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -46408,11 +43724,6 @@ impl ::std::convert::From<&IssuesDeleted> for IssuesDeleted {
 pub enum IssuesDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
-}
-impl ::std::convert::From<&Self> for IssuesDeletedAction {
-    fn from(value: &IssuesDeletedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -46527,11 +43838,6 @@ pub struct IssuesDemilestoned {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&IssuesDemilestoned> for IssuesDemilestoned {
-    fn from(value: &IssuesDemilestoned) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssuesDemilestonedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -46560,11 +43866,6 @@ impl ::std::convert::From<&IssuesDemilestoned> for IssuesDemilestoned {
 pub enum IssuesDemilestonedAction {
     #[serde(rename = "demilestoned")]
     Demilestoned,
-}
-impl ::std::convert::From<&Self> for IssuesDemilestonedAction {
-    fn from(value: &IssuesDemilestonedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesDemilestonedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -46670,11 +43971,6 @@ pub struct IssuesDemilestonedIssue {
     pub url: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&IssuesDemilestonedIssue> for IssuesDemilestonedIssue {
-    fn from(value: &IssuesDemilestonedIssue) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssuesDemilestonedIssueActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -46712,11 +44008,6 @@ pub enum IssuesDemilestonedIssueActiveLockReason {
     TooHeated,
     #[serde(rename = "spam")]
     Spam,
-}
-impl ::std::convert::From<&Self> for IssuesDemilestonedIssueActiveLockReason {
-    fn from(value: &IssuesDemilestonedIssueActiveLockReason) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesDemilestonedIssueActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -46803,13 +44094,6 @@ pub struct IssuesDemilestonedIssuePullRequest {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub url: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&IssuesDemilestonedIssuePullRequest>
-    for IssuesDemilestonedIssuePullRequest
-{
-    fn from(value: &IssuesDemilestonedIssuePullRequest) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for IssuesDemilestonedIssuePullRequest {
     fn default() -> Self {
         Self {
@@ -46852,11 +44136,6 @@ pub enum IssuesDemilestonedIssueState {
     Open,
     #[serde(rename = "closed")]
     Closed,
-}
-impl ::std::convert::From<&Self> for IssuesDemilestonedIssueState {
-    fn from(value: &IssuesDemilestonedIssueState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesDemilestonedIssueState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -46992,11 +44271,6 @@ pub struct IssuesEdited {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&IssuesEdited> for IssuesEdited {
-    fn from(value: &IssuesEdited) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssuesEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -47025,11 +44299,6 @@ impl ::std::convert::From<&IssuesEdited> for IssuesEdited {
 pub enum IssuesEditedAction {
     #[serde(rename = "edited")]
     Edited,
-}
-impl ::std::convert::From<&Self> for IssuesEditedAction {
-    fn from(value: &IssuesEditedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -47117,11 +44386,6 @@ pub struct IssuesEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<IssuesEditedChangesTitle>,
 }
-impl ::std::convert::From<&IssuesEditedChanges> for IssuesEditedChanges {
-    fn from(value: &IssuesEditedChanges) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for IssuesEditedChanges {
     fn default() -> Self {
         Self {
@@ -47156,11 +44420,6 @@ pub struct IssuesEditedChangesBody {
     #[doc = "The previous version of the body."]
     pub from: ::std::string::String,
 }
-impl ::std::convert::From<&IssuesEditedChangesBody> for IssuesEditedChangesBody {
-    fn from(value: &IssuesEditedChangesBody) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssuesEditedChangesTitle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -47186,11 +44445,6 @@ impl ::std::convert::From<&IssuesEditedChangesBody> for IssuesEditedChangesBody 
 pub struct IssuesEditedChangesTitle {
     #[doc = "The previous version of the title."]
     pub from: ::std::string::String,
-}
-impl ::std::convert::From<&IssuesEditedChangesTitle> for IssuesEditedChangesTitle {
-    fn from(value: &IssuesEditedChangesTitle) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`IssuesEvent`"]
 #[doc = r""]
@@ -47270,11 +44524,6 @@ pub enum IssuesEvent {
     Unlabeled(IssuesUnlabeled),
     Unlocked(IssuesUnlocked),
     Unpinned(IssuesUnpinned),
-}
-impl ::std::convert::From<&Self> for IssuesEvent {
-    fn from(value: &IssuesEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<IssuesAssigned> for IssuesEvent {
     fn from(value: IssuesAssigned) -> Self {
@@ -47417,11 +44666,6 @@ pub struct IssuesLabeled {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&IssuesLabeled> for IssuesLabeled {
-    fn from(value: &IssuesLabeled) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssuesLabeledAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -47450,11 +44694,6 @@ impl ::std::convert::From<&IssuesLabeled> for IssuesLabeled {
 pub enum IssuesLabeledAction {
     #[serde(rename = "labeled")]
     Labeled,
-}
-impl ::std::convert::From<&Self> for IssuesLabeledAction {
-    fn from(value: &IssuesLabeledAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesLabeledAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -47581,11 +44820,6 @@ pub struct IssuesLocked {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&IssuesLocked> for IssuesLocked {
-    fn from(value: &IssuesLocked) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssuesLockedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -47614,11 +44848,6 @@ impl ::std::convert::From<&IssuesLocked> for IssuesLocked {
 pub enum IssuesLockedAction {
     #[serde(rename = "locked")]
     Locked,
-}
-impl ::std::convert::From<&Self> for IssuesLockedAction {
-    fn from(value: &IssuesLockedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesLockedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -47740,11 +44969,6 @@ pub struct IssuesLockedIssue {
     pub url: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&IssuesLockedIssue> for IssuesLockedIssue {
-    fn from(value: &IssuesLockedIssue) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssuesLockedIssueActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -47782,11 +45006,6 @@ pub enum IssuesLockedIssueActiveLockReason {
     TooHeated,
     #[serde(rename = "spam")]
     Spam,
-}
-impl ::std::convert::From<&Self> for IssuesLockedIssueActiveLockReason {
-    fn from(value: &IssuesLockedIssueActiveLockReason) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesLockedIssueActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -47873,11 +45092,6 @@ pub struct IssuesLockedIssuePullRequest {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub url: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&IssuesLockedIssuePullRequest> for IssuesLockedIssuePullRequest {
-    fn from(value: &IssuesLockedIssuePullRequest) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for IssuesLockedIssuePullRequest {
     fn default() -> Self {
         Self {
@@ -47920,11 +45134,6 @@ pub enum IssuesLockedIssueState {
     Open,
     #[serde(rename = "closed")]
     Closed,
-}
-impl ::std::convert::From<&Self> for IssuesLockedIssueState {
-    fn from(value: &IssuesLockedIssueState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesLockedIssueState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -48041,11 +45250,6 @@ pub struct IssuesMilestoned {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&IssuesMilestoned> for IssuesMilestoned {
-    fn from(value: &IssuesMilestoned) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssuesMilestonedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -48074,11 +45278,6 @@ impl ::std::convert::From<&IssuesMilestoned> for IssuesMilestoned {
 pub enum IssuesMilestonedAction {
     #[serde(rename = "milestoned")]
     Milestoned,
-}
-impl ::std::convert::From<&Self> for IssuesMilestonedAction {
-    fn from(value: &IssuesMilestonedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesMilestonedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -48184,11 +45383,6 @@ pub struct IssuesMilestonedIssue {
     pub url: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&IssuesMilestonedIssue> for IssuesMilestonedIssue {
-    fn from(value: &IssuesMilestonedIssue) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssuesMilestonedIssueActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -48226,11 +45420,6 @@ pub enum IssuesMilestonedIssueActiveLockReason {
     TooHeated,
     #[serde(rename = "spam")]
     Spam,
-}
-impl ::std::convert::From<&Self> for IssuesMilestonedIssueActiveLockReason {
-    fn from(value: &IssuesMilestonedIssueActiveLockReason) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesMilestonedIssueActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -48410,11 +45599,6 @@ pub struct IssuesMilestonedIssueMilestone {
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&IssuesMilestonedIssueMilestone> for IssuesMilestonedIssueMilestone {
-    fn from(value: &IssuesMilestonedIssueMilestone) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssuesMilestonedIssueMilestoneState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -48446,11 +45630,6 @@ pub enum IssuesMilestonedIssueMilestoneState {
     Open,
     #[serde(rename = "closed")]
     Closed,
-}
-impl ::std::convert::From<&Self> for IssuesMilestonedIssueMilestoneState {
-    fn from(value: &IssuesMilestonedIssueMilestoneState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesMilestonedIssueMilestoneState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -48533,11 +45712,6 @@ pub struct IssuesMilestonedIssuePullRequest {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub url: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&IssuesMilestonedIssuePullRequest> for IssuesMilestonedIssuePullRequest {
-    fn from(value: &IssuesMilestonedIssuePullRequest) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for IssuesMilestonedIssuePullRequest {
     fn default() -> Self {
         Self {
@@ -48580,11 +45754,6 @@ pub enum IssuesMilestonedIssueState {
     Open,
     #[serde(rename = "closed")]
     Closed,
-}
-impl ::std::convert::From<&Self> for IssuesMilestonedIssueState {
-    fn from(value: &IssuesMilestonedIssueState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesMilestonedIssueState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -48721,11 +45890,6 @@ pub struct IssuesOpened {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&IssuesOpened> for IssuesOpened {
-    fn from(value: &IssuesOpened) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssuesOpenedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -48754,11 +45918,6 @@ impl ::std::convert::From<&IssuesOpened> for IssuesOpened {
 pub enum IssuesOpenedAction {
     #[serde(rename = "opened")]
     Opened,
-}
-impl ::std::convert::From<&Self> for IssuesOpenedAction {
-    fn from(value: &IssuesOpenedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesOpenedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -48826,11 +45985,6 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesOpenedAction {
 pub struct IssuesOpenedChanges {
     pub old_issue: Issue,
     pub old_repository: Repository,
-}
-impl ::std::convert::From<&IssuesOpenedChanges> for IssuesOpenedChanges {
-    fn from(value: &IssuesOpenedChanges) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`IssuesOpenedIssue`"]
 #[doc = r""]
@@ -48903,11 +46057,6 @@ pub struct IssuesOpenedIssue {
     pub url: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&IssuesOpenedIssue> for IssuesOpenedIssue {
-    fn from(value: &IssuesOpenedIssue) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssuesOpenedIssueActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -48945,11 +46094,6 @@ pub enum IssuesOpenedIssueActiveLockReason {
     TooHeated,
     #[serde(rename = "spam")]
     Spam,
-}
-impl ::std::convert::From<&Self> for IssuesOpenedIssueActiveLockReason {
-    fn from(value: &IssuesOpenedIssueActiveLockReason) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesOpenedIssueActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -49036,11 +46180,6 @@ pub struct IssuesOpenedIssuePullRequest {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub url: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&IssuesOpenedIssuePullRequest> for IssuesOpenedIssuePullRequest {
-    fn from(value: &IssuesOpenedIssuePullRequest) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for IssuesOpenedIssuePullRequest {
     fn default() -> Self {
         Self {
@@ -49079,11 +46218,6 @@ impl ::std::default::Default for IssuesOpenedIssuePullRequest {
 pub enum IssuesOpenedIssueState {
     #[serde(rename = "open")]
     Open,
-}
-impl ::std::convert::From<&Self> for IssuesOpenedIssueState {
-    fn from(value: &IssuesOpenedIssueState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesOpenedIssueState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -49177,11 +46311,6 @@ pub struct IssuesPinned {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&IssuesPinned> for IssuesPinned {
-    fn from(value: &IssuesPinned) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssuesPinnedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -49210,11 +46339,6 @@ impl ::std::convert::From<&IssuesPinned> for IssuesPinned {
 pub enum IssuesPinnedAction {
     #[serde(rename = "pinned")]
     Pinned,
-}
-impl ::std::convert::From<&Self> for IssuesPinnedAction {
-    fn from(value: &IssuesPinnedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesPinnedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -49327,11 +46451,6 @@ pub struct IssuesReopened {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&IssuesReopened> for IssuesReopened {
-    fn from(value: &IssuesReopened) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssuesReopenedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -49360,11 +46479,6 @@ impl ::std::convert::From<&IssuesReopened> for IssuesReopened {
 pub enum IssuesReopenedAction {
     #[serde(rename = "reopened")]
     Reopened,
-}
-impl ::std::convert::From<&Self> for IssuesReopenedAction {
-    fn from(value: &IssuesReopenedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesReopenedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -49471,11 +46585,6 @@ pub struct IssuesReopenedIssue {
     pub url: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&IssuesReopenedIssue> for IssuesReopenedIssue {
-    fn from(value: &IssuesReopenedIssue) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssuesReopenedIssueActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -49513,11 +46622,6 @@ pub enum IssuesReopenedIssueActiveLockReason {
     TooHeated,
     #[serde(rename = "spam")]
     Spam,
-}
-impl ::std::convert::From<&Self> for IssuesReopenedIssueActiveLockReason {
-    fn from(value: &IssuesReopenedIssueActiveLockReason) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesReopenedIssueActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -49604,11 +46708,6 @@ pub struct IssuesReopenedIssuePullRequest {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub url: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&IssuesReopenedIssuePullRequest> for IssuesReopenedIssuePullRequest {
-    fn from(value: &IssuesReopenedIssuePullRequest) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for IssuesReopenedIssuePullRequest {
     fn default() -> Self {
         Self {
@@ -49647,11 +46746,6 @@ impl ::std::default::Default for IssuesReopenedIssuePullRequest {
 pub enum IssuesReopenedIssueState {
     #[serde(rename = "open")]
     Open,
-}
-impl ::std::convert::From<&Self> for IssuesReopenedIssueState {
-    fn from(value: &IssuesReopenedIssueState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesReopenedIssueState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -49763,11 +46857,6 @@ pub struct IssuesTransferred {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&IssuesTransferred> for IssuesTransferred {
-    fn from(value: &IssuesTransferred) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssuesTransferredAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -49796,11 +46885,6 @@ impl ::std::convert::From<&IssuesTransferred> for IssuesTransferred {
 pub enum IssuesTransferredAction {
     #[serde(rename = "transferred")]
     Transferred,
-}
-impl ::std::convert::From<&Self> for IssuesTransferredAction {
-    fn from(value: &IssuesTransferredAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesTransferredAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -49868,11 +46952,6 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesTransferredAction 
 pub struct IssuesTransferredChanges {
     pub new_issue: Issue,
     pub new_repository: Repository,
-}
-impl ::std::convert::From<&IssuesTransferredChanges> for IssuesTransferredChanges {
-    fn from(value: &IssuesTransferredChanges) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`IssuesUnassigned`"]
 #[doc = r""]
@@ -49944,11 +47023,6 @@ pub struct IssuesUnassigned {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&IssuesUnassigned> for IssuesUnassigned {
-    fn from(value: &IssuesUnassigned) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The action that was performed."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -49978,11 +47052,6 @@ impl ::std::convert::From<&IssuesUnassigned> for IssuesUnassigned {
 pub enum IssuesUnassignedAction {
     #[serde(rename = "unassigned")]
     Unassigned,
-}
-impl ::std::convert::From<&Self> for IssuesUnassignedAction {
-    fn from(value: &IssuesUnassignedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesUnassignedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -50083,11 +47152,6 @@ pub struct IssuesUnlabeled {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&IssuesUnlabeled> for IssuesUnlabeled {
-    fn from(value: &IssuesUnlabeled) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssuesUnlabeledAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -50116,11 +47180,6 @@ impl ::std::convert::From<&IssuesUnlabeled> for IssuesUnlabeled {
 pub enum IssuesUnlabeledAction {
     #[serde(rename = "unlabeled")]
     Unlabeled,
-}
-impl ::std::convert::From<&Self> for IssuesUnlabeledAction {
-    fn from(value: &IssuesUnlabeledAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesUnlabeledAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -50237,11 +47296,6 @@ pub struct IssuesUnlocked {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&IssuesUnlocked> for IssuesUnlocked {
-    fn from(value: &IssuesUnlocked) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssuesUnlockedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -50270,11 +47324,6 @@ impl ::std::convert::From<&IssuesUnlocked> for IssuesUnlocked {
 pub enum IssuesUnlockedAction {
     #[serde(rename = "unlocked")]
     Unlocked,
-}
-impl ::std::convert::From<&Self> for IssuesUnlockedAction {
-    fn from(value: &IssuesUnlockedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesUnlockedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -50386,11 +47435,6 @@ pub struct IssuesUnlockedIssue {
     pub url: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&IssuesUnlockedIssue> for IssuesUnlockedIssue {
-    fn from(value: &IssuesUnlockedIssue) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssuesUnlockedIssueActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -50416,13 +47460,6 @@ impl ::std::ops::Deref for IssuesUnlockedIssueActiveLockReason {
 impl ::std::convert::From<IssuesUnlockedIssueActiveLockReason> for () {
     fn from(value: IssuesUnlockedIssueActiveLockReason) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&IssuesUnlockedIssueActiveLockReason>
-    for IssuesUnlockedIssueActiveLockReason
-{
-    fn from(value: &IssuesUnlockedIssueActiveLockReason) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::TryFrom<()> for IssuesUnlockedIssueActiveLockReason {
@@ -50485,11 +47522,6 @@ pub struct IssuesUnlockedIssuePullRequest {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub url: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&IssuesUnlockedIssuePullRequest> for IssuesUnlockedIssuePullRequest {
-    fn from(value: &IssuesUnlockedIssuePullRequest) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for IssuesUnlockedIssuePullRequest {
     fn default() -> Self {
         Self {
@@ -50532,11 +47564,6 @@ pub enum IssuesUnlockedIssueState {
     Open,
     #[serde(rename = "closed")]
     Closed,
-}
-impl ::std::convert::From<&Self> for IssuesUnlockedIssueState {
-    fn from(value: &IssuesUnlockedIssueState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesUnlockedIssueState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -50632,11 +47659,6 @@ pub struct IssuesUnpinned {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&IssuesUnpinned> for IssuesUnpinned {
-    fn from(value: &IssuesUnpinned) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IssuesUnpinnedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -50665,11 +47687,6 @@ impl ::std::convert::From<&IssuesUnpinned> for IssuesUnpinned {
 pub enum IssuesUnpinnedAction {
     #[serde(rename = "unpinned")]
     Unpinned,
-}
-impl ::std::convert::From<&Self> for IssuesUnpinnedAction {
-    fn from(value: &IssuesUnpinnedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IssuesUnpinnedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -50775,11 +47792,6 @@ pub struct Label {
     #[doc = "URL for the label"]
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&Label> for Label {
-    fn from(value: &Label) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`LabelCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -50836,11 +47848,6 @@ pub struct LabelCreated {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&LabelCreated> for LabelCreated {
-    fn from(value: &LabelCreated) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`LabelCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -50869,11 +47876,6 @@ impl ::std::convert::From<&LabelCreated> for LabelCreated {
 pub enum LabelCreatedAction {
     #[serde(rename = "created")]
     Created,
-}
-impl ::std::convert::From<&Self> for LabelCreatedAction {
-    fn from(value: &LabelCreatedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LabelCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -50969,11 +47971,6 @@ pub struct LabelDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&LabelDeleted> for LabelDeleted {
-    fn from(value: &LabelDeleted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`LabelDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -51002,11 +47999,6 @@ impl ::std::convert::From<&LabelDeleted> for LabelDeleted {
 pub enum LabelDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
-}
-impl ::std::convert::From<&Self> for LabelDeletedAction {
-    fn from(value: &LabelDeletedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LabelDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -51150,11 +48142,6 @@ pub struct LabelEdited {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&LabelEdited> for LabelEdited {
-    fn from(value: &LabelEdited) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`LabelEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -51183,11 +48170,6 @@ impl ::std::convert::From<&LabelEdited> for LabelEdited {
 pub enum LabelEditedAction {
     #[serde(rename = "edited")]
     Edited,
-}
-impl ::std::convert::From<&Self> for LabelEditedAction {
-    fn from(value: &LabelEditedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LabelEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -51290,11 +48272,6 @@ pub struct LabelEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<LabelEditedChangesName>,
 }
-impl ::std::convert::From<&LabelEditedChanges> for LabelEditedChanges {
-    fn from(value: &LabelEditedChanges) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for LabelEditedChanges {
     fn default() -> Self {
         Self {
@@ -51330,11 +48307,6 @@ pub struct LabelEditedChangesColor {
     #[doc = "The previous version of the color if the action was `edited`."]
     pub from: ::std::string::String,
 }
-impl ::std::convert::From<&LabelEditedChangesColor> for LabelEditedChangesColor {
-    fn from(value: &LabelEditedChangesColor) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`LabelEditedChangesDescription`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -51360,11 +48332,6 @@ impl ::std::convert::From<&LabelEditedChangesColor> for LabelEditedChangesColor 
 pub struct LabelEditedChangesDescription {
     #[doc = "The previous version of the description if the action was `edited`."]
     pub from: ::std::string::String,
-}
-impl ::std::convert::From<&LabelEditedChangesDescription> for LabelEditedChangesDescription {
-    fn from(value: &LabelEditedChangesDescription) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`LabelEditedChangesName`"]
 #[doc = r""]
@@ -51392,11 +48359,6 @@ pub struct LabelEditedChangesName {
     #[doc = "The previous version of the name if the action was `edited`."]
     pub from: ::std::string::String,
 }
-impl ::std::convert::From<&LabelEditedChangesName> for LabelEditedChangesName {
-    fn from(value: &LabelEditedChangesName) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`LabelEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -51423,11 +48385,6 @@ pub enum LabelEvent {
     Created(LabelCreated),
     Deleted(LabelDeleted),
     Edited(LabelEdited),
-}
-impl ::std::convert::From<&Self> for LabelEvent {
-    fn from(value: &LabelEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LabelCreated> for LabelEvent {
     fn from(value: LabelCreated) -> Self {
@@ -51494,11 +48451,6 @@ pub struct License {
     pub spdx_id: ::std::string::String,
     pub url: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&License> for License {
-    fn from(value: &License) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`Link`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -51525,11 +48477,6 @@ impl ::std::convert::From<&License> for License {
 #[serde(deny_unknown_fields)]
 pub struct Link {
     pub href: ::std::string::String,
-}
-impl ::std::convert::From<&Link> for Link {
-    fn from(value: &Link) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`MarketplacePurchase`"]
 #[doc = r""]
@@ -51659,11 +48606,6 @@ pub struct MarketplacePurchase {
     pub plan: MarketplacePurchasePlan,
     pub unit_count: i64,
 }
-impl ::std::convert::From<&MarketplacePurchase> for MarketplacePurchase {
-    fn from(value: &MarketplacePurchase) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MarketplacePurchaseAccount`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -51708,11 +48650,6 @@ pub struct MarketplacePurchaseAccount {
     pub organization_billing_email: ::std::string::String,
     #[serde(rename = "type")]
     pub type_: ::std::string::String,
-}
-impl ::std::convert::From<&MarketplacePurchaseAccount> for MarketplacePurchaseAccount {
-    fn from(value: &MarketplacePurchaseAccount) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`MarketplacePurchaseCancelled`"]
 #[doc = r""]
@@ -51868,11 +48805,6 @@ pub struct MarketplacePurchaseCancelled {
     pub previous_marketplace_purchase: ::std::option::Option<MarketplacePurchase>,
     pub sender: MarketplacePurchaseCancelledSender,
 }
-impl ::std::convert::From<&MarketplacePurchaseCancelled> for MarketplacePurchaseCancelled {
-    fn from(value: &MarketplacePurchaseCancelled) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MarketplacePurchaseCancelledAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -51901,11 +48833,6 @@ impl ::std::convert::From<&MarketplacePurchaseCancelled> for MarketplacePurchase
 pub enum MarketplacePurchaseCancelledAction {
     #[serde(rename = "cancelled")]
     Cancelled,
-}
-impl ::std::convert::From<&Self> for MarketplacePurchaseCancelledAction {
-    fn from(value: &MarketplacePurchaseCancelledAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for MarketplacePurchaseCancelledAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -51982,13 +48909,6 @@ pub struct MarketplacePurchaseCancelledMarketplacePurchase {
     pub plan: MarketplacePurchaseCancelledMarketplacePurchasePlan,
     pub unit_count: i64,
 }
-impl ::std::convert::From<&MarketplacePurchaseCancelledMarketplacePurchase>
-    for MarketplacePurchaseCancelledMarketplacePurchase
-{
-    fn from(value: &MarketplacePurchaseCancelledMarketplacePurchase) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MarketplacePurchaseCancelledMarketplacePurchaseAccount`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -52033,13 +48953,6 @@ pub struct MarketplacePurchaseCancelledMarketplacePurchaseAccount {
     pub organization_billing_email: ::std::string::String,
     #[serde(rename = "type")]
     pub type_: ::std::string::String,
-}
-impl ::std::convert::From<&MarketplacePurchaseCancelledMarketplacePurchaseAccount>
-    for MarketplacePurchaseCancelledMarketplacePurchaseAccount
-{
-    fn from(value: &MarketplacePurchaseCancelledMarketplacePurchaseAccount) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`MarketplacePurchaseCancelledMarketplacePurchasePlan`"]
 #[doc = r""]
@@ -52110,13 +49023,6 @@ pub struct MarketplacePurchaseCancelledMarketplacePurchasePlan {
     pub price_model: ::std::string::String,
     pub unit_name: ::std::option::Option<::std::string::String>,
     pub yearly_price_in_cents: i64,
-}
-impl ::std::convert::From<&MarketplacePurchaseCancelledMarketplacePurchasePlan>
-    for MarketplacePurchaseCancelledMarketplacePurchasePlan
-{
-    fn from(value: &MarketplacePurchaseCancelledMarketplacePurchasePlan) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`MarketplacePurchaseCancelledSender`"]
 #[doc = r""]
@@ -52239,13 +49145,6 @@ pub struct MarketplacePurchaseCancelledSender {
     #[serde(rename = "type")]
     pub type_: ::std::string::String,
     pub url: ::std::string::String,
-}
-impl ::std::convert::From<&MarketplacePurchaseCancelledSender>
-    for MarketplacePurchaseCancelledSender
-{
-    fn from(value: &MarketplacePurchaseCancelledSender) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`MarketplacePurchaseChanged`"]
 #[doc = r""]
@@ -52401,11 +49300,6 @@ pub struct MarketplacePurchaseChanged {
     pub previous_marketplace_purchase: ::std::option::Option<MarketplacePurchase>,
     pub sender: MarketplacePurchaseChangedSender,
 }
-impl ::std::convert::From<&MarketplacePurchaseChanged> for MarketplacePurchaseChanged {
-    fn from(value: &MarketplacePurchaseChanged) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MarketplacePurchaseChangedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -52434,11 +49328,6 @@ impl ::std::convert::From<&MarketplacePurchaseChanged> for MarketplacePurchaseCh
 pub enum MarketplacePurchaseChangedAction {
     #[serde(rename = "changed")]
     Changed,
-}
-impl ::std::convert::From<&Self> for MarketplacePurchaseChangedAction {
-    fn from(value: &MarketplacePurchaseChangedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for MarketplacePurchaseChangedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -52515,13 +49404,6 @@ pub struct MarketplacePurchaseChangedMarketplacePurchase {
     pub plan: MarketplacePurchaseChangedMarketplacePurchasePlan,
     pub unit_count: i64,
 }
-impl ::std::convert::From<&MarketplacePurchaseChangedMarketplacePurchase>
-    for MarketplacePurchaseChangedMarketplacePurchase
-{
-    fn from(value: &MarketplacePurchaseChangedMarketplacePurchase) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MarketplacePurchaseChangedMarketplacePurchaseAccount`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -52566,13 +49448,6 @@ pub struct MarketplacePurchaseChangedMarketplacePurchaseAccount {
     pub organization_billing_email: ::std::string::String,
     #[serde(rename = "type")]
     pub type_: ::std::string::String,
-}
-impl ::std::convert::From<&MarketplacePurchaseChangedMarketplacePurchaseAccount>
-    for MarketplacePurchaseChangedMarketplacePurchaseAccount
-{
-    fn from(value: &MarketplacePurchaseChangedMarketplacePurchaseAccount) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`MarketplacePurchaseChangedMarketplacePurchasePlan`"]
 #[doc = r""]
@@ -52643,13 +49518,6 @@ pub struct MarketplacePurchaseChangedMarketplacePurchasePlan {
     pub price_model: ::std::string::String,
     pub unit_name: ::std::option::Option<::std::string::String>,
     pub yearly_price_in_cents: i64,
-}
-impl ::std::convert::From<&MarketplacePurchaseChangedMarketplacePurchasePlan>
-    for MarketplacePurchaseChangedMarketplacePurchasePlan
-{
-    fn from(value: &MarketplacePurchaseChangedMarketplacePurchasePlan) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`MarketplacePurchaseChangedSender`"]
 #[doc = r""]
@@ -52773,11 +49641,6 @@ pub struct MarketplacePurchaseChangedSender {
     pub type_: ::std::string::String,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&MarketplacePurchaseChangedSender> for MarketplacePurchaseChangedSender {
-    fn from(value: &MarketplacePurchaseChangedSender) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MarketplacePurchaseEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -52812,11 +49675,6 @@ pub enum MarketplacePurchaseEvent {
     PendingChange(MarketplacePurchasePendingChange),
     PendingChangeCancelled(MarketplacePurchasePendingChangeCancelled),
     Purchased(MarketplacePurchasePurchased),
-}
-impl ::std::convert::From<&Self> for MarketplacePurchaseEvent {
-    fn from(value: &MarketplacePurchaseEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<MarketplacePurchaseCancelled> for MarketplacePurchaseEvent {
     fn from(value: MarketplacePurchaseCancelled) -> Self {
@@ -52997,11 +49855,6 @@ pub struct MarketplacePurchasePendingChange {
     pub previous_marketplace_purchase: ::std::option::Option<MarketplacePurchase>,
     pub sender: MarketplacePurchasePendingChangeSender,
 }
-impl ::std::convert::From<&MarketplacePurchasePendingChange> for MarketplacePurchasePendingChange {
-    fn from(value: &MarketplacePurchasePendingChange) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MarketplacePurchasePendingChangeAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -53030,11 +49883,6 @@ impl ::std::convert::From<&MarketplacePurchasePendingChange> for MarketplacePurc
 pub enum MarketplacePurchasePendingChangeAction {
     #[serde(rename = "pending_change")]
     PendingChange,
-}
-impl ::std::convert::From<&Self> for MarketplacePurchasePendingChangeAction {
-    fn from(value: &MarketplacePurchasePendingChangeAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for MarketplacePurchasePendingChangeAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -53228,13 +50076,6 @@ pub struct MarketplacePurchasePendingChangeCancelled {
     pub previous_marketplace_purchase: ::std::option::Option<MarketplacePurchase>,
     pub sender: MarketplacePurchasePendingChangeCancelledSender,
 }
-impl ::std::convert::From<&MarketplacePurchasePendingChangeCancelled>
-    for MarketplacePurchasePendingChangeCancelled
-{
-    fn from(value: &MarketplacePurchasePendingChangeCancelled) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MarketplacePurchasePendingChangeCancelledAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -53263,11 +50104,6 @@ impl ::std::convert::From<&MarketplacePurchasePendingChangeCancelled>
 pub enum MarketplacePurchasePendingChangeCancelledAction {
     #[serde(rename = "pending_change_cancelled")]
     PendingChangeCancelled,
-}
-impl ::std::convert::From<&Self> for MarketplacePurchasePendingChangeCancelledAction {
-    fn from(value: &MarketplacePurchasePendingChangeCancelledAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for MarketplacePurchasePendingChangeCancelledAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -53348,13 +50184,6 @@ pub struct MarketplacePurchasePendingChangeCancelledMarketplacePurchase {
     pub plan: MarketplacePurchasePendingChangeCancelledMarketplacePurchasePlan,
     pub unit_count: i64,
 }
-impl ::std::convert::From<&MarketplacePurchasePendingChangeCancelledMarketplacePurchase>
-    for MarketplacePurchasePendingChangeCancelledMarketplacePurchase
-{
-    fn from(value: &MarketplacePurchasePendingChangeCancelledMarketplacePurchase) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MarketplacePurchasePendingChangeCancelledMarketplacePurchaseAccount`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -53399,13 +50228,6 @@ pub struct MarketplacePurchasePendingChangeCancelledMarketplacePurchaseAccount {
     pub organization_billing_email: ::std::string::String,
     #[serde(rename = "type")]
     pub type_: ::std::string::String,
-}
-impl ::std::convert::From<&MarketplacePurchasePendingChangeCancelledMarketplacePurchaseAccount>
-    for MarketplacePurchasePendingChangeCancelledMarketplacePurchaseAccount
-{
-    fn from(value: &MarketplacePurchasePendingChangeCancelledMarketplacePurchaseAccount) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`MarketplacePurchasePendingChangeCancelledMarketplacePurchasePlan`"]
 #[doc = r""]
@@ -53476,13 +50298,6 @@ pub struct MarketplacePurchasePendingChangeCancelledMarketplacePurchasePlan {
     pub price_model: ::std::string::String,
     pub unit_name: ::std::option::Option<::std::string::String>,
     pub yearly_price_in_cents: i64,
-}
-impl ::std::convert::From<&MarketplacePurchasePendingChangeCancelledMarketplacePurchasePlan>
-    for MarketplacePurchasePendingChangeCancelledMarketplacePurchasePlan
-{
-    fn from(value: &MarketplacePurchasePendingChangeCancelledMarketplacePurchasePlan) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`MarketplacePurchasePendingChangeCancelledSender`"]
 #[doc = r""]
@@ -53606,13 +50421,6 @@ pub struct MarketplacePurchasePendingChangeCancelledSender {
     pub type_: ::std::string::String,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&MarketplacePurchasePendingChangeCancelledSender>
-    for MarketplacePurchasePendingChangeCancelledSender
-{
-    fn from(value: &MarketplacePurchasePendingChangeCancelledSender) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MarketplacePurchasePendingChangeMarketplacePurchase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -53649,13 +50457,6 @@ pub struct MarketplacePurchasePendingChangeMarketplacePurchase {
     pub on_free_trial: bool,
     pub plan: MarketplacePurchasePendingChangeMarketplacePurchasePlan,
     pub unit_count: i64,
-}
-impl ::std::convert::From<&MarketplacePurchasePendingChangeMarketplacePurchase>
-    for MarketplacePurchasePendingChangeMarketplacePurchase
-{
-    fn from(value: &MarketplacePurchasePendingChangeMarketplacePurchase) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`MarketplacePurchasePendingChangeMarketplacePurchaseAccount`"]
 #[doc = r""]
@@ -53701,13 +50502,6 @@ pub struct MarketplacePurchasePendingChangeMarketplacePurchaseAccount {
     pub organization_billing_email: ::std::string::String,
     #[serde(rename = "type")]
     pub type_: ::std::string::String,
-}
-impl ::std::convert::From<&MarketplacePurchasePendingChangeMarketplacePurchaseAccount>
-    for MarketplacePurchasePendingChangeMarketplacePurchaseAccount
-{
-    fn from(value: &MarketplacePurchasePendingChangeMarketplacePurchaseAccount) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`MarketplacePurchasePendingChangeMarketplacePurchasePlan`"]
 #[doc = r""]
@@ -53778,13 +50572,6 @@ pub struct MarketplacePurchasePendingChangeMarketplacePurchasePlan {
     pub price_model: ::std::string::String,
     pub unit_name: ::std::option::Option<::std::string::String>,
     pub yearly_price_in_cents: i64,
-}
-impl ::std::convert::From<&MarketplacePurchasePendingChangeMarketplacePurchasePlan>
-    for MarketplacePurchasePendingChangeMarketplacePurchasePlan
-{
-    fn from(value: &MarketplacePurchasePendingChangeMarketplacePurchasePlan) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`MarketplacePurchasePendingChangeSender`"]
 #[doc = r""]
@@ -53908,13 +50695,6 @@ pub struct MarketplacePurchasePendingChangeSender {
     pub type_: ::std::string::String,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&MarketplacePurchasePendingChangeSender>
-    for MarketplacePurchasePendingChangeSender
-{
-    fn from(value: &MarketplacePurchasePendingChangeSender) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MarketplacePurchasePlan`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -53984,11 +50764,6 @@ pub struct MarketplacePurchasePlan {
     pub price_model: ::std::string::String,
     pub unit_name: ::std::option::Option<::std::string::String>,
     pub yearly_price_in_cents: i64,
-}
-impl ::std::convert::From<&MarketplacePurchasePlan> for MarketplacePurchasePlan {
-    fn from(value: &MarketplacePurchasePlan) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`MarketplacePurchasePurchased`"]
 #[doc = r""]
@@ -54144,11 +50919,6 @@ pub struct MarketplacePurchasePurchased {
     pub previous_marketplace_purchase: ::std::option::Option<MarketplacePurchase>,
     pub sender: MarketplacePurchasePurchasedSender,
 }
-impl ::std::convert::From<&MarketplacePurchasePurchased> for MarketplacePurchasePurchased {
-    fn from(value: &MarketplacePurchasePurchased) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MarketplacePurchasePurchasedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -54177,11 +50947,6 @@ impl ::std::convert::From<&MarketplacePurchasePurchased> for MarketplacePurchase
 pub enum MarketplacePurchasePurchasedAction {
     #[serde(rename = "purchased")]
     Purchased,
-}
-impl ::std::convert::From<&Self> for MarketplacePurchasePurchasedAction {
-    fn from(value: &MarketplacePurchasePurchasedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for MarketplacePurchasePurchasedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -54258,13 +51023,6 @@ pub struct MarketplacePurchasePurchasedMarketplacePurchase {
     pub plan: MarketplacePurchasePurchasedMarketplacePurchasePlan,
     pub unit_count: i64,
 }
-impl ::std::convert::From<&MarketplacePurchasePurchasedMarketplacePurchase>
-    for MarketplacePurchasePurchasedMarketplacePurchase
-{
-    fn from(value: &MarketplacePurchasePurchasedMarketplacePurchase) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MarketplacePurchasePurchasedMarketplacePurchaseAccount`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -54309,13 +51067,6 @@ pub struct MarketplacePurchasePurchasedMarketplacePurchaseAccount {
     pub organization_billing_email: ::std::string::String,
     #[serde(rename = "type")]
     pub type_: ::std::string::String,
-}
-impl ::std::convert::From<&MarketplacePurchasePurchasedMarketplacePurchaseAccount>
-    for MarketplacePurchasePurchasedMarketplacePurchaseAccount
-{
-    fn from(value: &MarketplacePurchasePurchasedMarketplacePurchaseAccount) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`MarketplacePurchasePurchasedMarketplacePurchasePlan`"]
 #[doc = r""]
@@ -54386,13 +51137,6 @@ pub struct MarketplacePurchasePurchasedMarketplacePurchasePlan {
     pub price_model: ::std::string::String,
     pub unit_name: ::std::option::Option<::std::string::String>,
     pub yearly_price_in_cents: i64,
-}
-impl ::std::convert::From<&MarketplacePurchasePurchasedMarketplacePurchasePlan>
-    for MarketplacePurchasePurchasedMarketplacePurchasePlan
-{
-    fn from(value: &MarketplacePurchasePurchasedMarketplacePurchasePlan) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`MarketplacePurchasePurchasedSender`"]
 #[doc = r""]
@@ -54516,13 +51260,6 @@ pub struct MarketplacePurchasePurchasedSender {
     pub type_: ::std::string::String,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&MarketplacePurchasePurchasedSender>
-    for MarketplacePurchasePurchasedSender
-{
-    fn from(value: &MarketplacePurchasePurchasedSender) -> Self {
-        value.clone()
-    }
-}
 #[doc = "Activity related to repository collaborators. The type of activity is specified in the action property."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -54599,11 +51336,6 @@ pub struct MemberAdded {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&MemberAdded> for MemberAdded {
-    fn from(value: &MemberAdded) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MemberAddedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -54632,11 +51364,6 @@ impl ::std::convert::From<&MemberAdded> for MemberAdded {
 pub enum MemberAddedAction {
     #[serde(rename = "added")]
     Added,
-}
-impl ::std::convert::From<&Self> for MemberAddedAction {
-    fn from(value: &MemberAddedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for MemberAddedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -54711,11 +51438,6 @@ pub struct MemberAddedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub permission: ::std::option::Option<MemberAddedChangesPermission>,
 }
-impl ::std::convert::From<&MemberAddedChanges> for MemberAddedChanges {
-    fn from(value: &MemberAddedChanges) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for MemberAddedChanges {
     fn default() -> Self {
         Self {
@@ -54751,11 +51473,6 @@ impl ::std::default::Default for MemberAddedChanges {
 pub struct MemberAddedChangesPermission {
     pub to: MemberAddedChangesPermissionTo,
 }
-impl ::std::convert::From<&MemberAddedChangesPermission> for MemberAddedChangesPermission {
-    fn from(value: &MemberAddedChangesPermission) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MemberAddedChangesPermissionTo`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -54787,11 +51504,6 @@ pub enum MemberAddedChangesPermissionTo {
     Write,
     #[serde(rename = "admin")]
     Admin,
-}
-impl ::std::convert::From<&Self> for MemberAddedChangesPermissionTo {
-    fn from(value: &MemberAddedChangesPermissionTo) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for MemberAddedChangesPermissionTo {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -54909,11 +51621,6 @@ pub struct MemberEdited {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&MemberEdited> for MemberEdited {
-    fn from(value: &MemberEdited) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MemberEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -54942,11 +51649,6 @@ impl ::std::convert::From<&MemberEdited> for MemberEdited {
 pub enum MemberEditedAction {
     #[serde(rename = "edited")]
     Edited,
-}
-impl ::std::convert::From<&Self> for MemberEditedAction {
-    fn from(value: &MemberEditedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for MemberEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -55021,11 +51723,6 @@ impl ::std::convert::TryFrom<::std::string::String> for MemberEditedAction {
 pub struct MemberEditedChanges {
     pub old_permission: MemberEditedChangesOldPermission,
 }
-impl ::std::convert::From<&MemberEditedChanges> for MemberEditedChanges {
-    fn from(value: &MemberEditedChanges) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MemberEditedChangesOldPermission`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -55051,11 +51748,6 @@ impl ::std::convert::From<&MemberEditedChanges> for MemberEditedChanges {
 pub struct MemberEditedChangesOldPermission {
     #[doc = "The previous permissions of the collaborator if the action was edited."]
     pub from: ::std::string::String,
-}
-impl ::std::convert::From<&MemberEditedChangesOldPermission> for MemberEditedChangesOldPermission {
-    fn from(value: &MemberEditedChangesOldPermission) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`MemberEvent`"]
 #[doc = r""]
@@ -55083,11 +51775,6 @@ pub enum MemberEvent {
     Added(MemberAdded),
     Edited(MemberEdited),
     Removed(MemberRemoved),
-}
-impl ::std::convert::From<&Self> for MemberEvent {
-    fn from(value: &MemberEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<MemberAdded> for MemberEvent {
     fn from(value: MemberAdded) -> Self {
@@ -55155,11 +51842,6 @@ pub struct MemberRemoved {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&MemberRemoved> for MemberRemoved {
-    fn from(value: &MemberRemoved) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MemberRemovedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -55188,11 +51870,6 @@ impl ::std::convert::From<&MemberRemoved> for MemberRemoved {
 pub enum MemberRemovedAction {
     #[serde(rename = "removed")]
     Removed,
-}
-impl ::std::convert::From<&Self> for MemberRemovedAction {
-    fn from(value: &MemberRemovedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for MemberRemovedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -55281,11 +51958,6 @@ pub struct Membership {
     pub url: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&Membership> for Membership {
-    fn from(value: &Membership) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MembershipAdded`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -55354,11 +52026,6 @@ pub struct MembershipAdded {
     #[doc = "The [team](https://docs.github.com/en/rest/reference/teams) for the membership."]
     pub team: Team,
 }
-impl ::std::convert::From<&MembershipAdded> for MembershipAdded {
-    fn from(value: &MembershipAdded) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MembershipAddedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -55387,11 +52054,6 @@ impl ::std::convert::From<&MembershipAdded> for MembershipAdded {
 pub enum MembershipAddedAction {
     #[serde(rename = "added")]
     Added,
-}
-impl ::std::convert::From<&Self> for MembershipAddedAction {
-    fn from(value: &MembershipAddedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for MembershipAddedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -55461,11 +52123,6 @@ pub enum MembershipAddedScope {
     #[serde(rename = "team")]
     Team,
 }
-impl ::std::convert::From<&Self> for MembershipAddedScope {
-    fn from(value: &MembershipAddedScope) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for MembershipAddedScope {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -55526,11 +52183,6 @@ impl ::std::convert::TryFrom<::std::string::String> for MembershipAddedScope {
 pub enum MembershipEvent {
     Added(MembershipAdded),
     Removed(MembershipRemoved),
-}
-impl ::std::convert::From<&Self> for MembershipEvent {
-    fn from(value: &MembershipEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<MembershipAdded> for MembershipEvent {
     fn from(value: MembershipAdded) -> Self {
@@ -55634,11 +52286,6 @@ pub struct MembershipRemoved {
     #[doc = "The [team](https://docs.github.com/en/rest/reference/teams) for the membership."]
     pub team: MembershipRemovedTeam,
 }
-impl ::std::convert::From<&MembershipRemoved> for MembershipRemoved {
-    fn from(value: &MembershipRemoved) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MembershipRemovedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -55667,11 +52314,6 @@ impl ::std::convert::From<&MembershipRemoved> for MembershipRemoved {
 pub enum MembershipRemovedAction {
     #[serde(rename = "removed")]
     Removed,
-}
-impl ::std::convert::From<&Self> for MembershipRemovedAction {
-    fn from(value: &MembershipRemovedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for MembershipRemovedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -55743,11 +52385,6 @@ pub enum MembershipRemovedScope {
     Team,
     #[serde(rename = "organization")]
     Organization,
-}
-impl ::std::convert::From<&Self> for MembershipRemovedScope {
-    fn from(value: &MembershipRemovedScope) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for MembershipRemovedScope {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -55833,11 +52470,6 @@ pub enum MembershipRemovedTeam {
         id: i64,
         name: ::std::string::String,
     },
-}
-impl ::std::convert::From<&Self> for MembershipRemovedTeam {
-    fn from(value: &MembershipRemovedTeam) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<Team> for MembershipRemovedTeam {
     fn from(value: Team) -> Self {
@@ -55955,11 +52587,6 @@ pub struct MetaDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&MetaDeleted> for MetaDeleted {
-    fn from(value: &MetaDeleted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MetaDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -55988,11 +52615,6 @@ impl ::std::convert::From<&MetaDeleted> for MetaDeleted {
 pub enum MetaDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
-}
-impl ::std::convert::From<&Self> for MetaDeletedAction {
-    fn from(value: &MetaDeletedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for MetaDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -56115,11 +52737,6 @@ pub struct MetaDeletedHook {
     pub type_: ::std::string::String,
     pub updated_at: ::std::string::String,
 }
-impl ::std::convert::From<&MetaDeletedHook> for MetaDeletedHook {
-    fn from(value: &MetaDeletedHook) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MetaDeletedHookConfig`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -56159,11 +52776,6 @@ pub struct MetaDeletedHookConfig {
     pub insecure_ssl: ::std::string::String,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&MetaDeletedHookConfig> for MetaDeletedHookConfig {
-    fn from(value: &MetaDeletedHookConfig) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MetaDeletedHookConfigContentType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -56195,11 +52807,6 @@ pub enum MetaDeletedHookConfigContentType {
     Json,
     #[serde(rename = "form")]
     Form,
-}
-impl ::std::convert::From<&Self> for MetaDeletedHookConfigContentType {
-    fn from(value: &MetaDeletedHookConfigContentType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for MetaDeletedHookConfigContentType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -56267,11 +52874,6 @@ impl ::std::ops::Deref for MetaEvent {
 impl ::std::convert::From<MetaEvent> for MetaDeleted {
     fn from(value: MetaEvent) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&MetaEvent> for MetaEvent {
-    fn from(value: &MetaEvent) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<MetaDeleted> for MetaEvent {
@@ -56407,11 +53009,6 @@ pub struct Milestone {
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&Milestone> for Milestone {
-    fn from(value: &Milestone) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MilestoneClosed`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -56489,11 +53086,6 @@ pub struct MilestoneClosed {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&MilestoneClosed> for MilestoneClosed {
-    fn from(value: &MilestoneClosed) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MilestoneClosedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -56522,11 +53114,6 @@ impl ::std::convert::From<&MilestoneClosed> for MilestoneClosed {
 pub enum MilestoneClosedAction {
     #[serde(rename = "closed")]
     Closed,
-}
-impl ::std::convert::From<&Self> for MilestoneClosedAction {
-    fn from(value: &MilestoneClosedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for MilestoneClosedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -56621,11 +53208,6 @@ pub struct MilestoneClosedMilestone {
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&MilestoneClosedMilestone> for MilestoneClosedMilestone {
-    fn from(value: &MilestoneClosedMilestone) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MilestoneClosedMilestoneState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -56654,11 +53236,6 @@ impl ::std::convert::From<&MilestoneClosedMilestone> for MilestoneClosedMileston
 pub enum MilestoneClosedMilestoneState {
     #[serde(rename = "closed")]
     Closed,
-}
-impl ::std::convert::From<&Self> for MilestoneClosedMilestoneState {
-    fn from(value: &MilestoneClosedMilestoneState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for MilestoneClosedMilestoneState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -56775,11 +53352,6 @@ pub struct MilestoneCreated {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&MilestoneCreated> for MilestoneCreated {
-    fn from(value: &MilestoneCreated) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MilestoneCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -56808,11 +53380,6 @@ impl ::std::convert::From<&MilestoneCreated> for MilestoneCreated {
 pub enum MilestoneCreatedAction {
     #[serde(rename = "created")]
     Created,
-}
-impl ::std::convert::From<&Self> for MilestoneCreatedAction {
-    fn from(value: &MilestoneCreatedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for MilestoneCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -56907,11 +53474,6 @@ pub struct MilestoneCreatedMilestone {
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&MilestoneCreatedMilestone> for MilestoneCreatedMilestone {
-    fn from(value: &MilestoneCreatedMilestone) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MilestoneCreatedMilestoneState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -56940,11 +53502,6 @@ impl ::std::convert::From<&MilestoneCreatedMilestone> for MilestoneCreatedMilest
 pub enum MilestoneCreatedMilestoneState {
     #[serde(rename = "open")]
     Open,
-}
-impl ::std::convert::From<&Self> for MilestoneCreatedMilestoneState {
-    fn from(value: &MilestoneCreatedMilestoneState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for MilestoneCreatedMilestoneState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -57038,11 +53595,6 @@ pub struct MilestoneDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&MilestoneDeleted> for MilestoneDeleted {
-    fn from(value: &MilestoneDeleted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MilestoneDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -57071,11 +53623,6 @@ impl ::std::convert::From<&MilestoneDeleted> for MilestoneDeleted {
 pub enum MilestoneDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
-}
-impl ::std::convert::From<&Self> for MilestoneDeletedAction {
-    fn from(value: &MilestoneDeletedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for MilestoneDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -57217,11 +53764,6 @@ pub struct MilestoneEdited {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&MilestoneEdited> for MilestoneEdited {
-    fn from(value: &MilestoneEdited) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MilestoneEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -57250,11 +53792,6 @@ impl ::std::convert::From<&MilestoneEdited> for MilestoneEdited {
 pub enum MilestoneEditedAction {
     #[serde(rename = "edited")]
     Edited,
-}
-impl ::std::convert::From<&Self> for MilestoneEditedAction {
-    fn from(value: &MilestoneEditedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for MilestoneEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -57357,11 +53894,6 @@ pub struct MilestoneEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<MilestoneEditedChangesTitle>,
 }
-impl ::std::convert::From<&MilestoneEditedChanges> for MilestoneEditedChanges {
-    fn from(value: &MilestoneEditedChanges) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for MilestoneEditedChanges {
     fn default() -> Self {
         Self {
@@ -57397,13 +53929,6 @@ pub struct MilestoneEditedChangesDescription {
     #[doc = "The previous version of the description if the action was `edited`."]
     pub from: ::std::string::String,
 }
-impl ::std::convert::From<&MilestoneEditedChangesDescription>
-    for MilestoneEditedChangesDescription
-{
-    fn from(value: &MilestoneEditedChangesDescription) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MilestoneEditedChangesDueOn`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -57430,11 +53955,6 @@ pub struct MilestoneEditedChangesDueOn {
     #[doc = "The previous version of the due date if the action was `edited`."]
     pub from: ::std::string::String,
 }
-impl ::std::convert::From<&MilestoneEditedChangesDueOn> for MilestoneEditedChangesDueOn {
-    fn from(value: &MilestoneEditedChangesDueOn) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MilestoneEditedChangesTitle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -57460,11 +53980,6 @@ impl ::std::convert::From<&MilestoneEditedChangesDueOn> for MilestoneEditedChang
 pub struct MilestoneEditedChangesTitle {
     #[doc = "The previous version of the title if the action was `edited`."]
     pub from: ::std::string::String,
-}
-impl ::std::convert::From<&MilestoneEditedChangesTitle> for MilestoneEditedChangesTitle {
-    fn from(value: &MilestoneEditedChangesTitle) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`MilestoneEvent`"]
 #[doc = r""]
@@ -57500,11 +54015,6 @@ pub enum MilestoneEvent {
     Deleted(MilestoneDeleted),
     Edited(MilestoneEdited),
     Opened(MilestoneOpened),
-}
-impl ::std::convert::From<&Self> for MilestoneEvent {
-    fn from(value: &MilestoneEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<MilestoneClosed> for MilestoneEvent {
     fn from(value: MilestoneClosed) -> Self {
@@ -57608,11 +54118,6 @@ pub struct MilestoneOpened {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&MilestoneOpened> for MilestoneOpened {
-    fn from(value: &MilestoneOpened) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MilestoneOpenedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -57641,11 +54146,6 @@ impl ::std::convert::From<&MilestoneOpened> for MilestoneOpened {
 pub enum MilestoneOpenedAction {
     #[serde(rename = "opened")]
     Opened,
-}
-impl ::std::convert::From<&Self> for MilestoneOpenedAction {
-    fn from(value: &MilestoneOpenedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for MilestoneOpenedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -57740,11 +54240,6 @@ pub struct MilestoneOpenedMilestone {
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&MilestoneOpenedMilestone> for MilestoneOpenedMilestone {
-    fn from(value: &MilestoneOpenedMilestone) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MilestoneOpenedMilestoneState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -57773,11 +54268,6 @@ impl ::std::convert::From<&MilestoneOpenedMilestone> for MilestoneOpenedMileston
 pub enum MilestoneOpenedMilestoneState {
     #[serde(rename = "open")]
     Open,
-}
-impl ::std::convert::From<&Self> for MilestoneOpenedMilestoneState {
-    fn from(value: &MilestoneOpenedMilestoneState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for MilestoneOpenedMilestoneState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -57849,11 +54339,6 @@ pub enum MilestoneState {
     Open,
     #[serde(rename = "closed")]
     Closed,
-}
-impl ::std::convert::From<&Self> for MilestoneState {
-    fn from(value: &MilestoneState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for MilestoneState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -57946,11 +54431,6 @@ pub struct OrgBlockBlocked {
     pub organization: Organization,
     pub sender: User,
 }
-impl ::std::convert::From<&OrgBlockBlocked> for OrgBlockBlocked {
-    fn from(value: &OrgBlockBlocked) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`OrgBlockBlockedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -57979,11 +54459,6 @@ impl ::std::convert::From<&OrgBlockBlocked> for OrgBlockBlocked {
 pub enum OrgBlockBlockedAction {
     #[serde(rename = "blocked")]
     Blocked,
-}
-impl ::std::convert::From<&Self> for OrgBlockBlockedAction {
-    fn from(value: &OrgBlockBlockedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for OrgBlockBlockedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -58046,11 +54521,6 @@ pub enum OrgBlockEvent {
     Blocked(OrgBlockBlocked),
     Unblocked(OrgBlockUnblocked),
 }
-impl ::std::convert::From<&Self> for OrgBlockEvent {
-    fn from(value: &OrgBlockEvent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<OrgBlockBlocked> for OrgBlockEvent {
     fn from(value: OrgBlockBlocked) -> Self {
         Self::Blocked(value)
@@ -58112,11 +54582,6 @@ pub struct OrgBlockUnblocked {
     pub organization: Organization,
     pub sender: User,
 }
-impl ::std::convert::From<&OrgBlockUnblocked> for OrgBlockUnblocked {
-    fn from(value: &OrgBlockUnblocked) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`OrgBlockUnblockedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -58145,11 +54610,6 @@ impl ::std::convert::From<&OrgBlockUnblocked> for OrgBlockUnblocked {
 pub enum OrgBlockUnblockedAction {
     #[serde(rename = "unblocked")]
     Unblocked,
-}
-impl ::std::convert::From<&Self> for OrgBlockUnblockedAction {
-    fn from(value: &OrgBlockUnblockedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for OrgBlockUnblockedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -58287,11 +54747,6 @@ pub struct Organization {
     pub repos_url: ::std::string::String,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&Organization> for Organization {
-    fn from(value: &Organization) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`OrganizationDeleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -58341,11 +54796,6 @@ pub struct OrganizationDeleted {
     pub organization: Organization,
     pub sender: User,
 }
-impl ::std::convert::From<&OrganizationDeleted> for OrganizationDeleted {
-    fn from(value: &OrganizationDeleted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`OrganizationDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -58374,11 +54824,6 @@ impl ::std::convert::From<&OrganizationDeleted> for OrganizationDeleted {
 pub enum OrganizationDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
-}
-impl ::std::convert::From<&Self> for OrganizationDeletedAction {
-    fn from(value: &OrganizationDeletedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for OrganizationDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -58452,11 +54897,6 @@ pub enum OrganizationEvent {
     MemberInvited(OrganizationMemberInvited),
     MemberRemoved(OrganizationMemberRemoved),
     Renamed(OrganizationRenamed),
-}
-impl ::std::convert::From<&Self> for OrganizationEvent {
-    fn from(value: &OrganizationEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<OrganizationDeleted> for OrganizationEvent {
     fn from(value: OrganizationDeleted) -> Self {
@@ -58532,11 +54972,6 @@ pub struct OrganizationMemberAdded {
     pub organization: Organization,
     pub sender: User,
 }
-impl ::std::convert::From<&OrganizationMemberAdded> for OrganizationMemberAdded {
-    fn from(value: &OrganizationMemberAdded) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`OrganizationMemberAddedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -58565,11 +55000,6 @@ impl ::std::convert::From<&OrganizationMemberAdded> for OrganizationMemberAdded 
 pub enum OrganizationMemberAddedAction {
     #[serde(rename = "member_added")]
     MemberAdded,
-}
-impl ::std::convert::From<&Self> for OrganizationMemberAddedAction {
-    fn from(value: &OrganizationMemberAddedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for OrganizationMemberAddedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -58729,11 +55159,6 @@ pub struct OrganizationMemberInvited {
     pub sender: User,
     pub user: User,
 }
-impl ::std::convert::From<&OrganizationMemberInvited> for OrganizationMemberInvited {
-    fn from(value: &OrganizationMemberInvited) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`OrganizationMemberInvitedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -58762,11 +55187,6 @@ impl ::std::convert::From<&OrganizationMemberInvited> for OrganizationMemberInvi
 pub enum OrganizationMemberInvitedAction {
     #[serde(rename = "member_invited")]
     MemberInvited,
-}
-impl ::std::convert::From<&Self> for OrganizationMemberInvitedAction {
-    fn from(value: &OrganizationMemberInvitedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for OrganizationMemberInvitedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -58897,13 +55317,6 @@ pub struct OrganizationMemberInvitedInvitation {
     pub role: ::std::string::String,
     pub team_count: f64,
 }
-impl ::std::convert::From<&OrganizationMemberInvitedInvitation>
-    for OrganizationMemberInvitedInvitation
-{
-    fn from(value: &OrganizationMemberInvitedInvitation) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`OrganizationMemberRemoved`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -58953,11 +55366,6 @@ pub struct OrganizationMemberRemoved {
     pub organization: Organization,
     pub sender: User,
 }
-impl ::std::convert::From<&OrganizationMemberRemoved> for OrganizationMemberRemoved {
-    fn from(value: &OrganizationMemberRemoved) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`OrganizationMemberRemovedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -58986,11 +55394,6 @@ impl ::std::convert::From<&OrganizationMemberRemoved> for OrganizationMemberRemo
 pub enum OrganizationMemberRemovedAction {
     #[serde(rename = "member_removed")]
     MemberRemoved,
-}
-impl ::std::convert::From<&Self> for OrganizationMemberRemovedAction {
-    fn from(value: &OrganizationMemberRemovedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for OrganizationMemberRemovedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -59079,11 +55482,6 @@ pub struct OrganizationRenamed {
     pub organization: Organization,
     pub sender: User,
 }
-impl ::std::convert::From<&OrganizationRenamed> for OrganizationRenamed {
-    fn from(value: &OrganizationRenamed) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`OrganizationRenamedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -59112,11 +55510,6 @@ impl ::std::convert::From<&OrganizationRenamed> for OrganizationRenamed {
 pub enum OrganizationRenamedAction {
     #[serde(rename = "renamed")]
     Renamed,
-}
-impl ::std::convert::From<&Self> for OrganizationRenamedAction {
-    fn from(value: &OrganizationRenamedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for OrganizationRenamedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -59178,11 +55571,6 @@ impl ::std::convert::TryFrom<::std::string::String> for OrganizationRenamedActio
 pub enum PackageEvent {
     Published(PackagePublished),
     Updated(PackageUpdated),
-}
-impl ::std::convert::From<&Self> for PackageEvent {
-    fn from(value: &PackageEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<PackagePublished> for PackageEvent {
     fn from(value: PackagePublished) -> Self {
@@ -59532,11 +55920,6 @@ pub struct PackagePublished {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&PackagePublished> for PackagePublished {
-    fn from(value: &PackagePublished) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PackagePublishedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -59565,11 +55948,6 @@ impl ::std::convert::From<&PackagePublished> for PackagePublished {
 pub enum PackagePublishedAction {
     #[serde(rename = "published")]
     Published,
-}
-impl ::std::convert::From<&Self> for PackagePublishedAction {
-    fn from(value: &PackagePublishedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PackagePublishedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -59924,11 +56302,6 @@ pub struct PackagePublishedPackage {
     pub registry: PackagePublishedPackageRegistry,
     pub updated_at: ::std::string::String,
 }
-impl ::std::convert::From<&PackagePublishedPackage> for PackagePublishedPackage {
-    fn from(value: &PackagePublishedPackage) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PackagePublishedPackagePackageVersion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -60170,13 +56543,6 @@ pub struct PackagePublishedPackagePackageVersion {
     pub updated_at: ::std::string::String,
     pub version: ::std::string::String,
 }
-impl ::std::convert::From<&PackagePublishedPackagePackageVersion>
-    for PackagePublishedPackagePackageVersion
-{
-    fn from(value: &PackagePublishedPackagePackageVersion) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PackagePublishedPackagePackageVersionPackageFilesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -60251,13 +56617,6 @@ pub struct PackagePublishedPackagePackageVersionPackageFilesItem {
     pub size: i64,
     pub state: ::std::string::String,
     pub updated_at: ::std::string::String,
-}
-impl ::std::convert::From<&PackagePublishedPackagePackageVersionPackageFilesItem>
-    for PackagePublishedPackagePackageVersionPackageFilesItem
-{
-    fn from(value: &PackagePublishedPackagePackageVersionPackageFilesItem) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`PackagePublishedPackagePackageVersionRelease`"]
 #[doc = r""]
@@ -60335,13 +56694,6 @@ pub struct PackagePublishedPackagePackageVersionRelease {
     pub target_commitish: ::std::string::String,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&PackagePublishedPackagePackageVersionRelease>
-    for PackagePublishedPackagePackageVersionRelease
-{
-    fn from(value: &PackagePublishedPackagePackageVersionRelease) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PackagePublishedPackageRegistry`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -60388,11 +56740,6 @@ pub struct PackagePublishedPackageRegistry {
     pub type_: ::std::string::String,
     pub url: ::std::string::String,
     pub vendor: ::std::string::String,
-}
-impl ::std::convert::From<&PackagePublishedPackageRegistry> for PackagePublishedPackageRegistry {
-    fn from(value: &PackagePublishedPackageRegistry) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`PackageUpdated`"]
 #[doc = r""]
@@ -60733,11 +57080,6 @@ pub struct PackageUpdated {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&PackageUpdated> for PackageUpdated {
-    fn from(value: &PackageUpdated) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PackageUpdatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -60766,11 +57108,6 @@ impl ::std::convert::From<&PackageUpdated> for PackageUpdated {
 pub enum PackageUpdatedAction {
     #[serde(rename = "updated")]
     Updated,
-}
-impl ::std::convert::From<&Self> for PackageUpdatedAction {
-    fn from(value: &PackageUpdatedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PackageUpdatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -61126,11 +57463,6 @@ pub struct PackageUpdatedPackage {
     pub registry: PackageUpdatedPackageRegistry,
     pub updated_at: ::std::string::String,
 }
-impl ::std::convert::From<&PackageUpdatedPackage> for PackageUpdatedPackage {
-    fn from(value: &PackageUpdatedPackage) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PackageUpdatedPackagePackageVersion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -61373,13 +57705,6 @@ pub struct PackageUpdatedPackagePackageVersion {
     pub updated_at: ::std::string::String,
     pub version: ::std::string::String,
 }
-impl ::std::convert::From<&PackageUpdatedPackagePackageVersion>
-    for PackageUpdatedPackagePackageVersion
-{
-    fn from(value: &PackageUpdatedPackagePackageVersion) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PackageUpdatedPackagePackageVersionPackageFilesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -61454,13 +57779,6 @@ pub struct PackageUpdatedPackagePackageVersionPackageFilesItem {
     pub size: i64,
     pub state: ::std::string::String,
     pub updated_at: ::std::string::String,
-}
-impl ::std::convert::From<&PackageUpdatedPackagePackageVersionPackageFilesItem>
-    for PackageUpdatedPackagePackageVersionPackageFilesItem
-{
-    fn from(value: &PackageUpdatedPackagePackageVersionPackageFilesItem) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`PackageUpdatedPackagePackageVersionRelease`"]
 #[doc = r""]
@@ -61538,13 +57856,6 @@ pub struct PackageUpdatedPackagePackageVersionRelease {
     pub target_commitish: ::std::string::String,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&PackageUpdatedPackagePackageVersionRelease>
-    for PackageUpdatedPackagePackageVersionRelease
-{
-    fn from(value: &PackageUpdatedPackagePackageVersionRelease) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PackageUpdatedPackageRegistry`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -61591,11 +57902,6 @@ pub struct PackageUpdatedPackageRegistry {
     pub type_: ::std::string::String,
     pub url: ::std::string::String,
     pub vendor: ::std::string::String,
-}
-impl ::std::convert::From<&PackageUpdatedPackageRegistry> for PackageUpdatedPackageRegistry {
-    fn from(value: &PackageUpdatedPackageRegistry) -> Self {
-        value.clone()
-    }
 }
 #[doc = "Page Build"]
 #[doc = r""]
@@ -61700,11 +58006,6 @@ pub struct PageBuildEvent {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&PageBuildEvent> for PageBuildEvent {
-    fn from(value: &PageBuildEvent) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The [List GitHub Pages builds](https://docs.github.com/en/rest/reference/repos#list-github-pages-builds) itself."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -61778,11 +58079,6 @@ pub struct PageBuildEventBuild {
     pub updated_at: ::std::string::String,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&PageBuildEventBuild> for PageBuildEventBuild {
-    fn from(value: &PageBuildEventBuild) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PageBuildEventBuildError`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -61809,11 +58105,6 @@ impl ::std::convert::From<&PageBuildEventBuild> for PageBuildEventBuild {
 #[serde(deny_unknown_fields)]
 pub struct PageBuildEventBuildError {
     pub message: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&PageBuildEventBuildError> for PageBuildEventBuildError {
-    fn from(value: &PageBuildEventBuildError) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`PingEvent`"]
 #[doc = r""]
@@ -61969,11 +58260,6 @@ pub struct PingEvent {
     pub sender: ::std::option::Option<User>,
     pub zen: ::std::string::String,
 }
-impl ::std::convert::From<&PingEvent> for PingEvent {
-    fn from(value: &PingEvent) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The [webhook configuration](https://docs.github.com/en/rest/reference/repos#get-a-repository-webhook)."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -62107,11 +58393,6 @@ pub struct PingEventHook {
     pub updated_at: ::std::string::String,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&PingEventHook> for PingEventHook {
-    fn from(value: &PingEventHook) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PingEventHookConfig`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -62156,11 +58437,6 @@ pub struct PingEventHookConfig {
     pub secret: ::std::option::Option<::std::string::String>,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&PingEventHookConfig> for PingEventHookConfig {
-    fn from(value: &PingEventHookConfig) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PingEventHookConfigContentType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -62192,11 +58468,6 @@ pub enum PingEventHookConfigContentType {
     Json,
     #[serde(rename = "form")]
     Form,
-}
-impl ::std::convert::From<&Self> for PingEventHookConfigContentType {
-    fn from(value: &PingEventHookConfigContentType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PingEventHookConfigContentType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -62271,11 +58542,6 @@ pub struct PingEventHookLastResponse {
     pub code: (),
     pub message: (),
     pub status: ::std::string::String,
-}
-impl ::std::convert::From<&PingEventHookLastResponse> for PingEventHookLastResponse {
-    fn from(value: &PingEventHookLastResponse) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`Project`"]
 #[doc = r""]
@@ -62382,11 +58648,6 @@ pub struct Project {
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&Project> for Project {
-    fn from(value: &Project) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ProjectCard`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -62486,11 +58747,6 @@ pub struct ProjectCard {
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&ProjectCard> for ProjectCard {
-    fn from(value: &ProjectCard) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ProjectCardConverted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -62568,11 +58824,6 @@ pub struct ProjectCardConverted {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&ProjectCardConverted> for ProjectCardConverted {
-    fn from(value: &ProjectCardConverted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ProjectCardConvertedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -62601,11 +58852,6 @@ impl ::std::convert::From<&ProjectCardConverted> for ProjectCardConverted {
 pub enum ProjectCardConvertedAction {
     #[serde(rename = "converted")]
     Converted,
-}
-impl ::std::convert::From<&Self> for ProjectCardConvertedAction {
-    fn from(value: &ProjectCardConvertedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ProjectCardConvertedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -62678,11 +58924,6 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectCardConvertedActi
 pub struct ProjectCardConvertedChanges {
     pub note: ProjectCardConvertedChangesNote,
 }
-impl ::std::convert::From<&ProjectCardConvertedChanges> for ProjectCardConvertedChanges {
-    fn from(value: &ProjectCardConvertedChanges) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ProjectCardConvertedChangesNote`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -62706,11 +58947,6 @@ impl ::std::convert::From<&ProjectCardConvertedChanges> for ProjectCardConverted
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardConvertedChangesNote {
     pub from: ::std::string::String,
-}
-impl ::std::convert::From<&ProjectCardConvertedChangesNote> for ProjectCardConvertedChangesNote {
-    fn from(value: &ProjectCardConvertedChangesNote) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`ProjectCardCreated`"]
 #[doc = r""]
@@ -62766,11 +59002,6 @@ pub struct ProjectCardCreated {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&ProjectCardCreated> for ProjectCardCreated {
-    fn from(value: &ProjectCardCreated) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ProjectCardCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -62799,11 +59030,6 @@ impl ::std::convert::From<&ProjectCardCreated> for ProjectCardCreated {
 pub enum ProjectCardCreatedAction {
     #[serde(rename = "created")]
     Created,
-}
-impl ::std::convert::From<&Self> for ProjectCardCreatedAction {
-    fn from(value: &ProjectCardCreatedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ProjectCardCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -62897,11 +59123,6 @@ pub struct ProjectCardDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&ProjectCardDeleted> for ProjectCardDeleted {
-    fn from(value: &ProjectCardDeleted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ProjectCardDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -62930,11 +59151,6 @@ impl ::std::convert::From<&ProjectCardDeleted> for ProjectCardDeleted {
 pub enum ProjectCardDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
-}
-impl ::std::convert::From<&Self> for ProjectCardDeletedAction {
-    fn from(value: &ProjectCardDeletedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ProjectCardDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -63051,11 +59267,6 @@ pub struct ProjectCardEdited {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&ProjectCardEdited> for ProjectCardEdited {
-    fn from(value: &ProjectCardEdited) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ProjectCardEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -63084,11 +59295,6 @@ impl ::std::convert::From<&ProjectCardEdited> for ProjectCardEdited {
 pub enum ProjectCardEditedAction {
     #[serde(rename = "edited")]
     Edited,
-}
-impl ::std::convert::From<&Self> for ProjectCardEditedAction {
-    fn from(value: &ProjectCardEditedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ProjectCardEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -63161,11 +59367,6 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectCardEditedAction 
 pub struct ProjectCardEditedChanges {
     pub note: ProjectCardEditedChangesNote,
 }
-impl ::std::convert::From<&ProjectCardEditedChanges> for ProjectCardEditedChanges {
-    fn from(value: &ProjectCardEditedChanges) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ProjectCardEditedChangesNote`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -63189,11 +59390,6 @@ impl ::std::convert::From<&ProjectCardEditedChanges> for ProjectCardEditedChange
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardEditedChangesNote {
     pub from: ::std::string::String,
-}
-impl ::std::convert::From<&ProjectCardEditedChangesNote> for ProjectCardEditedChangesNote {
-    fn from(value: &ProjectCardEditedChangesNote) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`ProjectCardEvent`"]
 #[doc = r""]
@@ -63229,11 +59425,6 @@ pub enum ProjectCardEvent {
     Deleted(ProjectCardDeleted),
     Edited(ProjectCardEdited),
     Moved(ProjectCardMoved),
-}
-impl ::std::convert::From<&Self> for ProjectCardEvent {
-    fn from(value: &ProjectCardEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ProjectCardConverted> for ProjectCardEvent {
     fn from(value: ProjectCardConverted) -> Self {
@@ -63356,11 +59547,6 @@ pub struct ProjectCardMoved {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&ProjectCardMoved> for ProjectCardMoved {
-    fn from(value: &ProjectCardMoved) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ProjectCardMovedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -63389,11 +59575,6 @@ impl ::std::convert::From<&ProjectCardMoved> for ProjectCardMoved {
 pub enum ProjectCardMovedAction {
     #[serde(rename = "moved")]
     Moved,
-}
-impl ::std::convert::From<&Self> for ProjectCardMovedAction {
-    fn from(value: &ProjectCardMovedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ProjectCardMovedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -63466,11 +59647,6 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectCardMovedAction {
 pub struct ProjectCardMovedChanges {
     pub column_id: ProjectCardMovedChangesColumnId,
 }
-impl ::std::convert::From<&ProjectCardMovedChanges> for ProjectCardMovedChanges {
-    fn from(value: &ProjectCardMovedChanges) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ProjectCardMovedChangesColumnId`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -63494,11 +59670,6 @@ impl ::std::convert::From<&ProjectCardMovedChanges> for ProjectCardMovedChanges 
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardMovedChangesColumnId {
     pub from: i64,
-}
-impl ::std::convert::From<&ProjectCardMovedChangesColumnId> for ProjectCardMovedChangesColumnId {
-    fn from(value: &ProjectCardMovedChangesColumnId) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`ProjectCardMovedProjectCard`"]
 #[doc = r""]
@@ -63548,11 +59719,6 @@ pub struct ProjectCardMovedProjectCard {
     pub project_url: ::std::string::String,
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub url: ::std::string::String,
-}
-impl ::std::convert::From<&ProjectCardMovedProjectCard> for ProjectCardMovedProjectCard {
-    fn from(value: &ProjectCardMovedProjectCard) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`ProjectClosed`"]
 #[doc = r""]
@@ -63608,11 +59774,6 @@ pub struct ProjectClosed {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&ProjectClosed> for ProjectClosed {
-    fn from(value: &ProjectClosed) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ProjectClosedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -63641,11 +59802,6 @@ impl ::std::convert::From<&ProjectClosed> for ProjectClosed {
 pub enum ProjectClosedAction {
     #[serde(rename = "closed")]
     Closed,
-}
-impl ::std::convert::From<&Self> for ProjectClosedAction {
-    fn from(value: &ProjectClosedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ProjectClosedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -63755,11 +59911,6 @@ pub struct ProjectColumn {
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&ProjectColumn> for ProjectColumn {
-    fn from(value: &ProjectColumn) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ProjectColumnCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -63814,11 +59965,6 @@ pub struct ProjectColumnCreated {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&ProjectColumnCreated> for ProjectColumnCreated {
-    fn from(value: &ProjectColumnCreated) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ProjectColumnCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -63847,11 +59993,6 @@ impl ::std::convert::From<&ProjectColumnCreated> for ProjectColumnCreated {
 pub enum ProjectColumnCreatedAction {
     #[serde(rename = "created")]
     Created,
-}
-impl ::std::convert::From<&Self> for ProjectColumnCreatedAction {
-    fn from(value: &ProjectColumnCreatedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ProjectColumnCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -63945,11 +60086,6 @@ pub struct ProjectColumnDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&ProjectColumnDeleted> for ProjectColumnDeleted {
-    fn from(value: &ProjectColumnDeleted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ProjectColumnDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -63978,11 +60114,6 @@ impl ::std::convert::From<&ProjectColumnDeleted> for ProjectColumnDeleted {
 pub enum ProjectColumnDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
-}
-impl ::std::convert::From<&Self> for ProjectColumnDeletedAction {
-    fn from(value: &ProjectColumnDeletedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ProjectColumnDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -64096,11 +60227,6 @@ pub struct ProjectColumnEdited {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&ProjectColumnEdited> for ProjectColumnEdited {
-    fn from(value: &ProjectColumnEdited) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ProjectColumnEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -64129,11 +60255,6 @@ impl ::std::convert::From<&ProjectColumnEdited> for ProjectColumnEdited {
 pub enum ProjectColumnEditedAction {
     #[serde(rename = "edited")]
     Edited,
-}
-impl ::std::convert::From<&Self> for ProjectColumnEditedAction {
-    fn from(value: &ProjectColumnEditedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ProjectColumnEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -64204,11 +60325,6 @@ pub struct ProjectColumnEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<ProjectColumnEditedChangesName>,
 }
-impl ::std::convert::From<&ProjectColumnEditedChanges> for ProjectColumnEditedChanges {
-    fn from(value: &ProjectColumnEditedChanges) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for ProjectColumnEditedChanges {
     fn default() -> Self {
         Self {
@@ -64240,11 +60356,6 @@ impl ::std::default::Default for ProjectColumnEditedChanges {
 pub struct ProjectColumnEditedChangesName {
     pub from: ::std::string::String,
 }
-impl ::std::convert::From<&ProjectColumnEditedChangesName> for ProjectColumnEditedChangesName {
-    fn from(value: &ProjectColumnEditedChangesName) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ProjectColumnEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -64275,11 +60386,6 @@ pub enum ProjectColumnEvent {
     Deleted(ProjectColumnDeleted),
     Edited(ProjectColumnEdited),
     Moved(ProjectColumnMoved),
-}
-impl ::std::convert::From<&Self> for ProjectColumnEvent {
-    fn from(value: &ProjectColumnEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ProjectColumnCreated> for ProjectColumnEvent {
     fn from(value: ProjectColumnCreated) -> Self {
@@ -64355,11 +60461,6 @@ pub struct ProjectColumnMoved {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&ProjectColumnMoved> for ProjectColumnMoved {
-    fn from(value: &ProjectColumnMoved) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ProjectColumnMovedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -64388,11 +60489,6 @@ impl ::std::convert::From<&ProjectColumnMoved> for ProjectColumnMoved {
 pub enum ProjectColumnMovedAction {
     #[serde(rename = "moved")]
     Moved,
-}
-impl ::std::convert::From<&Self> for ProjectColumnMovedAction {
-    fn from(value: &ProjectColumnMovedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ProjectColumnMovedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -64486,11 +60582,6 @@ pub struct ProjectCreated {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&ProjectCreated> for ProjectCreated {
-    fn from(value: &ProjectCreated) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ProjectCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -64519,11 +60610,6 @@ impl ::std::convert::From<&ProjectCreated> for ProjectCreated {
 pub enum ProjectCreatedAction {
     #[serde(rename = "created")]
     Created,
-}
-impl ::std::convert::From<&Self> for ProjectCreatedAction {
-    fn from(value: &ProjectCreatedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ProjectCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -64617,11 +60703,6 @@ pub struct ProjectDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&ProjectDeleted> for ProjectDeleted {
-    fn from(value: &ProjectDeleted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ProjectDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -64650,11 +60731,6 @@ impl ::std::convert::From<&ProjectDeleted> for ProjectDeleted {
 pub enum ProjectDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
-}
-impl ::std::convert::From<&Self> for ProjectDeletedAction {
-    fn from(value: &ProjectDeletedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ProjectDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -64783,11 +60859,6 @@ pub struct ProjectEdited {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&ProjectEdited> for ProjectEdited {
-    fn from(value: &ProjectEdited) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ProjectEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -64816,11 +60887,6 @@ impl ::std::convert::From<&ProjectEdited> for ProjectEdited {
 pub enum ProjectEditedAction {
     #[serde(rename = "edited")]
     Edited,
-}
-impl ::std::convert::From<&Self> for ProjectEditedAction {
-    fn from(value: &ProjectEditedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ProjectEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -64908,11 +60974,6 @@ pub struct ProjectEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<ProjectEditedChangesName>,
 }
-impl ::std::convert::From<&ProjectEditedChanges> for ProjectEditedChanges {
-    fn from(value: &ProjectEditedChanges) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for ProjectEditedChanges {
     fn default() -> Self {
         Self {
@@ -64947,11 +61008,6 @@ pub struct ProjectEditedChangesBody {
     #[doc = "The previous version of the body if the action was `edited`."]
     pub from: ::std::string::String,
 }
-impl ::std::convert::From<&ProjectEditedChangesBody> for ProjectEditedChangesBody {
-    fn from(value: &ProjectEditedChangesBody) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ProjectEditedChangesName`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -64977,11 +61033,6 @@ impl ::std::convert::From<&ProjectEditedChangesBody> for ProjectEditedChangesBod
 pub struct ProjectEditedChangesName {
     #[doc = "The changes to the project if the action was `edited`."]
     pub from: ::std::string::String,
-}
-impl ::std::convert::From<&ProjectEditedChangesName> for ProjectEditedChangesName {
-    fn from(value: &ProjectEditedChangesName) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`ProjectEvent`"]
 #[doc = r""]
@@ -65017,11 +61068,6 @@ pub enum ProjectEvent {
     Deleted(ProjectDeleted),
     Edited(ProjectEdited),
     Reopened(ProjectReopened),
-}
-impl ::std::convert::From<&Self> for ProjectEvent {
-    fn from(value: &ProjectEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ProjectClosed> for ProjectEvent {
     fn from(value: ProjectClosed) -> Self {
@@ -65102,11 +61148,6 @@ pub struct ProjectReopened {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&ProjectReopened> for ProjectReopened {
-    fn from(value: &ProjectReopened) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ProjectReopenedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -65135,11 +61176,6 @@ impl ::std::convert::From<&ProjectReopened> for ProjectReopened {
 pub enum ProjectReopenedAction {
     #[serde(rename = "reopened")]
     Reopened,
-}
-impl ::std::convert::From<&Self> for ProjectReopenedAction {
-    fn from(value: &ProjectReopenedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ProjectReopenedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -65211,11 +61247,6 @@ pub enum ProjectState {
     Open,
     #[serde(rename = "closed")]
     Closed,
-}
-impl ::std::convert::From<&Self> for ProjectState {
-    fn from(value: &ProjectState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ProjectState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -65317,11 +61348,6 @@ pub struct PublicEvent {
     pub organization: ::std::option::Option<Organization>,
     pub repository: PublicEventRepository,
     pub sender: User,
-}
-impl ::std::convert::From<&PublicEvent> for PublicEvent {
-    fn from(value: &PublicEvent) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`PublicEventRepository`"]
 #[doc = r""]
@@ -65467,11 +61493,6 @@ pub struct PublicEventRepository {
     pub watchers: i64,
     pub watchers_count: i64,
 }
-impl ::std::convert::From<&PublicEventRepository> for PublicEventRepository {
-    fn from(value: &PublicEventRepository) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PublicEventRepositoryCreatedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -65495,11 +61516,6 @@ impl ::std::convert::From<&PublicEventRepository> for PublicEventRepository {
 pub enum PublicEventRepositoryCreatedAt {
     Integer(i64),
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
-}
-impl ::std::convert::From<&Self> for PublicEventRepositoryCreatedAt {
-    fn from(value: &PublicEventRepositoryCreatedAt) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for PublicEventRepositoryCreatedAt {
     type Err = self::error::ConversionError;
@@ -65599,11 +61615,6 @@ pub struct PublicEventRepositoryPermissions {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub triage: ::std::option::Option<bool>,
 }
-impl ::std::convert::From<&PublicEventRepositoryPermissions> for PublicEventRepositoryPermissions {
-    fn from(value: &PublicEventRepositoryPermissions) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PublicEventRepositoryPushedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -65631,11 +61642,6 @@ pub enum PublicEventRepositoryPushedAt {
     Integer(i64),
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
     Null,
-}
-impl ::std::convert::From<&Self> for PublicEventRepositoryPushedAt {
-    fn from(value: &PublicEventRepositoryPushedAt) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<i64> for PublicEventRepositoryPushedAt {
     fn from(value: i64) -> Self {
@@ -66097,11 +62103,6 @@ pub struct PullRequest {
     pub url: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&PullRequest> for PullRequest {
-    fn from(value: &PullRequest) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -66139,11 +62140,6 @@ pub enum PullRequestActiveLockReason {
     TooHeated,
     #[serde(rename = "spam")]
     Spam,
-}
-impl ::std::convert::From<&Self> for PullRequestActiveLockReason {
-    fn from(value: &PullRequestActiveLockReason) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -66255,11 +62251,6 @@ pub struct PullRequestAssigned {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&PullRequestAssigned> for PullRequestAssigned {
-    fn from(value: &PullRequestAssigned) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestAssignedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -66288,11 +62279,6 @@ impl ::std::convert::From<&PullRequestAssigned> for PullRequestAssigned {
 pub enum PullRequestAssignedAction {
     #[serde(rename = "assigned")]
     Assigned,
-}
-impl ::std::convert::From<&Self> for PullRequestAssignedAction {
-    fn from(value: &PullRequestAssignedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestAssignedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -66391,11 +62377,6 @@ pub struct PullRequestAutoMergeDisabled {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&PullRequestAutoMergeDisabled> for PullRequestAutoMergeDisabled {
-    fn from(value: &PullRequestAutoMergeDisabled) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestAutoMergeDisabledAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -66424,11 +62405,6 @@ impl ::std::convert::From<&PullRequestAutoMergeDisabled> for PullRequestAutoMerg
 pub enum PullRequestAutoMergeDisabledAction {
     #[serde(rename = "auto_merge_disabled")]
     AutoMergeDisabled,
-}
-impl ::std::convert::From<&Self> for PullRequestAutoMergeDisabledAction {
-    fn from(value: &PullRequestAutoMergeDisabledAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestAutoMergeDisabledAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -66527,11 +62503,6 @@ pub struct PullRequestAutoMergeEnabled {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&PullRequestAutoMergeEnabled> for PullRequestAutoMergeEnabled {
-    fn from(value: &PullRequestAutoMergeEnabled) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestAutoMergeEnabledAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -66560,11 +62531,6 @@ impl ::std::convert::From<&PullRequestAutoMergeEnabled> for PullRequestAutoMerge
 pub enum PullRequestAutoMergeEnabledAction {
     #[serde(rename = "auto_merge_enabled")]
     AutoMergeEnabled,
-}
-impl ::std::convert::From<&Self> for PullRequestAutoMergeEnabledAction {
-    fn from(value: &PullRequestAutoMergeEnabledAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestAutoMergeEnabledAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -66648,11 +62614,6 @@ pub struct PullRequestBase {
     pub repo: Repository,
     pub sha: ::std::string::String,
     pub user: User,
-}
-impl ::std::convert::From<&PullRequestBase> for PullRequestBase {
-    fn from(value: &PullRequestBase) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`PullRequestClosed`"]
 #[doc = r""]
@@ -66744,11 +62705,6 @@ pub struct PullRequestClosed {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&PullRequestClosed> for PullRequestClosed {
-    fn from(value: &PullRequestClosed) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestClosedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -66777,11 +62733,6 @@ impl ::std::convert::From<&PullRequestClosed> for PullRequestClosed {
 pub enum PullRequestClosedAction {
     #[serde(rename = "closed")]
     Closed,
-}
-impl ::std::convert::From<&Self> for PullRequestClosedAction {
-    fn from(value: &PullRequestClosedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestClosedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -66917,11 +62868,6 @@ pub struct PullRequestClosedPullRequest {
     pub url: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&PullRequestClosedPullRequest> for PullRequestClosedPullRequest {
-    fn from(value: &PullRequestClosedPullRequest) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestClosedPullRequestActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -66959,11 +62905,6 @@ pub enum PullRequestClosedPullRequestActiveLockReason {
     TooHeated,
     #[serde(rename = "spam")]
     Spam,
-}
-impl ::std::convert::From<&Self> for PullRequestClosedPullRequestActiveLockReason {
-    fn from(value: &PullRequestClosedPullRequestActiveLockReason) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestClosedPullRequestActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -67058,11 +62999,6 @@ pub struct PullRequestClosedPullRequestBase {
     pub sha: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&PullRequestClosedPullRequestBase> for PullRequestClosedPullRequestBase {
-    fn from(value: &PullRequestClosedPullRequestBase) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestClosedPullRequestHead`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -67107,11 +63043,6 @@ pub struct PullRequestClosedPullRequestHead {
     pub repo: Repository,
     pub sha: ::std::string::String,
     pub user: User,
-}
-impl ::std::convert::From<&PullRequestClosedPullRequestHead> for PullRequestClosedPullRequestHead {
-    fn from(value: &PullRequestClosedPullRequestHead) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`PullRequestClosedPullRequestLinks`"]
 #[doc = r""]
@@ -67173,13 +63104,6 @@ pub struct PullRequestClosedPullRequestLinks {
     pub self_: Link,
     pub statuses: Link,
 }
-impl ::std::convert::From<&PullRequestClosedPullRequestLinks>
-    for PullRequestClosedPullRequestLinks
-{
-    fn from(value: &PullRequestClosedPullRequestLinks) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestClosedPullRequestRequestedReviewersItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -67202,11 +63126,6 @@ impl ::std::convert::From<&PullRequestClosedPullRequestLinks>
 pub enum PullRequestClosedPullRequestRequestedReviewersItem {
     User(User),
     Team(Team),
-}
-impl ::std::convert::From<&Self> for PullRequestClosedPullRequestRequestedReviewersItem {
-    fn from(value: &PullRequestClosedPullRequestRequestedReviewersItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<User> for PullRequestClosedPullRequestRequestedReviewersItem {
     fn from(value: User) -> Self {
@@ -67246,11 +63165,6 @@ impl ::std::convert::From<Team> for PullRequestClosedPullRequestRequestedReviewe
 pub enum PullRequestClosedPullRequestState {
     #[serde(rename = "closed")]
     Closed,
-}
-impl ::std::convert::From<&Self> for PullRequestClosedPullRequestState {
-    fn from(value: &PullRequestClosedPullRequestState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestClosedPullRequestState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -67390,11 +63304,6 @@ pub struct PullRequestConvertedToDraft {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&PullRequestConvertedToDraft> for PullRequestConvertedToDraft {
-    fn from(value: &PullRequestConvertedToDraft) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestConvertedToDraftAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -67423,11 +63332,6 @@ impl ::std::convert::From<&PullRequestConvertedToDraft> for PullRequestConverted
 pub enum PullRequestConvertedToDraftAction {
     #[serde(rename = "converted_to_draft")]
     ConvertedToDraft,
-}
-impl ::std::convert::From<&Self> for PullRequestConvertedToDraftAction {
-    fn from(value: &PullRequestConvertedToDraftAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestConvertedToDraftAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -67575,13 +63479,6 @@ pub struct PullRequestConvertedToDraftPullRequest {
     pub url: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&PullRequestConvertedToDraftPullRequest>
-    for PullRequestConvertedToDraftPullRequest
-{
-    fn from(value: &PullRequestConvertedToDraftPullRequest) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestConvertedToDraftPullRequestActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -67619,11 +63516,6 @@ pub enum PullRequestConvertedToDraftPullRequestActiveLockReason {
     TooHeated,
     #[serde(rename = "spam")]
     Spam,
-}
-impl ::std::convert::From<&Self> for PullRequestConvertedToDraftPullRequestActiveLockReason {
-    fn from(value: &PullRequestConvertedToDraftPullRequestActiveLockReason) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestConvertedToDraftPullRequestActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -67718,13 +63610,6 @@ pub struct PullRequestConvertedToDraftPullRequestBase {
     pub sha: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&PullRequestConvertedToDraftPullRequestBase>
-    for PullRequestConvertedToDraftPullRequestBase
-{
-    fn from(value: &PullRequestConvertedToDraftPullRequestBase) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestConvertedToDraftPullRequestHead`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -67769,13 +63654,6 @@ pub struct PullRequestConvertedToDraftPullRequestHead {
     pub repo: Repository,
     pub sha: ::std::string::String,
     pub user: User,
-}
-impl ::std::convert::From<&PullRequestConvertedToDraftPullRequestHead>
-    for PullRequestConvertedToDraftPullRequestHead
-{
-    fn from(value: &PullRequestConvertedToDraftPullRequestHead) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`PullRequestConvertedToDraftPullRequestLinks`"]
 #[doc = r""]
@@ -67837,13 +63715,6 @@ pub struct PullRequestConvertedToDraftPullRequestLinks {
     pub self_: Link,
     pub statuses: Link,
 }
-impl ::std::convert::From<&PullRequestConvertedToDraftPullRequestLinks>
-    for PullRequestConvertedToDraftPullRequestLinks
-{
-    fn from(value: &PullRequestConvertedToDraftPullRequestLinks) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestConvertedToDraftPullRequestRequestedReviewersItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -67866,11 +63737,6 @@ impl ::std::convert::From<&PullRequestConvertedToDraftPullRequestLinks>
 pub enum PullRequestConvertedToDraftPullRequestRequestedReviewersItem {
     User(User),
     Team(Team),
-}
-impl ::std::convert::From<&Self> for PullRequestConvertedToDraftPullRequestRequestedReviewersItem {
-    fn from(value: &PullRequestConvertedToDraftPullRequestRequestedReviewersItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<User> for PullRequestConvertedToDraftPullRequestRequestedReviewersItem {
     fn from(value: User) -> Self {
@@ -67914,11 +63780,6 @@ pub enum PullRequestConvertedToDraftPullRequestState {
     Open,
     #[serde(rename = "closed")]
     Closed,
-}
-impl ::std::convert::From<&Self> for PullRequestConvertedToDraftPullRequestState {
-    fn from(value: &PullRequestConvertedToDraftPullRequestState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestConvertedToDraftPullRequestState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -68060,11 +63921,6 @@ pub struct PullRequestEdited {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&PullRequestEdited> for PullRequestEdited {
-    fn from(value: &PullRequestEdited) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -68093,11 +63949,6 @@ impl ::std::convert::From<&PullRequestEdited> for PullRequestEdited {
 pub enum PullRequestEditedAction {
     #[serde(rename = "edited")]
     Edited,
-}
-impl ::std::convert::From<&Self> for PullRequestEditedAction {
-    fn from(value: &PullRequestEditedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -68185,11 +64036,6 @@ pub struct PullRequestEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<PullRequestEditedChangesTitle>,
 }
-impl ::std::convert::From<&PullRequestEditedChanges> for PullRequestEditedChanges {
-    fn from(value: &PullRequestEditedChanges) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for PullRequestEditedChanges {
     fn default() -> Self {
         Self {
@@ -68224,11 +64070,6 @@ pub struct PullRequestEditedChangesBody {
     #[doc = "The previous version of the body if the action was `edited`."]
     pub from: ::std::string::String,
 }
-impl ::std::convert::From<&PullRequestEditedChangesBody> for PullRequestEditedChangesBody {
-    fn from(value: &PullRequestEditedChangesBody) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestEditedChangesTitle`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -68254,11 +64095,6 @@ impl ::std::convert::From<&PullRequestEditedChangesBody> for PullRequestEditedCh
 pub struct PullRequestEditedChangesTitle {
     #[doc = "The previous version of the title if the action was `edited`."]
     pub from: ::std::string::String,
-}
-impl ::std::convert::From<&PullRequestEditedChangesTitle> for PullRequestEditedChangesTitle {
-    fn from(value: &PullRequestEditedChangesTitle) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`PullRequestEvent`"]
 #[doc = r""]
@@ -68342,11 +64178,6 @@ pub enum PullRequestEvent {
     Unassigned(PullRequestUnassigned),
     Unlabeled(PullRequestUnlabeled),
     Unlocked(PullRequestUnlocked),
-}
-impl ::std::convert::From<&Self> for PullRequestEvent {
-    fn from(value: &PullRequestEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<PullRequestAssigned> for PullRequestEvent {
     fn from(value: PullRequestAssigned) -> Self {
@@ -68478,11 +64309,6 @@ pub struct PullRequestHead {
     pub sha: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&PullRequestHead> for PullRequestHead {
-    fn from(value: &PullRequestHead) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestLabeled`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -68549,11 +64375,6 @@ pub struct PullRequestLabeled {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&PullRequestLabeled> for PullRequestLabeled {
-    fn from(value: &PullRequestLabeled) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestLabeledAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -68582,11 +64403,6 @@ impl ::std::convert::From<&PullRequestLabeled> for PullRequestLabeled {
 pub enum PullRequestLabeledAction {
     #[serde(rename = "labeled")]
     Labeled,
-}
-impl ::std::convert::From<&Self> for PullRequestLabeledAction {
-    fn from(value: &PullRequestLabeledAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestLabeledAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -68686,11 +64502,6 @@ pub struct PullRequestLinks {
     pub self_: Link,
     pub statuses: Link,
 }
-impl ::std::convert::From<&PullRequestLinks> for PullRequestLinks {
-    fn from(value: &PullRequestLinks) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestLocked`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -68752,11 +64563,6 @@ pub struct PullRequestLocked {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&PullRequestLocked> for PullRequestLocked {
-    fn from(value: &PullRequestLocked) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestLockedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -68785,11 +64591,6 @@ impl ::std::convert::From<&PullRequestLocked> for PullRequestLocked {
 pub enum PullRequestLockedAction {
     #[serde(rename = "locked")]
     Locked,
-}
-impl ::std::convert::From<&Self> for PullRequestLockedAction {
-    fn from(value: &PullRequestLockedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestLockedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -68929,11 +64730,6 @@ pub struct PullRequestOpened {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&PullRequestOpened> for PullRequestOpened {
-    fn from(value: &PullRequestOpened) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestOpenedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -68962,11 +64758,6 @@ impl ::std::convert::From<&PullRequestOpened> for PullRequestOpened {
 pub enum PullRequestOpenedAction {
     #[serde(rename = "opened")]
     Opened,
-}
-impl ::std::convert::From<&Self> for PullRequestOpenedAction {
-    fn from(value: &PullRequestOpenedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestOpenedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -69112,11 +64903,6 @@ pub struct PullRequestOpenedPullRequest {
     pub url: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&PullRequestOpenedPullRequest> for PullRequestOpenedPullRequest {
-    fn from(value: &PullRequestOpenedPullRequest) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestOpenedPullRequestActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -69142,13 +64928,6 @@ impl ::std::ops::Deref for PullRequestOpenedPullRequestActiveLockReason {
 impl ::std::convert::From<PullRequestOpenedPullRequestActiveLockReason> for () {
     fn from(value: PullRequestOpenedPullRequestActiveLockReason) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&PullRequestOpenedPullRequestActiveLockReason>
-    for PullRequestOpenedPullRequestActiveLockReason
-{
-    fn from(value: &PullRequestOpenedPullRequestActiveLockReason) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::TryFrom<()> for PullRequestOpenedPullRequestActiveLockReason {
@@ -69215,11 +64994,6 @@ pub struct PullRequestOpenedPullRequestBase {
     pub sha: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&PullRequestOpenedPullRequestBase> for PullRequestOpenedPullRequestBase {
-    fn from(value: &PullRequestOpenedPullRequestBase) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestOpenedPullRequestHead`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -69264,11 +65038,6 @@ pub struct PullRequestOpenedPullRequestHead {
     pub repo: Repository,
     pub sha: ::std::string::String,
     pub user: User,
-}
-impl ::std::convert::From<&PullRequestOpenedPullRequestHead> for PullRequestOpenedPullRequestHead {
-    fn from(value: &PullRequestOpenedPullRequestHead) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`PullRequestOpenedPullRequestLinks`"]
 #[doc = r""]
@@ -69330,13 +65099,6 @@ pub struct PullRequestOpenedPullRequestLinks {
     pub self_: Link,
     pub statuses: Link,
 }
-impl ::std::convert::From<&PullRequestOpenedPullRequestLinks>
-    for PullRequestOpenedPullRequestLinks
-{
-    fn from(value: &PullRequestOpenedPullRequestLinks) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestOpenedPullRequestRequestedReviewersItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -69359,11 +65121,6 @@ impl ::std::convert::From<&PullRequestOpenedPullRequestLinks>
 pub enum PullRequestOpenedPullRequestRequestedReviewersItem {
     User(User),
     Team(Team),
-}
-impl ::std::convert::From<&Self> for PullRequestOpenedPullRequestRequestedReviewersItem {
-    fn from(value: &PullRequestOpenedPullRequestRequestedReviewersItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<User> for PullRequestOpenedPullRequestRequestedReviewersItem {
     fn from(value: User) -> Self {
@@ -69403,11 +65160,6 @@ impl ::std::convert::From<Team> for PullRequestOpenedPullRequestRequestedReviewe
 pub enum PullRequestOpenedPullRequestState {
     #[serde(rename = "open")]
     Open,
-}
-impl ::std::convert::From<&Self> for PullRequestOpenedPullRequestState {
-    fn from(value: &PullRequestOpenedPullRequestState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestOpenedPullRequestState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -69551,11 +65303,6 @@ pub struct PullRequestReadyForReview {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&PullRequestReadyForReview> for PullRequestReadyForReview {
-    fn from(value: &PullRequestReadyForReview) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReadyForReviewAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -69584,11 +65331,6 @@ impl ::std::convert::From<&PullRequestReadyForReview> for PullRequestReadyForRev
 pub enum PullRequestReadyForReviewAction {
     #[serde(rename = "ready_for_review")]
     ReadyForReview,
-}
-impl ::std::convert::From<&Self> for PullRequestReadyForReviewAction {
-    fn from(value: &PullRequestReadyForReviewAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestReadyForReviewAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -69739,13 +65481,6 @@ pub struct PullRequestReadyForReviewPullRequest {
     pub url: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&PullRequestReadyForReviewPullRequest>
-    for PullRequestReadyForReviewPullRequest
-{
-    fn from(value: &PullRequestReadyForReviewPullRequest) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReadyForReviewPullRequestActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -69783,11 +65518,6 @@ pub enum PullRequestReadyForReviewPullRequestActiveLockReason {
     TooHeated,
     #[serde(rename = "spam")]
     Spam,
-}
-impl ::std::convert::From<&Self> for PullRequestReadyForReviewPullRequestActiveLockReason {
-    fn from(value: &PullRequestReadyForReviewPullRequestActiveLockReason) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestReadyForReviewPullRequestActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -69882,13 +65612,6 @@ pub struct PullRequestReadyForReviewPullRequestBase {
     pub sha: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&PullRequestReadyForReviewPullRequestBase>
-    for PullRequestReadyForReviewPullRequestBase
-{
-    fn from(value: &PullRequestReadyForReviewPullRequestBase) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReadyForReviewPullRequestHead`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -69933,13 +65656,6 @@ pub struct PullRequestReadyForReviewPullRequestHead {
     pub repo: Repository,
     pub sha: ::std::string::String,
     pub user: User,
-}
-impl ::std::convert::From<&PullRequestReadyForReviewPullRequestHead>
-    for PullRequestReadyForReviewPullRequestHead
-{
-    fn from(value: &PullRequestReadyForReviewPullRequestHead) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`PullRequestReadyForReviewPullRequestLinks`"]
 #[doc = r""]
@@ -70001,13 +65717,6 @@ pub struct PullRequestReadyForReviewPullRequestLinks {
     pub self_: Link,
     pub statuses: Link,
 }
-impl ::std::convert::From<&PullRequestReadyForReviewPullRequestLinks>
-    for PullRequestReadyForReviewPullRequestLinks
-{
-    fn from(value: &PullRequestReadyForReviewPullRequestLinks) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReadyForReviewPullRequestRequestedReviewersItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -70030,11 +65739,6 @@ impl ::std::convert::From<&PullRequestReadyForReviewPullRequestLinks>
 pub enum PullRequestReadyForReviewPullRequestRequestedReviewersItem {
     User(User),
     Team(Team),
-}
-impl ::std::convert::From<&Self> for PullRequestReadyForReviewPullRequestRequestedReviewersItem {
-    fn from(value: &PullRequestReadyForReviewPullRequestRequestedReviewersItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<User> for PullRequestReadyForReviewPullRequestRequestedReviewersItem {
     fn from(value: User) -> Self {
@@ -70074,11 +65778,6 @@ impl ::std::convert::From<Team> for PullRequestReadyForReviewPullRequestRequeste
 pub enum PullRequestReadyForReviewPullRequestState {
     #[serde(rename = "open")]
     Open,
-}
-impl ::std::convert::From<&Self> for PullRequestReadyForReviewPullRequestState {
-    fn from(value: &PullRequestReadyForReviewPullRequestState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestReadyForReviewPullRequestState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -70218,11 +65917,6 @@ pub struct PullRequestReopened {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&PullRequestReopened> for PullRequestReopened {
-    fn from(value: &PullRequestReopened) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReopenedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -70251,11 +65945,6 @@ impl ::std::convert::From<&PullRequestReopened> for PullRequestReopened {
 pub enum PullRequestReopenedAction {
     #[serde(rename = "reopened")]
     Reopened,
-}
-impl ::std::convert::From<&Self> for PullRequestReopenedAction {
-    fn from(value: &PullRequestReopenedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestReopenedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -70401,11 +66090,6 @@ pub struct PullRequestReopenedPullRequest {
     pub url: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&PullRequestReopenedPullRequest> for PullRequestReopenedPullRequest {
-    fn from(value: &PullRequestReopenedPullRequest) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReopenedPullRequestActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -70443,11 +66127,6 @@ pub enum PullRequestReopenedPullRequestActiveLockReason {
     TooHeated,
     #[serde(rename = "spam")]
     Spam,
-}
-impl ::std::convert::From<&Self> for PullRequestReopenedPullRequestActiveLockReason {
-    fn from(value: &PullRequestReopenedPullRequestActiveLockReason) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestReopenedPullRequestActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -70542,13 +66221,6 @@ pub struct PullRequestReopenedPullRequestBase {
     pub sha: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&PullRequestReopenedPullRequestBase>
-    for PullRequestReopenedPullRequestBase
-{
-    fn from(value: &PullRequestReopenedPullRequestBase) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReopenedPullRequestHead`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -70593,13 +66265,6 @@ pub struct PullRequestReopenedPullRequestHead {
     pub repo: Repository,
     pub sha: ::std::string::String,
     pub user: User,
-}
-impl ::std::convert::From<&PullRequestReopenedPullRequestHead>
-    for PullRequestReopenedPullRequestHead
-{
-    fn from(value: &PullRequestReopenedPullRequestHead) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`PullRequestReopenedPullRequestLinks`"]
 #[doc = r""]
@@ -70661,13 +66326,6 @@ pub struct PullRequestReopenedPullRequestLinks {
     pub self_: Link,
     pub statuses: Link,
 }
-impl ::std::convert::From<&PullRequestReopenedPullRequestLinks>
-    for PullRequestReopenedPullRequestLinks
-{
-    fn from(value: &PullRequestReopenedPullRequestLinks) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReopenedPullRequestRequestedReviewersItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -70690,11 +66348,6 @@ impl ::std::convert::From<&PullRequestReopenedPullRequestLinks>
 pub enum PullRequestReopenedPullRequestRequestedReviewersItem {
     User(User),
     Team(Team),
-}
-impl ::std::convert::From<&Self> for PullRequestReopenedPullRequestRequestedReviewersItem {
-    fn from(value: &PullRequestReopenedPullRequestRequestedReviewersItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<User> for PullRequestReopenedPullRequestRequestedReviewersItem {
     fn from(value: User) -> Self {
@@ -70734,11 +66387,6 @@ impl ::std::convert::From<Team> for PullRequestReopenedPullRequestRequestedRevie
 pub enum PullRequestReopenedPullRequestState {
     #[serde(rename = "open")]
     Open,
-}
-impl ::std::convert::From<&Self> for PullRequestReopenedPullRequestState {
-    fn from(value: &PullRequestReopenedPullRequestState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestReopenedPullRequestState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -70800,11 +66448,6 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReopenedPullR
 pub enum PullRequestRequestedReviewersItem {
     User(User),
     Team(Team),
-}
-impl ::std::convert::From<&Self> for PullRequestRequestedReviewersItem {
-    fn from(value: &PullRequestRequestedReviewersItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<User> for PullRequestRequestedReviewersItem {
     fn from(value: User) -> Self {
@@ -71050,11 +66693,6 @@ pub struct PullRequestReviewComment {
     #[doc = "URL for the pull request review comment"]
     pub url: ::std::string::String,
     pub user: User,
-}
-impl ::std::convert::From<&PullRequestReviewComment> for PullRequestReviewComment {
-    fn from(value: &PullRequestReviewComment) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`PullRequestReviewCommentCreated`"]
 #[doc = r""]
@@ -71415,11 +67053,6 @@ pub struct PullRequestReviewCommentCreated {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&PullRequestReviewCommentCreated> for PullRequestReviewCommentCreated {
-    fn from(value: &PullRequestReviewCommentCreated) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReviewCommentCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -71448,11 +67081,6 @@ impl ::std::convert::From<&PullRequestReviewCommentCreated> for PullRequestRevie
 pub enum PullRequestReviewCommentCreatedAction {
     #[serde(rename = "created")]
     Created,
-}
-impl ::std::convert::From<&Self> for PullRequestReviewCommentCreatedAction {
-    fn from(value: &PullRequestReviewCommentCreatedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestReviewCommentCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -71847,13 +67475,6 @@ pub struct PullRequestReviewCommentCreatedPullRequest {
     pub url: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&PullRequestReviewCommentCreatedPullRequest>
-    for PullRequestReviewCommentCreatedPullRequest
-{
-    fn from(value: &PullRequestReviewCommentCreatedPullRequest) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReviewCommentCreatedPullRequestActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -71891,11 +67512,6 @@ pub enum PullRequestReviewCommentCreatedPullRequestActiveLockReason {
     TooHeated,
     #[serde(rename = "spam")]
     Spam,
-}
-impl ::std::convert::From<&Self> for PullRequestReviewCommentCreatedPullRequestActiveLockReason {
-    fn from(value: &PullRequestReviewCommentCreatedPullRequestActiveLockReason) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestReviewCommentCreatedPullRequestActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -71990,13 +67606,6 @@ pub struct PullRequestReviewCommentCreatedPullRequestBase {
     pub sha: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&PullRequestReviewCommentCreatedPullRequestBase>
-    for PullRequestReviewCommentCreatedPullRequestBase
-{
-    fn from(value: &PullRequestReviewCommentCreatedPullRequestBase) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReviewCommentCreatedPullRequestHead`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -72041,13 +67650,6 @@ pub struct PullRequestReviewCommentCreatedPullRequestHead {
     pub repo: Repository,
     pub sha: ::std::string::String,
     pub user: User,
-}
-impl ::std::convert::From<&PullRequestReviewCommentCreatedPullRequestHead>
-    for PullRequestReviewCommentCreatedPullRequestHead
-{
-    fn from(value: &PullRequestReviewCommentCreatedPullRequestHead) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`PullRequestReviewCommentCreatedPullRequestLinks`"]
 #[doc = r""]
@@ -72109,13 +67711,6 @@ pub struct PullRequestReviewCommentCreatedPullRequestLinks {
     pub self_: Link,
     pub statuses: Link,
 }
-impl ::std::convert::From<&PullRequestReviewCommentCreatedPullRequestLinks>
-    for PullRequestReviewCommentCreatedPullRequestLinks
-{
-    fn from(value: &PullRequestReviewCommentCreatedPullRequestLinks) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReviewCommentCreatedPullRequestRequestedReviewersItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -72138,13 +67733,6 @@ impl ::std::convert::From<&PullRequestReviewCommentCreatedPullRequestLinks>
 pub enum PullRequestReviewCommentCreatedPullRequestRequestedReviewersItem {
     User(User),
     Team(Team),
-}
-impl ::std::convert::From<&Self>
-    for PullRequestReviewCommentCreatedPullRequestRequestedReviewersItem
-{
-    fn from(value: &PullRequestReviewCommentCreatedPullRequestRequestedReviewersItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<User>
     for PullRequestReviewCommentCreatedPullRequestRequestedReviewersItem
@@ -72191,11 +67779,6 @@ pub enum PullRequestReviewCommentCreatedPullRequestState {
     Open,
     #[serde(rename = "closed")]
     Closed,
-}
-impl ::std::convert::From<&Self> for PullRequestReviewCommentCreatedPullRequestState {
-    fn from(value: &PullRequestReviewCommentCreatedPullRequestState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestReviewCommentCreatedPullRequestState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -72600,11 +68183,6 @@ pub struct PullRequestReviewCommentDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&PullRequestReviewCommentDeleted> for PullRequestReviewCommentDeleted {
-    fn from(value: &PullRequestReviewCommentDeleted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReviewCommentDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -72633,11 +68211,6 @@ impl ::std::convert::From<&PullRequestReviewCommentDeleted> for PullRequestRevie
 pub enum PullRequestReviewCommentDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
-}
-impl ::std::convert::From<&Self> for PullRequestReviewCommentDeletedAction {
-    fn from(value: &PullRequestReviewCommentDeletedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestReviewCommentDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -73032,13 +68605,6 @@ pub struct PullRequestReviewCommentDeletedPullRequest {
     pub url: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&PullRequestReviewCommentDeletedPullRequest>
-    for PullRequestReviewCommentDeletedPullRequest
-{
-    fn from(value: &PullRequestReviewCommentDeletedPullRequest) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReviewCommentDeletedPullRequestActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -73076,11 +68642,6 @@ pub enum PullRequestReviewCommentDeletedPullRequestActiveLockReason {
     TooHeated,
     #[serde(rename = "spam")]
     Spam,
-}
-impl ::std::convert::From<&Self> for PullRequestReviewCommentDeletedPullRequestActiveLockReason {
-    fn from(value: &PullRequestReviewCommentDeletedPullRequestActiveLockReason) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestReviewCommentDeletedPullRequestActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -73175,13 +68736,6 @@ pub struct PullRequestReviewCommentDeletedPullRequestBase {
     pub sha: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&PullRequestReviewCommentDeletedPullRequestBase>
-    for PullRequestReviewCommentDeletedPullRequestBase
-{
-    fn from(value: &PullRequestReviewCommentDeletedPullRequestBase) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReviewCommentDeletedPullRequestHead`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -73226,13 +68780,6 @@ pub struct PullRequestReviewCommentDeletedPullRequestHead {
     pub repo: Repository,
     pub sha: ::std::string::String,
     pub user: User,
-}
-impl ::std::convert::From<&PullRequestReviewCommentDeletedPullRequestHead>
-    for PullRequestReviewCommentDeletedPullRequestHead
-{
-    fn from(value: &PullRequestReviewCommentDeletedPullRequestHead) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`PullRequestReviewCommentDeletedPullRequestLinks`"]
 #[doc = r""]
@@ -73294,13 +68841,6 @@ pub struct PullRequestReviewCommentDeletedPullRequestLinks {
     pub self_: Link,
     pub statuses: Link,
 }
-impl ::std::convert::From<&PullRequestReviewCommentDeletedPullRequestLinks>
-    for PullRequestReviewCommentDeletedPullRequestLinks
-{
-    fn from(value: &PullRequestReviewCommentDeletedPullRequestLinks) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReviewCommentDeletedPullRequestRequestedReviewersItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -73323,13 +68863,6 @@ impl ::std::convert::From<&PullRequestReviewCommentDeletedPullRequestLinks>
 pub enum PullRequestReviewCommentDeletedPullRequestRequestedReviewersItem {
     User(User),
     Team(Team),
-}
-impl ::std::convert::From<&Self>
-    for PullRequestReviewCommentDeletedPullRequestRequestedReviewersItem
-{
-    fn from(value: &PullRequestReviewCommentDeletedPullRequestRequestedReviewersItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<User>
     for PullRequestReviewCommentDeletedPullRequestRequestedReviewersItem
@@ -73376,11 +68909,6 @@ pub enum PullRequestReviewCommentDeletedPullRequestState {
     Open,
     #[serde(rename = "closed")]
     Closed,
-}
-impl ::std::convert::From<&Self> for PullRequestReviewCommentDeletedPullRequestState {
-    fn from(value: &PullRequestReviewCommentDeletedPullRequestState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestReviewCommentDeletedPullRequestState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -73807,11 +69335,6 @@ pub struct PullRequestReviewCommentEdited {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&PullRequestReviewCommentEdited> for PullRequestReviewCommentEdited {
-    fn from(value: &PullRequestReviewCommentEdited) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReviewCommentEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -73840,11 +69363,6 @@ impl ::std::convert::From<&PullRequestReviewCommentEdited> for PullRequestReview
 pub enum PullRequestReviewCommentEditedAction {
     #[serde(rename = "edited")]
     Edited,
-}
-impl ::std::convert::From<&Self> for PullRequestReviewCommentEditedAction {
-    fn from(value: &PullRequestReviewCommentEditedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestReviewCommentEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -73917,13 +69435,6 @@ pub struct PullRequestReviewCommentEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub body: ::std::option::Option<PullRequestReviewCommentEditedChangesBody>,
 }
-impl ::std::convert::From<&PullRequestReviewCommentEditedChanges>
-    for PullRequestReviewCommentEditedChanges
-{
-    fn from(value: &PullRequestReviewCommentEditedChanges) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for PullRequestReviewCommentEditedChanges {
     fn default() -> Self {
         Self {
@@ -73956,13 +69467,6 @@ impl ::std::default::Default for PullRequestReviewCommentEditedChanges {
 pub struct PullRequestReviewCommentEditedChangesBody {
     #[doc = "The previous version of the body."]
     pub from: ::std::string::String,
-}
-impl ::std::convert::From<&PullRequestReviewCommentEditedChangesBody>
-    for PullRequestReviewCommentEditedChangesBody
-{
-    fn from(value: &PullRequestReviewCommentEditedChangesBody) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`PullRequestReviewCommentEditedPullRequest`"]
 #[doc = r""]
@@ -74319,13 +69823,6 @@ pub struct PullRequestReviewCommentEditedPullRequest {
     pub url: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&PullRequestReviewCommentEditedPullRequest>
-    for PullRequestReviewCommentEditedPullRequest
-{
-    fn from(value: &PullRequestReviewCommentEditedPullRequest) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReviewCommentEditedPullRequestActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -74363,11 +69860,6 @@ pub enum PullRequestReviewCommentEditedPullRequestActiveLockReason {
     TooHeated,
     #[serde(rename = "spam")]
     Spam,
-}
-impl ::std::convert::From<&Self> for PullRequestReviewCommentEditedPullRequestActiveLockReason {
-    fn from(value: &PullRequestReviewCommentEditedPullRequestActiveLockReason) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestReviewCommentEditedPullRequestActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -74462,13 +69954,6 @@ pub struct PullRequestReviewCommentEditedPullRequestBase {
     pub sha: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&PullRequestReviewCommentEditedPullRequestBase>
-    for PullRequestReviewCommentEditedPullRequestBase
-{
-    fn from(value: &PullRequestReviewCommentEditedPullRequestBase) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReviewCommentEditedPullRequestHead`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -74513,13 +69998,6 @@ pub struct PullRequestReviewCommentEditedPullRequestHead {
     pub repo: Repository,
     pub sha: ::std::string::String,
     pub user: User,
-}
-impl ::std::convert::From<&PullRequestReviewCommentEditedPullRequestHead>
-    for PullRequestReviewCommentEditedPullRequestHead
-{
-    fn from(value: &PullRequestReviewCommentEditedPullRequestHead) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`PullRequestReviewCommentEditedPullRequestLinks`"]
 #[doc = r""]
@@ -74581,13 +70059,6 @@ pub struct PullRequestReviewCommentEditedPullRequestLinks {
     pub self_: Link,
     pub statuses: Link,
 }
-impl ::std::convert::From<&PullRequestReviewCommentEditedPullRequestLinks>
-    for PullRequestReviewCommentEditedPullRequestLinks
-{
-    fn from(value: &PullRequestReviewCommentEditedPullRequestLinks) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReviewCommentEditedPullRequestRequestedReviewersItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -74610,13 +70081,6 @@ impl ::std::convert::From<&PullRequestReviewCommentEditedPullRequestLinks>
 pub enum PullRequestReviewCommentEditedPullRequestRequestedReviewersItem {
     User(User),
     Team(Team),
-}
-impl ::std::convert::From<&Self>
-    for PullRequestReviewCommentEditedPullRequestRequestedReviewersItem
-{
-    fn from(value: &PullRequestReviewCommentEditedPullRequestRequestedReviewersItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<User>
     for PullRequestReviewCommentEditedPullRequestRequestedReviewersItem
@@ -74663,11 +70127,6 @@ pub enum PullRequestReviewCommentEditedPullRequestState {
     Open,
     #[serde(rename = "closed")]
     Closed,
-}
-impl ::std::convert::From<&Self> for PullRequestReviewCommentEditedPullRequestState {
-    fn from(value: &PullRequestReviewCommentEditedPullRequestState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestReviewCommentEditedPullRequestState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -74740,11 +70199,6 @@ pub enum PullRequestReviewCommentEvent {
     Deleted(PullRequestReviewCommentDeleted),
     Edited(PullRequestReviewCommentEdited),
 }
-impl ::std::convert::From<&Self> for PullRequestReviewCommentEvent {
-    fn from(value: &PullRequestReviewCommentEvent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<PullRequestReviewCommentCreated> for PullRequestReviewCommentEvent {
     fn from(value: PullRequestReviewCommentCreated) -> Self {
         Self::Created(value)
@@ -74795,11 +70249,6 @@ pub struct PullRequestReviewCommentLinks {
     #[serde(rename = "self")]
     pub self_: Link,
 }
-impl ::std::convert::From<&PullRequestReviewCommentLinks> for PullRequestReviewCommentLinks {
-    fn from(value: &PullRequestReviewCommentLinks) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The side of the first line of the range for a multi-line comment."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -74832,11 +70281,6 @@ pub enum PullRequestReviewCommentSide {
     Left,
     #[serde(rename = "RIGHT")]
     Right,
-}
-impl ::std::convert::From<&Self> for PullRequestReviewCommentSide {
-    fn from(value: &PullRequestReviewCommentSide) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestReviewCommentSide {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -74911,11 +70355,6 @@ pub enum PullRequestReviewCommentStartSide {
     Left,
     #[serde(rename = "RIGHT")]
     Right,
-}
-impl ::std::convert::From<&Self> for PullRequestReviewCommentStartSide {
-    fn from(value: &PullRequestReviewCommentStartSide) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestReviewCommentStartSide {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -75091,11 +70530,6 @@ pub struct PullRequestReviewDismissed {
     pub review: PullRequestReviewDismissedReview,
     pub sender: User,
 }
-impl ::std::convert::From<&PullRequestReviewDismissed> for PullRequestReviewDismissed {
-    fn from(value: &PullRequestReviewDismissed) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReviewDismissedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -75124,11 +70558,6 @@ impl ::std::convert::From<&PullRequestReviewDismissed> for PullRequestReviewDism
 pub enum PullRequestReviewDismissedAction {
     #[serde(rename = "dismissed")]
     Dismissed,
-}
-impl ::std::convert::From<&Self> for PullRequestReviewDismissedAction {
-    fn from(value: &PullRequestReviewDismissedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestReviewDismissedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -75272,11 +70701,6 @@ pub struct PullRequestReviewDismissedReview {
     pub submitted_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub user: User,
 }
-impl ::std::convert::From<&PullRequestReviewDismissedReview> for PullRequestReviewDismissedReview {
-    fn from(value: &PullRequestReviewDismissedReview) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReviewDismissedReviewLinks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -75306,13 +70730,6 @@ pub struct PullRequestReviewDismissedReviewLinks {
     pub html: Link,
     pub pull_request: Link,
 }
-impl ::std::convert::From<&PullRequestReviewDismissedReviewLinks>
-    for PullRequestReviewDismissedReviewLinks
-{
-    fn from(value: &PullRequestReviewDismissedReviewLinks) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReviewDismissedReviewState`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -75341,11 +70758,6 @@ impl ::std::convert::From<&PullRequestReviewDismissedReviewLinks>
 pub enum PullRequestReviewDismissedReviewState {
     #[serde(rename = "dismissed")]
     Dismissed,
-}
-impl ::std::convert::From<&Self> for PullRequestReviewDismissedReviewState {
-    fn from(value: &PullRequestReviewDismissedReviewState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestReviewDismissedReviewState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -75537,11 +70949,6 @@ pub struct PullRequestReviewEdited {
     pub review: PullRequestReviewEditedReview,
     pub sender: User,
 }
-impl ::std::convert::From<&PullRequestReviewEdited> for PullRequestReviewEdited {
-    fn from(value: &PullRequestReviewEdited) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReviewEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -75570,11 +70977,6 @@ impl ::std::convert::From<&PullRequestReviewEdited> for PullRequestReviewEdited 
 pub enum PullRequestReviewEditedAction {
     #[serde(rename = "edited")]
     Edited,
-}
-impl ::std::convert::From<&Self> for PullRequestReviewEditedAction {
-    fn from(value: &PullRequestReviewEditedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestReviewEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -75646,11 +71048,6 @@ pub struct PullRequestReviewEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub body: ::std::option::Option<PullRequestReviewEditedChangesBody>,
 }
-impl ::std::convert::From<&PullRequestReviewEditedChanges> for PullRequestReviewEditedChanges {
-    fn from(value: &PullRequestReviewEditedChanges) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for PullRequestReviewEditedChanges {
     fn default() -> Self {
         Self {
@@ -75683,13 +71080,6 @@ impl ::std::default::Default for PullRequestReviewEditedChanges {
 pub struct PullRequestReviewEditedChangesBody {
     #[doc = "The previous version of the body if the action was `edited`."]
     pub from: ::std::string::String,
-}
-impl ::std::convert::From<&PullRequestReviewEditedChangesBody>
-    for PullRequestReviewEditedChangesBody
-{
-    fn from(value: &PullRequestReviewEditedChangesBody) -> Self {
-        value.clone()
-    }
 }
 #[doc = "The review that was affected."]
 #[doc = r""]
@@ -75792,11 +71182,6 @@ pub struct PullRequestReviewEditedReview {
     pub submitted_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub user: User,
 }
-impl ::std::convert::From<&PullRequestReviewEditedReview> for PullRequestReviewEditedReview {
-    fn from(value: &PullRequestReviewEditedReview) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReviewEditedReviewLinks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -75826,13 +71211,6 @@ pub struct PullRequestReviewEditedReviewLinks {
     pub html: Link,
     pub pull_request: Link,
 }
-impl ::std::convert::From<&PullRequestReviewEditedReviewLinks>
-    for PullRequestReviewEditedReviewLinks
-{
-    fn from(value: &PullRequestReviewEditedReviewLinks) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReviewEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -75859,11 +71237,6 @@ pub enum PullRequestReviewEvent {
     Dismissed(PullRequestReviewDismissed),
     Edited(PullRequestReviewEdited),
     Submitted(PullRequestReviewSubmitted),
-}
-impl ::std::convert::From<&Self> for PullRequestReviewEvent {
-    fn from(value: &PullRequestReviewEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<PullRequestReviewDismissed> for PullRequestReviewEvent {
     fn from(value: PullRequestReviewDismissed) -> Self {
@@ -76007,11 +71380,6 @@ pub enum PullRequestReviewRequestRemoved {
         sender: User,
     },
 }
-impl ::std::convert::From<&Self> for PullRequestReviewRequestRemoved {
-    fn from(value: &PullRequestReviewRequestRemoved) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReviewRequestRemovedVariant0Action`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -76040,11 +71408,6 @@ impl ::std::convert::From<&Self> for PullRequestReviewRequestRemoved {
 pub enum PullRequestReviewRequestRemovedVariant0Action {
     #[serde(rename = "review_request_removed")]
     ReviewRequestRemoved,
-}
-impl ::std::convert::From<&Self> for PullRequestReviewRequestRemovedVariant0Action {
-    fn from(value: &PullRequestReviewRequestRemovedVariant0Action) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestReviewRequestRemovedVariant0Action {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -76116,11 +71479,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum PullRequestReviewRequestRemovedVariant1Action {
     #[serde(rename = "review_request_removed")]
     ReviewRequestRemoved,
-}
-impl ::std::convert::From<&Self> for PullRequestReviewRequestRemovedVariant1Action {
-    fn from(value: &PullRequestReviewRequestRemovedVariant1Action) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestReviewRequestRemovedVariant1Action {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -76291,11 +71649,6 @@ pub enum PullRequestReviewRequested {
         sender: User,
     },
 }
-impl ::std::convert::From<&Self> for PullRequestReviewRequested {
-    fn from(value: &PullRequestReviewRequested) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReviewRequestedVariant0Action`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -76324,11 +71677,6 @@ impl ::std::convert::From<&Self> for PullRequestReviewRequested {
 pub enum PullRequestReviewRequestedVariant0Action {
     #[serde(rename = "review_requested")]
     ReviewRequested,
-}
-impl ::std::convert::From<&Self> for PullRequestReviewRequestedVariant0Action {
-    fn from(value: &PullRequestReviewRequestedVariant0Action) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestReviewRequestedVariant0Action {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -76396,11 +71744,6 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReviewRequest
 pub enum PullRequestReviewRequestedVariant1Action {
     #[serde(rename = "review_requested")]
     ReviewRequested,
-}
-impl ::std::convert::From<&Self> for PullRequestReviewRequestedVariant1Action {
-    fn from(value: &PullRequestReviewRequestedVariant1Action) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestReviewRequestedVariant1Action {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -76571,11 +71914,6 @@ pub struct PullRequestReviewSubmitted {
     pub review: PullRequestReviewSubmittedReview,
     pub sender: User,
 }
-impl ::std::convert::From<&PullRequestReviewSubmitted> for PullRequestReviewSubmitted {
-    fn from(value: &PullRequestReviewSubmitted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReviewSubmittedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -76604,11 +71942,6 @@ impl ::std::convert::From<&PullRequestReviewSubmitted> for PullRequestReviewSubm
 pub enum PullRequestReviewSubmittedAction {
     #[serde(rename = "submitted")]
     Submitted,
-}
-impl ::std::convert::From<&Self> for PullRequestReviewSubmittedAction {
-    fn from(value: &PullRequestReviewSubmittedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestReviewSubmittedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -76749,11 +72082,6 @@ pub struct PullRequestReviewSubmittedReview {
     pub submitted_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub user: User,
 }
-impl ::std::convert::From<&PullRequestReviewSubmittedReview> for PullRequestReviewSubmittedReview {
-    fn from(value: &PullRequestReviewSubmittedReview) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestReviewSubmittedReviewLinks`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -76782,13 +72110,6 @@ impl ::std::convert::From<&PullRequestReviewSubmittedReview> for PullRequestRevi
 pub struct PullRequestReviewSubmittedReviewLinks {
     pub html: Link,
     pub pull_request: Link,
-}
-impl ::std::convert::From<&PullRequestReviewSubmittedReviewLinks>
-    for PullRequestReviewSubmittedReviewLinks
-{
-    fn from(value: &PullRequestReviewSubmittedReviewLinks) -> Self {
-        value.clone()
-    }
 }
 #[doc = "State of this Pull Request. Either `open` or `closed`."]
 #[doc = r""]
@@ -76822,11 +72143,6 @@ pub enum PullRequestState {
     Open,
     #[serde(rename = "closed")]
     Closed,
-}
-impl ::std::convert::From<&Self> for PullRequestState {
-    fn from(value: &PullRequestState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -76939,11 +72255,6 @@ pub struct PullRequestSynchronize {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&PullRequestSynchronize> for PullRequestSynchronize {
-    fn from(value: &PullRequestSynchronize) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestSynchronizeAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -76972,11 +72283,6 @@ impl ::std::convert::From<&PullRequestSynchronize> for PullRequestSynchronize {
 pub enum PullRequestSynchronizeAction {
     #[serde(rename = "synchronize")]
     Synchronize,
-}
-impl ::std::convert::From<&Self> for PullRequestSynchronizeAction {
-    fn from(value: &PullRequestSynchronizeAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestSynchronizeAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -77082,11 +72388,6 @@ pub struct PullRequestUnassigned {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&PullRequestUnassigned> for PullRequestUnassigned {
-    fn from(value: &PullRequestUnassigned) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestUnassignedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -77115,11 +72416,6 @@ impl ::std::convert::From<&PullRequestUnassigned> for PullRequestUnassigned {
 pub enum PullRequestUnassignedAction {
     #[serde(rename = "unassigned")]
     Unassigned,
-}
-impl ::std::convert::From<&Self> for PullRequestUnassignedAction {
-    fn from(value: &PullRequestUnassignedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestUnassignedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -77225,11 +72521,6 @@ pub struct PullRequestUnlabeled {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&PullRequestUnlabeled> for PullRequestUnlabeled {
-    fn from(value: &PullRequestUnlabeled) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestUnlabeledAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -77258,11 +72549,6 @@ impl ::std::convert::From<&PullRequestUnlabeled> for PullRequestUnlabeled {
 pub enum PullRequestUnlabeledAction {
     #[serde(rename = "unlabeled")]
     Unlabeled,
-}
-impl ::std::convert::From<&Self> for PullRequestUnlabeledAction {
-    fn from(value: &PullRequestUnlabeledAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestUnlabeledAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -77363,11 +72649,6 @@ pub struct PullRequestUnlocked {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&PullRequestUnlocked> for PullRequestUnlocked {
-    fn from(value: &PullRequestUnlocked) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PullRequestUnlockedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -77396,11 +72677,6 @@ impl ::std::convert::From<&PullRequestUnlocked> for PullRequestUnlocked {
 pub enum PullRequestUnlockedAction {
     #[serde(rename = "unlocked")]
     Unlocked,
-}
-impl ::std::convert::From<&Self> for PullRequestUnlockedAction {
-    fn from(value: &PullRequestUnlockedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PullRequestUnlockedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -77558,11 +72834,6 @@ pub struct PushEvent {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&PushEvent> for PushEvent {
-    fn from(value: &PushEvent) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The [release](https://docs.github.com/en/rest/reference/repos/#get-a-release) object."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -77706,11 +72977,6 @@ pub struct Release {
     pub url: ::std::string::String,
     pub zipball_url: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&Release> for Release {
-    fn from(value: &Release) -> Self {
-        value.clone()
-    }
-}
 #[doc = "Data related to a release."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -77812,11 +73078,6 @@ pub struct ReleaseAsset {
     pub uploader: ::std::option::Option<User>,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&ReleaseAsset> for ReleaseAsset {
-    fn from(value: &ReleaseAsset) -> Self {
-        value.clone()
-    }
-}
 #[doc = "State of the release asset."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -77846,11 +73107,6 @@ impl ::std::convert::From<&ReleaseAsset> for ReleaseAsset {
 pub enum ReleaseAssetState {
     #[serde(rename = "uploaded")]
     Uploaded,
-}
-impl ::std::convert::From<&Self> for ReleaseAssetState {
-    fn from(value: &ReleaseAssetState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ReleaseAssetState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -77944,11 +73200,6 @@ pub struct ReleaseCreated {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&ReleaseCreated> for ReleaseCreated {
-    fn from(value: &ReleaseCreated) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ReleaseCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -77977,11 +73228,6 @@ impl ::std::convert::From<&ReleaseCreated> for ReleaseCreated {
 pub enum ReleaseCreatedAction {
     #[serde(rename = "created")]
     Created,
-}
-impl ::std::convert::From<&Self> for ReleaseCreatedAction {
-    fn from(value: &ReleaseCreatedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ReleaseCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -78075,11 +73321,6 @@ pub struct ReleaseDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&ReleaseDeleted> for ReleaseDeleted {
-    fn from(value: &ReleaseDeleted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ReleaseDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -78108,11 +73349,6 @@ impl ::std::convert::From<&ReleaseDeleted> for ReleaseDeleted {
 pub enum ReleaseDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
-}
-impl ::std::convert::From<&Self> for ReleaseDeletedAction {
-    fn from(value: &ReleaseDeletedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ReleaseDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -78240,11 +73476,6 @@ pub struct ReleaseEdited {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&ReleaseEdited> for ReleaseEdited {
-    fn from(value: &ReleaseEdited) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ReleaseEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -78273,11 +73504,6 @@ impl ::std::convert::From<&ReleaseEdited> for ReleaseEdited {
 pub enum ReleaseEditedAction {
     #[serde(rename = "edited")]
     Edited,
-}
-impl ::std::convert::From<&Self> for ReleaseEditedAction {
-    fn from(value: &ReleaseEditedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ReleaseEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -78364,11 +73590,6 @@ pub struct ReleaseEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<ReleaseEditedChangesName>,
 }
-impl ::std::convert::From<&ReleaseEditedChanges> for ReleaseEditedChanges {
-    fn from(value: &ReleaseEditedChanges) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for ReleaseEditedChanges {
     fn default() -> Self {
         Self {
@@ -78403,11 +73624,6 @@ pub struct ReleaseEditedChangesBody {
     #[doc = "The previous version of the body if the action was `edited`."]
     pub from: ::std::string::String,
 }
-impl ::std::convert::From<&ReleaseEditedChangesBody> for ReleaseEditedChangesBody {
-    fn from(value: &ReleaseEditedChangesBody) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ReleaseEditedChangesName`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -78433,11 +73649,6 @@ impl ::std::convert::From<&ReleaseEditedChangesBody> for ReleaseEditedChangesBod
 pub struct ReleaseEditedChangesName {
     #[doc = "The previous version of the name if the action was `edited`."]
     pub from: ::std::string::String,
-}
-impl ::std::convert::From<&ReleaseEditedChangesName> for ReleaseEditedChangesName {
-    fn from(value: &ReleaseEditedChangesName) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`ReleaseEvent`"]
 #[doc = r""]
@@ -78481,11 +73692,6 @@ pub enum ReleaseEvent {
     Published(ReleasePublished),
     Released(ReleaseReleased),
     Unpublished(ReleaseUnpublished),
-}
-impl ::std::convert::From<&Self> for ReleaseEvent {
-    fn from(value: &ReleaseEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ReleaseCreated> for ReleaseEvent {
     fn from(value: ReleaseCreated) -> Self {
@@ -78596,11 +73802,6 @@ pub struct ReleasePrereleased {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&ReleasePrereleased> for ReleasePrereleased {
-    fn from(value: &ReleasePrereleased) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ReleasePrereleasedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -78629,11 +73830,6 @@ impl ::std::convert::From<&ReleasePrereleased> for ReleasePrereleased {
 pub enum ReleasePrereleasedAction {
     #[serde(rename = "prereleased")]
     Prereleased,
-}
-impl ::std::convert::From<&Self> for ReleasePrereleasedAction {
-    fn from(value: &ReleasePrereleasedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ReleasePrereleasedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -78728,11 +73924,6 @@ pub struct ReleasePrereleasedRelease {
     pub url: ::std::string::String,
     pub zipball_url: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&ReleasePrereleasedRelease> for ReleasePrereleasedRelease {
-    fn from(value: &ReleasePrereleasedRelease) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ReleasePublished`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -78804,11 +73995,6 @@ pub struct ReleasePublished {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&ReleasePublished> for ReleasePublished {
-    fn from(value: &ReleasePublished) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ReleasePublishedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -78837,11 +74023,6 @@ impl ::std::convert::From<&ReleasePublished> for ReleasePublished {
 pub enum ReleasePublishedAction {
     #[serde(rename = "published")]
     Published,
-}
-impl ::std::convert::From<&Self> for ReleasePublishedAction {
-    fn from(value: &ReleasePublishedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ReleasePublishedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -78934,11 +74115,6 @@ pub struct ReleasePublishedRelease {
     pub url: ::std::string::String,
     pub zipball_url: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&ReleasePublishedRelease> for ReleasePublishedRelease {
-    fn from(value: &ReleasePublishedRelease) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ReleaseReleased`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -78993,11 +74169,6 @@ pub struct ReleaseReleased {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&ReleaseReleased> for ReleaseReleased {
-    fn from(value: &ReleaseReleased) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ReleaseReleasedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -79026,11 +74197,6 @@ impl ::std::convert::From<&ReleaseReleased> for ReleaseReleased {
 pub enum ReleaseReleasedAction {
     #[serde(rename = "released")]
     Released,
-}
-impl ::std::convert::From<&Self> for ReleaseReleasedAction {
-    fn from(value: &ReleaseReleasedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ReleaseReleasedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -79140,11 +74306,6 @@ pub struct ReleaseUnpublished {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&ReleaseUnpublished> for ReleaseUnpublished {
-    fn from(value: &ReleaseUnpublished) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ReleaseUnpublishedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -79173,11 +74334,6 @@ impl ::std::convert::From<&ReleaseUnpublished> for ReleaseUnpublished {
 pub enum ReleaseUnpublishedAction {
     #[serde(rename = "unpublished")]
     Unpublished,
-}
-impl ::std::convert::From<&Self> for ReleaseUnpublishedAction {
-    fn from(value: &ReleaseUnpublishedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ReleaseUnpublishedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -79269,11 +74425,6 @@ pub struct ReleaseUnpublishedRelease {
     pub url: ::std::string::String,
     pub zipball_url: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&ReleaseUnpublishedRelease> for ReleaseUnpublishedRelease {
-    fn from(value: &ReleaseUnpublishedRelease) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepoRef`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -79310,11 +74461,6 @@ pub struct RepoRef {
     pub id: i64,
     pub name: ::std::string::String,
     pub url: ::std::string::String,
-}
-impl ::std::convert::From<&RepoRef> for RepoRef {
-    fn from(value: &RepoRef) -> Self {
-        value.clone()
-    }
 }
 #[doc = "A git repository"]
 #[doc = r""]
@@ -79904,11 +75050,6 @@ pub struct Repository {
     pub watchers: i64,
     pub watchers_count: i64,
 }
-impl ::std::convert::From<&Repository> for Repository {
-    fn from(value: &Repository) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryArchived`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -79979,11 +75120,6 @@ pub struct RepositoryArchived {
     pub repository: RepositoryArchivedRepository,
     pub sender: User,
 }
-impl ::std::convert::From<&RepositoryArchived> for RepositoryArchived {
-    fn from(value: &RepositoryArchived) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryArchivedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -80012,11 +75148,6 @@ impl ::std::convert::From<&RepositoryArchived> for RepositoryArchived {
 pub enum RepositoryArchivedAction {
     #[serde(rename = "archived")]
     Archived,
-}
-impl ::std::convert::From<&Self> for RepositoryArchivedAction {
-    fn from(value: &RepositoryArchivedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for RepositoryArchivedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -80202,11 +75333,6 @@ pub struct RepositoryArchivedRepository {
     pub watchers: i64,
     pub watchers_count: i64,
 }
-impl ::std::convert::From<&RepositoryArchivedRepository> for RepositoryArchivedRepository {
-    fn from(value: &RepositoryArchivedRepository) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryArchivedRepositoryCreatedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -80230,11 +75356,6 @@ impl ::std::convert::From<&RepositoryArchivedRepository> for RepositoryArchivedR
 pub enum RepositoryArchivedRepositoryCreatedAt {
     Integer(i64),
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
-}
-impl ::std::convert::From<&Self> for RepositoryArchivedRepositoryCreatedAt {
-    fn from(value: &RepositoryArchivedRepositoryCreatedAt) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for RepositoryArchivedRepositoryCreatedAt {
     type Err = self::error::ConversionError;
@@ -80334,13 +75455,6 @@ pub struct RepositoryArchivedRepositoryPermissions {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub triage: ::std::option::Option<bool>,
 }
-impl ::std::convert::From<&RepositoryArchivedRepositoryPermissions>
-    for RepositoryArchivedRepositoryPermissions
-{
-    fn from(value: &RepositoryArchivedRepositoryPermissions) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryArchivedRepositoryPushedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -80368,11 +75482,6 @@ pub enum RepositoryArchivedRepositoryPushedAt {
     Integer(i64),
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
     Null,
-}
-impl ::std::convert::From<&Self> for RepositoryArchivedRepositoryPushedAt {
-    fn from(value: &RepositoryArchivedRepositoryPushedAt) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<i64> for RepositoryArchivedRepositoryPushedAt {
     fn from(value: i64) -> Self {
@@ -80435,11 +75544,6 @@ pub struct RepositoryCreated {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&RepositoryCreated> for RepositoryCreated {
-    fn from(value: &RepositoryCreated) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -80468,11 +75572,6 @@ impl ::std::convert::From<&RepositoryCreated> for RepositoryCreated {
 pub enum RepositoryCreatedAction {
     #[serde(rename = "created")]
     Created,
-}
-impl ::std::convert::From<&Self> for RepositoryCreatedAction {
-    fn from(value: &RepositoryCreatedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for RepositoryCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -80535,11 +75634,6 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryCreatedAction 
 pub enum RepositoryCreatedAt {
     Integer(i64),
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
-}
-impl ::std::convert::From<&Self> for RepositoryCreatedAt {
-    fn from(value: &RepositoryCreatedAt) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for RepositoryCreatedAt {
     type Err = self::error::ConversionError;
@@ -80642,11 +75736,6 @@ pub struct RepositoryDeleted {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&RepositoryDeleted> for RepositoryDeleted {
-    fn from(value: &RepositoryDeleted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -80675,11 +75764,6 @@ impl ::std::convert::From<&RepositoryDeleted> for RepositoryDeleted {
 pub enum RepositoryDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
-}
-impl ::std::convert::From<&Self> for RepositoryDeletedAction {
-    fn from(value: &RepositoryDeletedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for RepositoryDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -80747,11 +75831,6 @@ impl ::std::convert::From<RepositoryDispatchEvent> for RepositoryDispatchOnDeman
         value.0
     }
 }
-impl ::std::convert::From<&RepositoryDispatchEvent> for RepositoryDispatchEvent {
-    fn from(value: &RepositoryDispatchEvent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<RepositoryDispatchOnDemandTest> for RepositoryDispatchEvent {
     fn from(value: RepositoryDispatchOnDemandTest) -> Self {
         Self(value)
@@ -80817,11 +75896,6 @@ pub struct RepositoryDispatchOnDemandTest {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&RepositoryDispatchOnDemandTest> for RepositoryDispatchOnDemandTest {
-    fn from(value: &RepositoryDispatchOnDemandTest) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryDispatchOnDemandTestAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -80850,11 +75924,6 @@ impl ::std::convert::From<&RepositoryDispatchOnDemandTest> for RepositoryDispatc
 pub enum RepositoryDispatchOnDemandTestAction {
     #[serde(rename = "on-demand-test")]
     OnDemandTest,
-}
-impl ::std::convert::From<&Self> for RepositoryDispatchOnDemandTestAction {
-    fn from(value: &RepositoryDispatchOnDemandTestAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for RepositoryDispatchOnDemandTestAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -80993,11 +76062,6 @@ pub struct RepositoryEdited {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&RepositoryEdited> for RepositoryEdited {
-    fn from(value: &RepositoryEdited) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -81026,11 +76090,6 @@ impl ::std::convert::From<&RepositoryEdited> for RepositoryEdited {
 pub enum RepositoryEditedAction {
     #[serde(rename = "edited")]
     Edited,
-}
-impl ::std::convert::From<&Self> for RepositoryEditedAction {
-    fn from(value: &RepositoryEditedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for RepositoryEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -81135,11 +76194,6 @@ pub struct RepositoryEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub homepage: ::std::option::Option<RepositoryEditedChangesHomepage>,
 }
-impl ::std::convert::From<&RepositoryEditedChanges> for RepositoryEditedChanges {
-    fn from(value: &RepositoryEditedChanges) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for RepositoryEditedChanges {
     fn default() -> Self {
         Self {
@@ -81173,13 +76227,6 @@ impl ::std::default::Default for RepositoryEditedChanges {
 pub struct RepositoryEditedChangesDefaultBranch {
     pub from: ::std::string::String,
 }
-impl ::std::convert::From<&RepositoryEditedChangesDefaultBranch>
-    for RepositoryEditedChangesDefaultBranch
-{
-    fn from(value: &RepositoryEditedChangesDefaultBranch) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryEditedChangesDescription`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -81207,13 +76254,6 @@ impl ::std::convert::From<&RepositoryEditedChangesDefaultBranch>
 pub struct RepositoryEditedChangesDescription {
     pub from: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&RepositoryEditedChangesDescription>
-    for RepositoryEditedChangesDescription
-{
-    fn from(value: &RepositoryEditedChangesDescription) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryEditedChangesHomepage`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -81240,11 +76280,6 @@ impl ::std::convert::From<&RepositoryEditedChangesDescription>
 #[serde(deny_unknown_fields)]
 pub struct RepositoryEditedChangesHomepage {
     pub from: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&RepositoryEditedChangesHomepage> for RepositoryEditedChangesHomepage {
-    fn from(value: &RepositoryEditedChangesHomepage) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`RepositoryEvent`"]
 #[doc = r""]
@@ -81296,11 +76331,6 @@ pub enum RepositoryEvent {
     Renamed(RepositoryRenamed),
     Transferred(RepositoryTransferred),
     Unarchived(RepositoryUnarchived),
-}
-impl ::std::convert::From<&Self> for RepositoryEvent {
-    fn from(value: &RepositoryEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<RepositoryArchived> for RepositoryEvent {
     fn from(value: RepositoryArchived) -> Self {
@@ -81398,11 +76428,6 @@ pub struct RepositoryImportEvent {
     pub sender: User,
     pub status: RepositoryImportEventStatus,
 }
-impl ::std::convert::From<&RepositoryImportEvent> for RepositoryImportEvent {
-    fn from(value: &RepositoryImportEvent) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryImportEventStatus`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -81437,11 +76462,6 @@ pub enum RepositoryImportEventStatus {
     Cancelled,
     #[serde(rename = "failure")]
     Failure,
-}
-impl ::std::convert::From<&Self> for RepositoryImportEventStatus {
-    fn from(value: &RepositoryImportEventStatus) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for RepositoryImportEventStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -81783,11 +76803,6 @@ pub struct RepositoryLite {
     pub trees_url: ::std::string::String,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&RepositoryLite> for RepositoryLite {
-    fn from(value: &RepositoryLite) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryPermissions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -81831,11 +76846,6 @@ pub struct RepositoryPermissions {
     pub push: bool,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub triage: ::std::option::Option<bool>,
-}
-impl ::std::convert::From<&RepositoryPermissions> for RepositoryPermissions {
-    fn from(value: &RepositoryPermissions) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`RepositoryPrivatized`"]
 #[doc = r""]
@@ -81906,11 +76916,6 @@ pub struct RepositoryPrivatized {
     pub repository: RepositoryPrivatizedRepository,
     pub sender: User,
 }
-impl ::std::convert::From<&RepositoryPrivatized> for RepositoryPrivatized {
-    fn from(value: &RepositoryPrivatized) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryPrivatizedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -81939,11 +76944,6 @@ impl ::std::convert::From<&RepositoryPrivatized> for RepositoryPrivatized {
 pub enum RepositoryPrivatizedAction {
     #[serde(rename = "privatized")]
     Privatized,
-}
-impl ::std::convert::From<&Self> for RepositoryPrivatizedAction {
-    fn from(value: &RepositoryPrivatizedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for RepositoryPrivatizedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -82128,11 +77128,6 @@ pub struct RepositoryPrivatizedRepository {
     pub watchers: i64,
     pub watchers_count: i64,
 }
-impl ::std::convert::From<&RepositoryPrivatizedRepository> for RepositoryPrivatizedRepository {
-    fn from(value: &RepositoryPrivatizedRepository) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryPrivatizedRepositoryCreatedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -82156,11 +77151,6 @@ impl ::std::convert::From<&RepositoryPrivatizedRepository> for RepositoryPrivati
 pub enum RepositoryPrivatizedRepositoryCreatedAt {
     Integer(i64),
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
-}
-impl ::std::convert::From<&Self> for RepositoryPrivatizedRepositoryCreatedAt {
-    fn from(value: &RepositoryPrivatizedRepositoryCreatedAt) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for RepositoryPrivatizedRepositoryCreatedAt {
     type Err = self::error::ConversionError;
@@ -82260,13 +77250,6 @@ pub struct RepositoryPrivatizedRepositoryPermissions {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub triage: ::std::option::Option<bool>,
 }
-impl ::std::convert::From<&RepositoryPrivatizedRepositoryPermissions>
-    for RepositoryPrivatizedRepositoryPermissions
-{
-    fn from(value: &RepositoryPrivatizedRepositoryPermissions) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryPrivatizedRepositoryPushedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -82294,11 +77277,6 @@ pub enum RepositoryPrivatizedRepositoryPushedAt {
     Integer(i64),
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
     Null,
-}
-impl ::std::convert::From<&Self> for RepositoryPrivatizedRepositoryPushedAt {
-    fn from(value: &RepositoryPrivatizedRepositoryPushedAt) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<i64> for RepositoryPrivatizedRepositoryPushedAt {
     fn from(value: i64) -> Self {
@@ -82381,11 +77359,6 @@ pub struct RepositoryPublicized {
     pub repository: RepositoryPublicizedRepository,
     pub sender: User,
 }
-impl ::std::convert::From<&RepositoryPublicized> for RepositoryPublicized {
-    fn from(value: &RepositoryPublicized) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryPublicizedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -82414,11 +77387,6 @@ impl ::std::convert::From<&RepositoryPublicized> for RepositoryPublicized {
 pub enum RepositoryPublicizedAction {
     #[serde(rename = "publicized")]
     Publicized,
-}
-impl ::std::convert::From<&Self> for RepositoryPublicizedAction {
-    fn from(value: &RepositoryPublicizedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for RepositoryPublicizedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -82603,11 +77571,6 @@ pub struct RepositoryPublicizedRepository {
     pub watchers: i64,
     pub watchers_count: i64,
 }
-impl ::std::convert::From<&RepositoryPublicizedRepository> for RepositoryPublicizedRepository {
-    fn from(value: &RepositoryPublicizedRepository) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryPublicizedRepositoryCreatedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -82631,11 +77594,6 @@ impl ::std::convert::From<&RepositoryPublicizedRepository> for RepositoryPublici
 pub enum RepositoryPublicizedRepositoryCreatedAt {
     Integer(i64),
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
-}
-impl ::std::convert::From<&Self> for RepositoryPublicizedRepositoryCreatedAt {
-    fn from(value: &RepositoryPublicizedRepositoryCreatedAt) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for RepositoryPublicizedRepositoryCreatedAt {
     type Err = self::error::ConversionError;
@@ -82735,13 +77693,6 @@ pub struct RepositoryPublicizedRepositoryPermissions {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub triage: ::std::option::Option<bool>,
 }
-impl ::std::convert::From<&RepositoryPublicizedRepositoryPermissions>
-    for RepositoryPublicizedRepositoryPermissions
-{
-    fn from(value: &RepositoryPublicizedRepositoryPermissions) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryPublicizedRepositoryPushedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -82769,11 +77720,6 @@ pub enum RepositoryPublicizedRepositoryPushedAt {
     Integer(i64),
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
     Null,
-}
-impl ::std::convert::From<&Self> for RepositoryPublicizedRepositoryPushedAt {
-    fn from(value: &RepositoryPublicizedRepositoryPushedAt) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<i64> for RepositoryPublicizedRepositoryPushedAt {
     fn from(value: i64) -> Self {
@@ -82814,11 +77760,6 @@ pub enum RepositoryPushedAt {
     Integer(i64),
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
     Null,
-}
-impl ::std::convert::From<&Self> for RepositoryPushedAt {
-    fn from(value: &RepositoryPushedAt) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<i64> for RepositoryPushedAt {
     fn from(value: i64) -> Self {
@@ -82911,11 +77852,6 @@ pub struct RepositoryRenamed {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&RepositoryRenamed> for RepositoryRenamed {
-    fn from(value: &RepositoryRenamed) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryRenamedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -82944,11 +77880,6 @@ impl ::std::convert::From<&RepositoryRenamed> for RepositoryRenamed {
 pub enum RepositoryRenamedAction {
     #[serde(rename = "renamed")]
     Renamed,
-}
-impl ::std::convert::From<&Self> for RepositoryRenamedAction {
-    fn from(value: &RepositoryRenamedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for RepositoryRenamedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -83030,11 +77961,6 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryRenamedAction 
 pub struct RepositoryRenamedChanges {
     pub repository: RepositoryRenamedChangesRepository,
 }
-impl ::std::convert::From<&RepositoryRenamedChanges> for RepositoryRenamedChanges {
-    fn from(value: &RepositoryRenamedChanges) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryRenamedChangesRepository`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -83068,13 +77994,6 @@ impl ::std::convert::From<&RepositoryRenamedChanges> for RepositoryRenamedChange
 pub struct RepositoryRenamedChangesRepository {
     pub name: RepositoryRenamedChangesRepositoryName,
 }
-impl ::std::convert::From<&RepositoryRenamedChangesRepository>
-    for RepositoryRenamedChangesRepository
-{
-    fn from(value: &RepositoryRenamedChangesRepository) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryRenamedChangesRepositoryName`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -83098,13 +78017,6 @@ impl ::std::convert::From<&RepositoryRenamedChangesRepository>
 #[serde(deny_unknown_fields)]
 pub struct RepositoryRenamedChangesRepositoryName {
     pub from: ::std::string::String,
-}
-impl ::std::convert::From<&RepositoryRenamedChangesRepositoryName>
-    for RepositoryRenamedChangesRepositoryName
-{
-    fn from(value: &RepositoryRenamedChangesRepositoryName) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`RepositoryTransferred`"]
 #[doc = r""]
@@ -83184,11 +78096,6 @@ pub struct RepositoryTransferred {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&RepositoryTransferred> for RepositoryTransferred {
-    fn from(value: &RepositoryTransferred) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryTransferredAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -83217,11 +78124,6 @@ impl ::std::convert::From<&RepositoryTransferred> for RepositoryTransferred {
 pub enum RepositoryTransferredAction {
     #[serde(rename = "transferred")]
     Transferred,
-}
-impl ::std::convert::From<&Self> for RepositoryTransferredAction {
-    fn from(value: &RepositoryTransferredAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for RepositoryTransferredAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -83300,11 +78202,6 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryTransferredAct
 pub struct RepositoryTransferredChanges {
     pub owner: RepositoryTransferredChangesOwner,
 }
-impl ::std::convert::From<&RepositoryTransferredChanges> for RepositoryTransferredChanges {
-    fn from(value: &RepositoryTransferredChanges) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryTransferredChangesOwner`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -83335,13 +78232,6 @@ impl ::std::convert::From<&RepositoryTransferredChanges> for RepositoryTransferr
 pub struct RepositoryTransferredChangesOwner {
     pub from: RepositoryTransferredChangesOwnerFrom,
 }
-impl ::std::convert::From<&RepositoryTransferredChangesOwner>
-    for RepositoryTransferredChangesOwner
-{
-    fn from(value: &RepositoryTransferredChangesOwner) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryTransferredChangesOwnerFrom`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -83363,13 +78253,6 @@ impl ::std::convert::From<&RepositoryTransferredChangesOwner>
 pub struct RepositoryTransferredChangesOwnerFrom {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub user: ::std::option::Option<User>,
-}
-impl ::std::convert::From<&RepositoryTransferredChangesOwnerFrom>
-    for RepositoryTransferredChangesOwnerFrom
-{
-    fn from(value: &RepositoryTransferredChangesOwnerFrom) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for RepositoryTransferredChangesOwnerFrom {
     fn default() -> Self {
@@ -83448,11 +78331,6 @@ pub struct RepositoryUnarchived {
     pub repository: RepositoryUnarchivedRepository,
     pub sender: User,
 }
-impl ::std::convert::From<&RepositoryUnarchived> for RepositoryUnarchived {
-    fn from(value: &RepositoryUnarchived) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryUnarchivedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -83481,11 +78359,6 @@ impl ::std::convert::From<&RepositoryUnarchived> for RepositoryUnarchived {
 pub enum RepositoryUnarchivedAction {
     #[serde(rename = "unarchived")]
     Unarchived,
-}
-impl ::std::convert::From<&Self> for RepositoryUnarchivedAction {
-    fn from(value: &RepositoryUnarchivedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for RepositoryUnarchivedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -83671,11 +78544,6 @@ pub struct RepositoryUnarchivedRepository {
     pub watchers: i64,
     pub watchers_count: i64,
 }
-impl ::std::convert::From<&RepositoryUnarchivedRepository> for RepositoryUnarchivedRepository {
-    fn from(value: &RepositoryUnarchivedRepository) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryUnarchivedRepositoryCreatedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -83699,11 +78567,6 @@ impl ::std::convert::From<&RepositoryUnarchivedRepository> for RepositoryUnarchi
 pub enum RepositoryUnarchivedRepositoryCreatedAt {
     Integer(i64),
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
-}
-impl ::std::convert::From<&Self> for RepositoryUnarchivedRepositoryCreatedAt {
-    fn from(value: &RepositoryUnarchivedRepositoryCreatedAt) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for RepositoryUnarchivedRepositoryCreatedAt {
     type Err = self::error::ConversionError;
@@ -83803,13 +78666,6 @@ pub struct RepositoryUnarchivedRepositoryPermissions {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub triage: ::std::option::Option<bool>,
 }
-impl ::std::convert::From<&RepositoryUnarchivedRepositoryPermissions>
-    for RepositoryUnarchivedRepositoryPermissions
-{
-    fn from(value: &RepositoryUnarchivedRepositoryPermissions) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryUnarchivedRepositoryPushedAt`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -83837,11 +78693,6 @@ pub enum RepositoryUnarchivedRepositoryPushedAt {
     Integer(i64),
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
     Null,
-}
-impl ::std::convert::From<&Self> for RepositoryUnarchivedRepositoryPushedAt {
-    fn from(value: &RepositoryUnarchivedRepositoryPushedAt) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<i64> for RepositoryUnarchivedRepositoryPushedAt {
     fn from(value: i64) -> Self {
@@ -83953,13 +78804,6 @@ pub struct RepositoryVulnerabilityAlertCreate {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&RepositoryVulnerabilityAlertCreate>
-    for RepositoryVulnerabilityAlertCreate
-{
-    fn from(value: &RepositoryVulnerabilityAlertCreate) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryVulnerabilityAlertCreateAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -83988,11 +78832,6 @@ impl ::std::convert::From<&RepositoryVulnerabilityAlertCreate>
 pub enum RepositoryVulnerabilityAlertCreateAction {
     #[serde(rename = "create")]
     Create,
-}
-impl ::std::convert::From<&Self> for RepositoryVulnerabilityAlertCreateAction {
-    fn from(value: &RepositoryVulnerabilityAlertCreateAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for RepositoryVulnerabilityAlertCreateAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -84113,13 +78952,6 @@ pub struct RepositoryVulnerabilityAlertCreateAlert {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub severity: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&RepositoryVulnerabilityAlertCreateAlert>
-    for RepositoryVulnerabilityAlertCreateAlert
-{
-    fn from(value: &RepositoryVulnerabilityAlertCreateAlert) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryVulnerabilityAlertDismiss`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -84221,13 +79053,6 @@ pub struct RepositoryVulnerabilityAlertDismiss {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&RepositoryVulnerabilityAlertDismiss>
-    for RepositoryVulnerabilityAlertDismiss
-{
-    fn from(value: &RepositoryVulnerabilityAlertDismiss) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryVulnerabilityAlertDismissAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -84256,11 +79081,6 @@ impl ::std::convert::From<&RepositoryVulnerabilityAlertDismiss>
 pub enum RepositoryVulnerabilityAlertDismissAction {
     #[serde(rename = "dismiss")]
     Dismiss,
-}
-impl ::std::convert::From<&Self> for RepositoryVulnerabilityAlertDismissAction {
-    fn from(value: &RepositoryVulnerabilityAlertDismissAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for RepositoryVulnerabilityAlertDismissAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -84381,13 +79201,6 @@ pub struct RepositoryVulnerabilityAlertDismissAlert {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub severity: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&RepositoryVulnerabilityAlertDismissAlert>
-    for RepositoryVulnerabilityAlertDismissAlert
-{
-    fn from(value: &RepositoryVulnerabilityAlertDismissAlert) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryVulnerabilityAlertEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -84414,11 +79227,6 @@ pub enum RepositoryVulnerabilityAlertEvent {
     Create(RepositoryVulnerabilityAlertCreate),
     Dismiss(RepositoryVulnerabilityAlertDismiss),
     Resolve(RepositoryVulnerabilityAlertResolve),
-}
-impl ::std::convert::From<&Self> for RepositoryVulnerabilityAlertEvent {
-    fn from(value: &RepositoryVulnerabilityAlertEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<RepositoryVulnerabilityAlertCreate>
     for RepositoryVulnerabilityAlertEvent
@@ -84539,13 +79347,6 @@ pub struct RepositoryVulnerabilityAlertResolve {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&RepositoryVulnerabilityAlertResolve>
-    for RepositoryVulnerabilityAlertResolve
-{
-    fn from(value: &RepositoryVulnerabilityAlertResolve) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RepositoryVulnerabilityAlertResolveAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -84574,11 +79375,6 @@ impl ::std::convert::From<&RepositoryVulnerabilityAlertResolve>
 pub enum RepositoryVulnerabilityAlertResolveAction {
     #[serde(rename = "resolve")]
     Resolve,
-}
-impl ::std::convert::From<&Self> for RepositoryVulnerabilityAlertResolveAction {
-    fn from(value: &RepositoryVulnerabilityAlertResolveAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for RepositoryVulnerabilityAlertResolveAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -84699,13 +79495,6 @@ pub struct RepositoryVulnerabilityAlertResolveAlert {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub severity: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&RepositoryVulnerabilityAlertResolveAlert>
-    for RepositoryVulnerabilityAlertResolveAlert
-{
-    fn from(value: &RepositoryVulnerabilityAlertResolveAlert) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SecretScanningAlertCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -84781,11 +79570,6 @@ pub struct SecretScanningAlertCreated {
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
 }
-impl ::std::convert::From<&SecretScanningAlertCreated> for SecretScanningAlertCreated {
-    fn from(value: &SecretScanningAlertCreated) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SecretScanningAlertCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -84814,11 +79598,6 @@ impl ::std::convert::From<&SecretScanningAlertCreated> for SecretScanningAlertCr
 pub enum SecretScanningAlertCreatedAction {
     #[serde(rename = "created")]
     Created,
-}
-impl ::std::convert::From<&Self> for SecretScanningAlertCreatedAction {
-    fn from(value: &SecretScanningAlertCreatedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for SecretScanningAlertCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -84903,11 +79682,6 @@ pub struct SecretScanningAlertCreatedAlert {
     pub resolved_by: (),
     pub secret_type: ::std::string::String,
 }
-impl ::std::convert::From<&SecretScanningAlertCreatedAlert> for SecretScanningAlertCreatedAlert {
-    fn from(value: &SecretScanningAlertCreatedAlert) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SecretScanningAlertEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -84934,11 +79708,6 @@ pub enum SecretScanningAlertEvent {
     Created(SecretScanningAlertCreated),
     Reopened(SecretScanningAlertReopened),
     Resolved(SecretScanningAlertResolved),
-}
-impl ::std::convert::From<&Self> for SecretScanningAlertEvent {
-    fn from(value: &SecretScanningAlertEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<SecretScanningAlertCreated> for SecretScanningAlertEvent {
     fn from(value: SecretScanningAlertCreated) -> Self {
@@ -85035,11 +79804,6 @@ pub struct SecretScanningAlertReopened {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&SecretScanningAlertReopened> for SecretScanningAlertReopened {
-    fn from(value: &SecretScanningAlertReopened) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SecretScanningAlertReopenedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -85068,11 +79832,6 @@ impl ::std::convert::From<&SecretScanningAlertReopened> for SecretScanningAlertR
 pub enum SecretScanningAlertReopenedAction {
     #[serde(rename = "reopened")]
     Reopened,
-}
-impl ::std::convert::From<&Self> for SecretScanningAlertReopenedAction {
-    fn from(value: &SecretScanningAlertReopenedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for SecretScanningAlertReopenedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -85156,11 +79915,6 @@ pub struct SecretScanningAlertReopenedAlert {
     pub resolved_at: (),
     pub resolved_by: (),
     pub secret_type: ::std::string::String,
-}
-impl ::std::convert::From<&SecretScanningAlertReopenedAlert> for SecretScanningAlertReopenedAlert {
-    fn from(value: &SecretScanningAlertReopenedAlert) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`SecretScanningAlertResolved`"]
 #[doc = r""]
@@ -85248,11 +80002,6 @@ pub struct SecretScanningAlertResolved {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&SecretScanningAlertResolved> for SecretScanningAlertResolved {
-    fn from(value: &SecretScanningAlertResolved) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SecretScanningAlertResolvedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -85281,11 +80030,6 @@ impl ::std::convert::From<&SecretScanningAlertResolved> for SecretScanningAlertR
 pub enum SecretScanningAlertResolvedAction {
     #[serde(rename = "resolved")]
     Resolved,
-}
-impl ::std::convert::From<&Self> for SecretScanningAlertResolvedAction {
-    fn from(value: &SecretScanningAlertResolvedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for SecretScanningAlertResolvedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -85376,11 +80120,6 @@ pub struct SecretScanningAlertResolvedAlert {
     pub resolved_by: User,
     pub secret_type: ::std::string::String,
 }
-impl ::std::convert::From<&SecretScanningAlertResolvedAlert> for SecretScanningAlertResolvedAlert {
-    fn from(value: &SecretScanningAlertResolvedAlert) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SecretScanningAlertResolvedAlertResolution`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -85418,11 +80157,6 @@ pub enum SecretScanningAlertResolvedAlertResolution {
     Revoked,
     #[serde(rename = "used_in_tests")]
     UsedInTests,
-}
-impl ::std::convert::From<&Self> for SecretScanningAlertResolvedAlertResolution {
-    fn from(value: &SecretScanningAlertResolvedAlertResolution) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for SecretScanningAlertResolvedAlertResolution {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -85500,11 +80234,6 @@ pub enum SecurityAdvisoryEvent {
     Published(SecurityAdvisoryPublished),
     Updated(SecurityAdvisoryUpdated),
     Withdrawn(SecurityAdvisoryWithdrawn),
-}
-impl ::std::convert::From<&Self> for SecurityAdvisoryEvent {
-    fn from(value: &SecurityAdvisoryEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<SecurityAdvisoryPerformed> for SecurityAdvisoryEvent {
     fn from(value: SecurityAdvisoryPerformed) -> Self {
@@ -85727,11 +80456,6 @@ pub struct SecurityAdvisoryPerformed {
     pub action: SecurityAdvisoryPerformedAction,
     pub security_advisory: SecurityAdvisoryPerformedSecurityAdvisory,
 }
-impl ::std::convert::From<&SecurityAdvisoryPerformed> for SecurityAdvisoryPerformed {
-    fn from(value: &SecurityAdvisoryPerformed) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SecurityAdvisoryPerformedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -85760,11 +80484,6 @@ impl ::std::convert::From<&SecurityAdvisoryPerformed> for SecurityAdvisoryPerfor
 pub enum SecurityAdvisoryPerformedAction {
     #[serde(rename = "performed")]
     Performed,
-}
-impl ::std::convert::From<&Self> for SecurityAdvisoryPerformedAction {
-    fn from(value: &SecurityAdvisoryPerformedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for SecurityAdvisoryPerformedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -85998,13 +80717,6 @@ pub struct SecurityAdvisoryPerformedSecurityAdvisory {
         ::std::vec::Vec<SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItem>,
     pub withdrawn_at: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&SecurityAdvisoryPerformedSecurityAdvisory>
-    for SecurityAdvisoryPerformedSecurityAdvisory
-{
-    fn from(value: &SecurityAdvisoryPerformedSecurityAdvisory) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SecurityAdvisoryPerformedSecurityAdvisoryCvss`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -86037,13 +80749,6 @@ pub struct SecurityAdvisoryPerformedSecurityAdvisoryCvss {
     pub score: f64,
     pub vector_string: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&SecurityAdvisoryPerformedSecurityAdvisoryCvss>
-    for SecurityAdvisoryPerformedSecurityAdvisoryCvss
-{
-    fn from(value: &SecurityAdvisoryPerformedSecurityAdvisoryCvss) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SecurityAdvisoryPerformedSecurityAdvisoryCwesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -86072,13 +80777,6 @@ impl ::std::convert::From<&SecurityAdvisoryPerformedSecurityAdvisoryCvss>
 pub struct SecurityAdvisoryPerformedSecurityAdvisoryCwesItem {
     pub cwe_id: ::std::string::String,
     pub name: ::std::string::String,
-}
-impl ::std::convert::From<&SecurityAdvisoryPerformedSecurityAdvisoryCwesItem>
-    for SecurityAdvisoryPerformedSecurityAdvisoryCwesItem
-{
-    fn from(value: &SecurityAdvisoryPerformedSecurityAdvisoryCwesItem) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`SecurityAdvisoryPerformedSecurityAdvisoryIdentifiersItem`"]
 #[doc = r""]
@@ -86110,13 +80808,6 @@ pub struct SecurityAdvisoryPerformedSecurityAdvisoryIdentifiersItem {
     pub type_: ::std::string::String,
     pub value: ::std::string::String,
 }
-impl ::std::convert::From<&SecurityAdvisoryPerformedSecurityAdvisoryIdentifiersItem>
-    for SecurityAdvisoryPerformedSecurityAdvisoryIdentifiersItem
-{
-    fn from(value: &SecurityAdvisoryPerformedSecurityAdvisoryIdentifiersItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SecurityAdvisoryPerformedSecurityAdvisoryReferencesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -86141,13 +80832,6 @@ impl ::std::convert::From<&SecurityAdvisoryPerformedSecurityAdvisoryIdentifiersI
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPerformedSecurityAdvisoryReferencesItem {
     pub url: ::std::string::String,
-}
-impl ::std::convert::From<&SecurityAdvisoryPerformedSecurityAdvisoryReferencesItem>
-    for SecurityAdvisoryPerformedSecurityAdvisoryReferencesItem
-{
-    fn from(value: &SecurityAdvisoryPerformedSecurityAdvisoryReferencesItem) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItem`"]
 #[doc = r""]
@@ -86215,13 +80899,6 @@ pub struct SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItem {
     pub severity: ::std::string::String,
     pub vulnerable_version_range: ::std::string::String,
 }
-impl ::std::convert::From<&SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItem>
-    for SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItem
-{
-    fn from(value: &SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -86245,17 +80922,6 @@ impl ::std::convert::From<&SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilit
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion {
     pub identifier: ::std::string::String,
-}
-impl
-    ::std::convert::From<
-        &SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion,
-    > for SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion
-{
-    fn from(
-        value: &SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion,
-    ) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemPackage`"]
 #[doc = r""]
@@ -86285,13 +80951,6 @@ impl
 pub struct SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemPackage {
     pub ecosystem: ::std::string::String,
     pub name: ::std::string::String,
-}
-impl ::std::convert::From<&SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemPackage>
-    for SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemPackage
-{
-    fn from(value: &SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemPackage) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`SecurityAdvisoryPublished`"]
 #[doc = r""]
@@ -86494,11 +81153,6 @@ pub struct SecurityAdvisoryPublished {
     pub action: SecurityAdvisoryPublishedAction,
     pub security_advisory: SecurityAdvisoryPublishedSecurityAdvisory,
 }
-impl ::std::convert::From<&SecurityAdvisoryPublished> for SecurityAdvisoryPublished {
-    fn from(value: &SecurityAdvisoryPublished) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SecurityAdvisoryPublishedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -86527,11 +81181,6 @@ impl ::std::convert::From<&SecurityAdvisoryPublished> for SecurityAdvisoryPublis
 pub enum SecurityAdvisoryPublishedAction {
     #[serde(rename = "published")]
     Published,
-}
-impl ::std::convert::From<&Self> for SecurityAdvisoryPublishedAction {
-    fn from(value: &SecurityAdvisoryPublishedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for SecurityAdvisoryPublishedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -86765,13 +81414,6 @@ pub struct SecurityAdvisoryPublishedSecurityAdvisory {
         ::std::vec::Vec<SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItem>,
     pub withdrawn_at: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&SecurityAdvisoryPublishedSecurityAdvisory>
-    for SecurityAdvisoryPublishedSecurityAdvisory
-{
-    fn from(value: &SecurityAdvisoryPublishedSecurityAdvisory) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SecurityAdvisoryPublishedSecurityAdvisoryCvss`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -86804,13 +81446,6 @@ pub struct SecurityAdvisoryPublishedSecurityAdvisoryCvss {
     pub score: f64,
     pub vector_string: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&SecurityAdvisoryPublishedSecurityAdvisoryCvss>
-    for SecurityAdvisoryPublishedSecurityAdvisoryCvss
-{
-    fn from(value: &SecurityAdvisoryPublishedSecurityAdvisoryCvss) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SecurityAdvisoryPublishedSecurityAdvisoryCwesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -86839,13 +81474,6 @@ impl ::std::convert::From<&SecurityAdvisoryPublishedSecurityAdvisoryCvss>
 pub struct SecurityAdvisoryPublishedSecurityAdvisoryCwesItem {
     pub cwe_id: ::std::string::String,
     pub name: ::std::string::String,
-}
-impl ::std::convert::From<&SecurityAdvisoryPublishedSecurityAdvisoryCwesItem>
-    for SecurityAdvisoryPublishedSecurityAdvisoryCwesItem
-{
-    fn from(value: &SecurityAdvisoryPublishedSecurityAdvisoryCwesItem) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`SecurityAdvisoryPublishedSecurityAdvisoryIdentifiersItem`"]
 #[doc = r""]
@@ -86877,13 +81505,6 @@ pub struct SecurityAdvisoryPublishedSecurityAdvisoryIdentifiersItem {
     pub type_: ::std::string::String,
     pub value: ::std::string::String,
 }
-impl ::std::convert::From<&SecurityAdvisoryPublishedSecurityAdvisoryIdentifiersItem>
-    for SecurityAdvisoryPublishedSecurityAdvisoryIdentifiersItem
-{
-    fn from(value: &SecurityAdvisoryPublishedSecurityAdvisoryIdentifiersItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SecurityAdvisoryPublishedSecurityAdvisoryReferencesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -86908,13 +81529,6 @@ impl ::std::convert::From<&SecurityAdvisoryPublishedSecurityAdvisoryIdentifiersI
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPublishedSecurityAdvisoryReferencesItem {
     pub url: ::std::string::String,
-}
-impl ::std::convert::From<&SecurityAdvisoryPublishedSecurityAdvisoryReferencesItem>
-    for SecurityAdvisoryPublishedSecurityAdvisoryReferencesItem
-{
-    fn from(value: &SecurityAdvisoryPublishedSecurityAdvisoryReferencesItem) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItem`"]
 #[doc = r""]
@@ -86982,13 +81596,6 @@ pub struct SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItem {
     pub severity: ::std::string::String,
     pub vulnerable_version_range: ::std::string::String,
 }
-impl ::std::convert::From<&SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItem>
-    for SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItem
-{
-    fn from(value: &SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -87012,17 +81619,6 @@ impl ::std::convert::From<&SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilit
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion {
     pub identifier: ::std::string::String,
-}
-impl
-    ::std::convert::From<
-        &SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion,
-    > for SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion
-{
-    fn from(
-        value: &SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion,
-    ) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemPackage`"]
 #[doc = r""]
@@ -87052,13 +81648,6 @@ impl
 pub struct SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemPackage {
     pub ecosystem: ::std::string::String,
     pub name: ::std::string::String,
-}
-impl ::std::convert::From<&SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemPackage>
-    for SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemPackage
-{
-    fn from(value: &SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemPackage) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`SecurityAdvisoryUpdated`"]
 #[doc = r""]
@@ -87261,11 +81850,6 @@ pub struct SecurityAdvisoryUpdated {
     pub action: SecurityAdvisoryUpdatedAction,
     pub security_advisory: SecurityAdvisoryUpdatedSecurityAdvisory,
 }
-impl ::std::convert::From<&SecurityAdvisoryUpdated> for SecurityAdvisoryUpdated {
-    fn from(value: &SecurityAdvisoryUpdated) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SecurityAdvisoryUpdatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -87294,11 +81878,6 @@ impl ::std::convert::From<&SecurityAdvisoryUpdated> for SecurityAdvisoryUpdated 
 pub enum SecurityAdvisoryUpdatedAction {
     #[serde(rename = "updated")]
     Updated,
-}
-impl ::std::convert::From<&Self> for SecurityAdvisoryUpdatedAction {
-    fn from(value: &SecurityAdvisoryUpdatedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for SecurityAdvisoryUpdatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -87532,13 +82111,6 @@ pub struct SecurityAdvisoryUpdatedSecurityAdvisory {
         ::std::vec::Vec<SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItem>,
     pub withdrawn_at: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&SecurityAdvisoryUpdatedSecurityAdvisory>
-    for SecurityAdvisoryUpdatedSecurityAdvisory
-{
-    fn from(value: &SecurityAdvisoryUpdatedSecurityAdvisory) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SecurityAdvisoryUpdatedSecurityAdvisoryCvss`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -87571,13 +82143,6 @@ pub struct SecurityAdvisoryUpdatedSecurityAdvisoryCvss {
     pub score: f64,
     pub vector_string: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&SecurityAdvisoryUpdatedSecurityAdvisoryCvss>
-    for SecurityAdvisoryUpdatedSecurityAdvisoryCvss
-{
-    fn from(value: &SecurityAdvisoryUpdatedSecurityAdvisoryCvss) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SecurityAdvisoryUpdatedSecurityAdvisoryCwesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -87606,13 +82171,6 @@ impl ::std::convert::From<&SecurityAdvisoryUpdatedSecurityAdvisoryCvss>
 pub struct SecurityAdvisoryUpdatedSecurityAdvisoryCwesItem {
     pub cwe_id: ::std::string::String,
     pub name: ::std::string::String,
-}
-impl ::std::convert::From<&SecurityAdvisoryUpdatedSecurityAdvisoryCwesItem>
-    for SecurityAdvisoryUpdatedSecurityAdvisoryCwesItem
-{
-    fn from(value: &SecurityAdvisoryUpdatedSecurityAdvisoryCwesItem) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`SecurityAdvisoryUpdatedSecurityAdvisoryIdentifiersItem`"]
 #[doc = r""]
@@ -87644,13 +82202,6 @@ pub struct SecurityAdvisoryUpdatedSecurityAdvisoryIdentifiersItem {
     pub type_: ::std::string::String,
     pub value: ::std::string::String,
 }
-impl ::std::convert::From<&SecurityAdvisoryUpdatedSecurityAdvisoryIdentifiersItem>
-    for SecurityAdvisoryUpdatedSecurityAdvisoryIdentifiersItem
-{
-    fn from(value: &SecurityAdvisoryUpdatedSecurityAdvisoryIdentifiersItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SecurityAdvisoryUpdatedSecurityAdvisoryReferencesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -87675,13 +82226,6 @@ impl ::std::convert::From<&SecurityAdvisoryUpdatedSecurityAdvisoryIdentifiersIte
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryUpdatedSecurityAdvisoryReferencesItem {
     pub url: ::std::string::String,
-}
-impl ::std::convert::From<&SecurityAdvisoryUpdatedSecurityAdvisoryReferencesItem>
-    for SecurityAdvisoryUpdatedSecurityAdvisoryReferencesItem
-{
-    fn from(value: &SecurityAdvisoryUpdatedSecurityAdvisoryReferencesItem) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItem`"]
 #[doc = r""]
@@ -87749,13 +82293,6 @@ pub struct SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItem {
     pub severity: ::std::string::String,
     pub vulnerable_version_range: ::std::string::String,
 }
-impl ::std::convert::From<&SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItem>
-    for SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItem
-{
-    fn from(value: &SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -87779,17 +82316,6 @@ impl ::std::convert::From<&SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitie
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion {
     pub identifier: ::std::string::String,
-}
-impl
-    ::std::convert::From<
-        &SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion,
-    > for SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion
-{
-    fn from(
-        value: &SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion,
-    ) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemPackage`"]
 #[doc = r""]
@@ -87819,13 +82345,6 @@ impl
 pub struct SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemPackage {
     pub ecosystem: ::std::string::String,
     pub name: ::std::string::String,
-}
-impl ::std::convert::From<&SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemPackage>
-    for SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemPackage
-{
-    fn from(value: &SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemPackage) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`SecurityAdvisoryWithdrawn`"]
 #[doc = r""]
@@ -88025,11 +82544,6 @@ pub struct SecurityAdvisoryWithdrawn {
     pub action: SecurityAdvisoryWithdrawnAction,
     pub security_advisory: SecurityAdvisoryWithdrawnSecurityAdvisory,
 }
-impl ::std::convert::From<&SecurityAdvisoryWithdrawn> for SecurityAdvisoryWithdrawn {
-    fn from(value: &SecurityAdvisoryWithdrawn) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SecurityAdvisoryWithdrawnAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -88058,11 +82572,6 @@ impl ::std::convert::From<&SecurityAdvisoryWithdrawn> for SecurityAdvisoryWithdr
 pub enum SecurityAdvisoryWithdrawnAction {
     #[serde(rename = "withdrawn")]
     Withdrawn,
-}
-impl ::std::convert::From<&Self> for SecurityAdvisoryWithdrawnAction {
-    fn from(value: &SecurityAdvisoryWithdrawnAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for SecurityAdvisoryWithdrawnAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -88293,13 +82802,6 @@ pub struct SecurityAdvisoryWithdrawnSecurityAdvisory {
         ::std::vec::Vec<SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItem>,
     pub withdrawn_at: ::std::string::String,
 }
-impl ::std::convert::From<&SecurityAdvisoryWithdrawnSecurityAdvisory>
-    for SecurityAdvisoryWithdrawnSecurityAdvisory
-{
-    fn from(value: &SecurityAdvisoryWithdrawnSecurityAdvisory) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SecurityAdvisoryWithdrawnSecurityAdvisoryCvss`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -88332,13 +82834,6 @@ pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryCvss {
     pub score: f64,
     pub vector_string: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&SecurityAdvisoryWithdrawnSecurityAdvisoryCvss>
-    for SecurityAdvisoryWithdrawnSecurityAdvisoryCvss
-{
-    fn from(value: &SecurityAdvisoryWithdrawnSecurityAdvisoryCvss) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SecurityAdvisoryWithdrawnSecurityAdvisoryCwesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -88367,13 +82862,6 @@ impl ::std::convert::From<&SecurityAdvisoryWithdrawnSecurityAdvisoryCvss>
 pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryCwesItem {
     pub cwe_id: ::std::string::String,
     pub name: ::std::string::String,
-}
-impl ::std::convert::From<&SecurityAdvisoryWithdrawnSecurityAdvisoryCwesItem>
-    for SecurityAdvisoryWithdrawnSecurityAdvisoryCwesItem
-{
-    fn from(value: &SecurityAdvisoryWithdrawnSecurityAdvisoryCwesItem) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`SecurityAdvisoryWithdrawnSecurityAdvisoryIdentifiersItem`"]
 #[doc = r""]
@@ -88405,13 +82893,6 @@ pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryIdentifiersItem {
     pub type_: ::std::string::String,
     pub value: ::std::string::String,
 }
-impl ::std::convert::From<&SecurityAdvisoryWithdrawnSecurityAdvisoryIdentifiersItem>
-    for SecurityAdvisoryWithdrawnSecurityAdvisoryIdentifiersItem
-{
-    fn from(value: &SecurityAdvisoryWithdrawnSecurityAdvisoryIdentifiersItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SecurityAdvisoryWithdrawnSecurityAdvisoryReferencesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -88436,13 +82917,6 @@ impl ::std::convert::From<&SecurityAdvisoryWithdrawnSecurityAdvisoryIdentifiersI
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryReferencesItem {
     pub url: ::std::string::String,
-}
-impl ::std::convert::From<&SecurityAdvisoryWithdrawnSecurityAdvisoryReferencesItem>
-    for SecurityAdvisoryWithdrawnSecurityAdvisoryReferencesItem
-{
-    fn from(value: &SecurityAdvisoryWithdrawnSecurityAdvisoryReferencesItem) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItem`"]
 #[doc = r""]
@@ -88510,13 +82984,6 @@ pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItem {
     pub severity: ::std::string::String,
     pub vulnerable_version_range: ::std::string::String,
 }
-impl ::std::convert::From<&SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItem>
-    for SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItem
-{
-    fn from(value: &SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -88540,17 +83007,6 @@ impl ::std::convert::From<&SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilit
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion {
     pub identifier: ::std::string::String,
-}
-impl
-    ::std::convert::From<
-        &SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion,
-    > for SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion
-{
-    fn from(
-        value: &SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion,
-    ) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemPackage`"]
 #[doc = r""]
@@ -88580,13 +83036,6 @@ impl
 pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemPackage {
     pub ecosystem: ::std::string::String,
     pub name: ::std::string::String,
-}
-impl ::std::convert::From<&SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemPackage>
-    for SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemPackage
-{
-    fn from(value: &SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemPackage) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`SimplePullRequest`"]
 #[doc = r""]
@@ -88943,11 +83392,6 @@ pub struct SimplePullRequest {
     pub url: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&SimplePullRequest> for SimplePullRequest {
-    fn from(value: &SimplePullRequest) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SimplePullRequestActiveLockReason`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -88985,11 +83429,6 @@ pub enum SimplePullRequestActiveLockReason {
     TooHeated,
     #[serde(rename = "spam")]
     Spam,
-}
-impl ::std::convert::From<&Self> for SimplePullRequestActiveLockReason {
-    fn from(value: &SimplePullRequestActiveLockReason) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for SimplePullRequestActiveLockReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -89080,11 +83519,6 @@ pub struct SimplePullRequestBase {
     pub sha: ::std::string::String,
     pub user: User,
 }
-impl ::std::convert::From<&SimplePullRequestBase> for SimplePullRequestBase {
-    fn from(value: &SimplePullRequestBase) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SimplePullRequestHead`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -89129,11 +83563,6 @@ pub struct SimplePullRequestHead {
     pub repo: Repository,
     pub sha: ::std::string::String,
     pub user: User,
-}
-impl ::std::convert::From<&SimplePullRequestHead> for SimplePullRequestHead {
-    fn from(value: &SimplePullRequestHead) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`SimplePullRequestLinks`"]
 #[doc = r""]
@@ -89195,11 +83624,6 @@ pub struct SimplePullRequestLinks {
     pub self_: Link,
     pub statuses: Link,
 }
-impl ::std::convert::From<&SimplePullRequestLinks> for SimplePullRequestLinks {
-    fn from(value: &SimplePullRequestLinks) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SimplePullRequestRequestedReviewersItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -89222,11 +83646,6 @@ impl ::std::convert::From<&SimplePullRequestLinks> for SimplePullRequestLinks {
 pub enum SimplePullRequestRequestedReviewersItem {
     User(User),
     Team(Team),
-}
-impl ::std::convert::From<&Self> for SimplePullRequestRequestedReviewersItem {
-    fn from(value: &SimplePullRequestRequestedReviewersItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<User> for SimplePullRequestRequestedReviewersItem {
     fn from(value: User) -> Self {
@@ -89269,11 +83688,6 @@ pub enum SimplePullRequestState {
     Open,
     #[serde(rename = "closed")]
     Closed,
-}
-impl ::std::convert::From<&Self> for SimplePullRequestState {
-    fn from(value: &SimplePullRequestState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for SimplePullRequestState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -89383,11 +83797,6 @@ pub struct SponsorshipCancelled {
     pub sender: User,
     pub sponsorship: SponsorshipCancelledSponsorship,
 }
-impl ::std::convert::From<&SponsorshipCancelled> for SponsorshipCancelled {
-    fn from(value: &SponsorshipCancelled) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SponsorshipCancelledAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -89416,11 +83825,6 @@ impl ::std::convert::From<&SponsorshipCancelled> for SponsorshipCancelled {
 pub enum SponsorshipCancelledAction {
     #[serde(rename = "cancelled")]
     Cancelled,
-}
-impl ::std::convert::From<&Self> for SponsorshipCancelledAction {
-    fn from(value: &SponsorshipCancelledAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for SponsorshipCancelledAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -89509,11 +83913,6 @@ pub struct SponsorshipCancelledSponsorship {
     pub sponsorable: User,
     pub tier: SponsorshipTier,
 }
-impl ::std::convert::From<&SponsorshipCancelledSponsorship> for SponsorshipCancelledSponsorship {
-    fn from(value: &SponsorshipCancelledSponsorship) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SponsorshipCreated`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -89582,11 +83981,6 @@ pub struct SponsorshipCreated {
     pub sender: User,
     pub sponsorship: SponsorshipCreatedSponsorship,
 }
-impl ::std::convert::From<&SponsorshipCreated> for SponsorshipCreated {
-    fn from(value: &SponsorshipCreated) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SponsorshipCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -89615,11 +84009,6 @@ impl ::std::convert::From<&SponsorshipCreated> for SponsorshipCreated {
 pub enum SponsorshipCreatedAction {
     #[serde(rename = "created")]
     Created,
-}
-impl ::std::convert::From<&Self> for SponsorshipCreatedAction {
-    fn from(value: &SponsorshipCreatedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for SponsorshipCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -89707,11 +84096,6 @@ pub struct SponsorshipCreatedSponsorship {
     pub sponsor: User,
     pub sponsorable: User,
     pub tier: SponsorshipTier,
-}
-impl ::std::convert::From<&SponsorshipCreatedSponsorship> for SponsorshipCreatedSponsorship {
-    fn from(value: &SponsorshipCreatedSponsorship) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`SponsorshipEdited`"]
 #[doc = r""]
@@ -89802,11 +84186,6 @@ pub struct SponsorshipEdited {
     pub sender: User,
     pub sponsorship: SponsorshipEditedSponsorship,
 }
-impl ::std::convert::From<&SponsorshipEdited> for SponsorshipEdited {
-    fn from(value: &SponsorshipEdited) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SponsorshipEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -89835,11 +84214,6 @@ impl ::std::convert::From<&SponsorshipEdited> for SponsorshipEdited {
 pub enum SponsorshipEditedAction {
     #[serde(rename = "edited")]
     Edited,
-}
-impl ::std::convert::From<&Self> for SponsorshipEditedAction {
-    fn from(value: &SponsorshipEditedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for SponsorshipEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -89911,11 +84285,6 @@ pub struct SponsorshipEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub privacy_level: ::std::option::Option<SponsorshipEditedChangesPrivacyLevel>,
 }
-impl ::std::convert::From<&SponsorshipEditedChanges> for SponsorshipEditedChanges {
-    fn from(value: &SponsorshipEditedChanges) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for SponsorshipEditedChanges {
     fn default() -> Self {
         Self {
@@ -89948,13 +84317,6 @@ impl ::std::default::Default for SponsorshipEditedChanges {
 pub struct SponsorshipEditedChangesPrivacyLevel {
     #[doc = "The `edited` event types include the details about the change when someone edits a sponsorship to change the privacy."]
     pub from: ::std::string::String,
-}
-impl ::std::convert::From<&SponsorshipEditedChangesPrivacyLevel>
-    for SponsorshipEditedChangesPrivacyLevel
-{
-    fn from(value: &SponsorshipEditedChangesPrivacyLevel) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`SponsorshipEditedSponsorship`"]
 #[doc = r""]
@@ -90005,11 +84367,6 @@ pub struct SponsorshipEditedSponsorship {
     pub sponsorable: User,
     pub tier: SponsorshipTier,
 }
-impl ::std::convert::From<&SponsorshipEditedSponsorship> for SponsorshipEditedSponsorship {
-    fn from(value: &SponsorshipEditedSponsorship) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SponsorshipEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -90048,11 +84405,6 @@ pub enum SponsorshipEvent {
     PendingCancellation(SponsorshipPendingCancellation),
     PendingTierChange(SponsorshipPendingTierChange),
     TierChanged(SponsorshipTierChanged),
-}
-impl ::std::convert::From<&Self> for SponsorshipEvent {
-    fn from(value: &SponsorshipEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<SponsorshipCancelled> for SponsorshipEvent {
     fn from(value: SponsorshipCancelled) -> Self {
@@ -90159,11 +84511,6 @@ pub struct SponsorshipPendingCancellation {
     pub sender: User,
     pub sponsorship: SponsorshipPendingCancellationSponsorship,
 }
-impl ::std::convert::From<&SponsorshipPendingCancellation> for SponsorshipPendingCancellation {
-    fn from(value: &SponsorshipPendingCancellation) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SponsorshipPendingCancellationAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -90192,11 +84539,6 @@ impl ::std::convert::From<&SponsorshipPendingCancellation> for SponsorshipPendin
 pub enum SponsorshipPendingCancellationAction {
     #[serde(rename = "pending_cancellation")]
     PendingCancellation,
-}
-impl ::std::convert::From<&Self> for SponsorshipPendingCancellationAction {
-    fn from(value: &SponsorshipPendingCancellationAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for SponsorshipPendingCancellationAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -90284,13 +84626,6 @@ pub struct SponsorshipPendingCancellationSponsorship {
     pub sponsor: User,
     pub sponsorable: User,
     pub tier: SponsorshipTier,
-}
-impl ::std::convert::From<&SponsorshipPendingCancellationSponsorship>
-    for SponsorshipPendingCancellationSponsorship
-{
-    fn from(value: &SponsorshipPendingCancellationSponsorship) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`SponsorshipPendingTierChange`"]
 #[doc = r""]
@@ -90390,11 +84725,6 @@ pub struct SponsorshipPendingTierChange {
     pub sender: User,
     pub sponsorship: SponsorshipPendingTierChangeSponsorship,
 }
-impl ::std::convert::From<&SponsorshipPendingTierChange> for SponsorshipPendingTierChange {
-    fn from(value: &SponsorshipPendingTierChange) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SponsorshipPendingTierChangeAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -90423,11 +84753,6 @@ impl ::std::convert::From<&SponsorshipPendingTierChange> for SponsorshipPendingT
 pub enum SponsorshipPendingTierChangeAction {
     #[serde(rename = "pending_tier_change")]
     PendingTierChange,
-}
-impl ::std::convert::From<&Self> for SponsorshipPendingTierChangeAction {
-    fn from(value: &SponsorshipPendingTierChangeAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for SponsorshipPendingTierChangeAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -90500,13 +84825,6 @@ impl ::std::convert::TryFrom<::std::string::String> for SponsorshipPendingTierCh
 pub struct SponsorshipPendingTierChangeChanges {
     pub tier: SponsorshipPendingTierChangeChangesTier,
 }
-impl ::std::convert::From<&SponsorshipPendingTierChangeChanges>
-    for SponsorshipPendingTierChangeChanges
-{
-    fn from(value: &SponsorshipPendingTierChangeChanges) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SponsorshipPendingTierChangeChangesTier`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -90530,13 +84848,6 @@ impl ::std::convert::From<&SponsorshipPendingTierChangeChanges>
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipPendingTierChangeChangesTier {
     pub from: SponsorshipTier,
-}
-impl ::std::convert::From<&SponsorshipPendingTierChangeChangesTier>
-    for SponsorshipPendingTierChangeChangesTier
-{
-    fn from(value: &SponsorshipPendingTierChangeChangesTier) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`SponsorshipPendingTierChangeSponsorship`"]
 #[doc = r""]
@@ -90586,13 +84897,6 @@ pub struct SponsorshipPendingTierChangeSponsorship {
     pub sponsor: User,
     pub sponsorable: User,
     pub tier: SponsorshipTier,
-}
-impl ::std::convert::From<&SponsorshipPendingTierChangeSponsorship>
-    for SponsorshipPendingTierChangeSponsorship
-{
-    fn from(value: &SponsorshipPendingTierChangeSponsorship) -> Self {
-        value.clone()
-    }
 }
 #[doc = "The `tier_changed` and `pending_tier_change` will include the original tier before the change or pending change. For more information, see the pending tier change payload."]
 #[doc = r""]
@@ -90655,11 +84959,6 @@ pub struct SponsorshipTier {
     pub monthly_price_in_dollars: i64,
     pub name: ::std::string::String,
     pub node_id: ::std::string::String,
-}
-impl ::std::convert::From<&SponsorshipTier> for SponsorshipTier {
-    fn from(value: &SponsorshipTier) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`SponsorshipTierChanged`"]
 #[doc = r""]
@@ -90752,11 +85051,6 @@ pub struct SponsorshipTierChanged {
     pub sender: User,
     pub sponsorship: SponsorshipTierChangedSponsorship,
 }
-impl ::std::convert::From<&SponsorshipTierChanged> for SponsorshipTierChanged {
-    fn from(value: &SponsorshipTierChanged) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SponsorshipTierChangedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -90785,11 +85079,6 @@ impl ::std::convert::From<&SponsorshipTierChanged> for SponsorshipTierChanged {
 pub enum SponsorshipTierChangedAction {
     #[serde(rename = "tier_changed")]
     TierChanged,
-}
-impl ::std::convert::From<&Self> for SponsorshipTierChangedAction {
-    fn from(value: &SponsorshipTierChangedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for SponsorshipTierChangedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -90862,11 +85151,6 @@ impl ::std::convert::TryFrom<::std::string::String> for SponsorshipTierChangedAc
 pub struct SponsorshipTierChangedChanges {
     pub tier: SponsorshipTierChangedChangesTier,
 }
-impl ::std::convert::From<&SponsorshipTierChangedChanges> for SponsorshipTierChangedChanges {
-    fn from(value: &SponsorshipTierChangedChanges) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SponsorshipTierChangedChangesTier`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -90890,13 +85174,6 @@ impl ::std::convert::From<&SponsorshipTierChangedChanges> for SponsorshipTierCha
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipTierChangedChangesTier {
     pub from: SponsorshipTier,
-}
-impl ::std::convert::From<&SponsorshipTierChangedChangesTier>
-    for SponsorshipTierChangedChangesTier
-{
-    fn from(value: &SponsorshipTierChangedChangesTier) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`SponsorshipTierChangedSponsorship`"]
 #[doc = r""]
@@ -90946,13 +85223,6 @@ pub struct SponsorshipTierChangedSponsorship {
     pub sponsor: User,
     pub sponsorable: User,
     pub tier: SponsorshipTier,
-}
-impl ::std::convert::From<&SponsorshipTierChangedSponsorship>
-    for SponsorshipTierChangedSponsorship
-{
-    fn from(value: &SponsorshipTierChangedSponsorship) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`StarCreated`"]
 #[doc = r""]
@@ -91010,11 +85280,6 @@ pub struct StarCreated {
     #[doc = "The time the star was created. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Will be `null` for the `deleted` action."]
     pub starred_at: ::std::string::String,
 }
-impl ::std::convert::From<&StarCreated> for StarCreated {
-    fn from(value: &StarCreated) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StarCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -91043,11 +85308,6 @@ impl ::std::convert::From<&StarCreated> for StarCreated {
 pub enum StarCreatedAction {
     #[serde(rename = "created")]
     Created,
-}
-impl ::std::convert::From<&Self> for StarCreatedAction {
-    fn from(value: &StarCreatedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for StarCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -91143,11 +85403,6 @@ pub struct StarDeleted {
     #[doc = "The time the star was created. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Will be `null` for the `deleted` action."]
     pub starred_at: (),
 }
-impl ::std::convert::From<&StarDeleted> for StarDeleted {
-    fn from(value: &StarDeleted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StarDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -91176,11 +85431,6 @@ impl ::std::convert::From<&StarDeleted> for StarDeleted {
 pub enum StarDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
-}
-impl ::std::convert::From<&Self> for StarDeletedAction {
-    fn from(value: &StarDeletedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for StarDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -91242,11 +85492,6 @@ impl ::std::convert::TryFrom<::std::string::String> for StarDeletedAction {
 pub enum StarEvent {
     Created(StarCreated),
     Deleted(StarDeleted),
-}
-impl ::std::convert::From<&Self> for StarEvent {
-    fn from(value: &StarEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<StarCreated> for StarEvent {
     fn from(value: StarCreated) -> Self {
@@ -91623,11 +85868,6 @@ pub struct StatusEvent {
     pub target_url: ::std::option::Option<::std::string::String>,
     pub updated_at: ::std::string::String,
 }
-impl ::std::convert::From<&StatusEvent> for StatusEvent {
-    fn from(value: &StatusEvent) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StatusEventBranchesItem`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -91676,11 +85916,6 @@ pub struct StatusEventBranchesItem {
     pub name: ::std::string::String,
     pub protected: bool,
 }
-impl ::std::convert::From<&StatusEventBranchesItem> for StatusEventBranchesItem {
-    fn from(value: &StatusEventBranchesItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StatusEventBranchesItemCommit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -91710,11 +85945,6 @@ impl ::std::convert::From<&StatusEventBranchesItem> for StatusEventBranchesItem 
 pub struct StatusEventBranchesItemCommit {
     pub sha: ::std::string::String,
     pub url: ::std::string::String,
-}
-impl ::std::convert::From<&StatusEventBranchesItemCommit> for StatusEventBranchesItemCommit {
-    fn from(value: &StatusEventBranchesItemCommit) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`StatusEventCommit`"]
 #[doc = r""]
@@ -91941,11 +86171,6 @@ pub struct StatusEventCommit {
     pub sha: ::std::string::String,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&StatusEventCommit> for StatusEventCommit {
-    fn from(value: &StatusEventCommit) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StatusEventCommitCommit`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -92089,11 +86314,6 @@ pub struct StatusEventCommitCommit {
     pub url: ::std::string::String,
     pub verification: StatusEventCommitCommitVerification,
 }
-impl ::std::convert::From<&StatusEventCommitCommit> for StatusEventCommitCommit {
-    fn from(value: &StatusEventCommitCommit) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StatusEventCommitCommitAuthor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -92130,11 +86350,6 @@ pub struct StatusEventCommitCommitAuthor {
     pub name: ::std::string::String,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub username: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&StatusEventCommitCommitAuthor> for StatusEventCommitCommitAuthor {
-    fn from(value: &StatusEventCommitCommitAuthor) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`StatusEventCommitCommitCommitter`"]
 #[doc = r""]
@@ -92173,11 +86388,6 @@ pub struct StatusEventCommitCommitCommitter {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub username: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&StatusEventCommitCommitCommitter> for StatusEventCommitCommitCommitter {
-    fn from(value: &StatusEventCommitCommitCommitter) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StatusEventCommitCommitTree`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -92207,11 +86417,6 @@ impl ::std::convert::From<&StatusEventCommitCommitCommitter> for StatusEventComm
 pub struct StatusEventCommitCommitTree {
     pub sha: ::std::string::String,
     pub url: ::std::string::String,
-}
-impl ::std::convert::From<&StatusEventCommitCommitTree> for StatusEventCommitCommitTree {
-    fn from(value: &StatusEventCommitCommitTree) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`StatusEventCommitCommitVerification`"]
 #[doc = r""]
@@ -92272,13 +86477,6 @@ pub struct StatusEventCommitCommitVerification {
     pub reason: StatusEventCommitCommitVerificationReason,
     pub signature: ::std::option::Option<::std::string::String>,
     pub verified: bool,
-}
-impl ::std::convert::From<&StatusEventCommitCommitVerification>
-    for StatusEventCommitCommitVerification
-{
-    fn from(value: &StatusEventCommitCommitVerification) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`StatusEventCommitCommitVerificationReason`"]
 #[doc = r""]
@@ -92344,11 +86542,6 @@ pub enum StatusEventCommitCommitVerificationReason {
     Invalid,
     #[serde(rename = "valid")]
     Valid,
-}
-impl ::std::convert::From<&Self> for StatusEventCommitCommitVerificationReason {
-    fn from(value: &StatusEventCommitCommitVerificationReason) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for StatusEventCommitCommitVerificationReason {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -92448,11 +86641,6 @@ pub struct StatusEventCommitParentsItem {
     pub sha: ::std::string::String,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&StatusEventCommitParentsItem> for StatusEventCommitParentsItem {
-    fn from(value: &StatusEventCommitParentsItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "The new state. Can be `pending`, `success`, `failure`, or `error`."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -92491,11 +86679,6 @@ pub enum StatusEventState {
     Failure,
     #[serde(rename = "error")]
     Error,
-}
-impl ::std::convert::From<&Self> for StatusEventState {
-    fn from(value: &StatusEventState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for StatusEventState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -92714,11 +86897,6 @@ pub struct Team {
     #[doc = "URL for the team"]
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&Team> for Team {
-    fn from(value: &Team) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`TeamAddEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -92764,11 +86942,6 @@ pub struct TeamAddEvent {
     pub repository: Repository,
     pub sender: User,
     pub team: Team,
-}
-impl ::std::convert::From<&TeamAddEvent> for TeamAddEvent {
-    fn from(value: &TeamAddEvent) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`TeamAddedToRepository`"]
 #[doc = r""]
@@ -92824,11 +86997,6 @@ pub struct TeamAddedToRepository {
     pub sender: User,
     pub team: Team,
 }
-impl ::std::convert::From<&TeamAddedToRepository> for TeamAddedToRepository {
-    fn from(value: &TeamAddedToRepository) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`TeamAddedToRepositoryAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -92857,11 +87025,6 @@ impl ::std::convert::From<&TeamAddedToRepository> for TeamAddedToRepository {
 pub enum TeamAddedToRepositoryAction {
     #[serde(rename = "added_to_repository")]
     AddedToRepository,
-}
-impl ::std::convert::From<&Self> for TeamAddedToRepositoryAction {
-    fn from(value: &TeamAddedToRepositoryAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for TeamAddedToRepositoryAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -92955,11 +87118,6 @@ pub struct TeamCreated {
     pub sender: User,
     pub team: Team,
 }
-impl ::std::convert::From<&TeamCreated> for TeamCreated {
-    fn from(value: &TeamCreated) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`TeamCreatedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -92988,11 +87146,6 @@ impl ::std::convert::From<&TeamCreated> for TeamCreated {
 pub enum TeamCreatedAction {
     #[serde(rename = "created")]
     Created,
-}
-impl ::std::convert::From<&Self> for TeamCreatedAction {
-    fn from(value: &TeamCreatedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for TeamCreatedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -93086,11 +87239,6 @@ pub struct TeamDeleted {
     pub sender: User,
     pub team: Team,
 }
-impl ::std::convert::From<&TeamDeleted> for TeamDeleted {
-    fn from(value: &TeamDeleted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`TeamDeletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -93119,11 +87267,6 @@ impl ::std::convert::From<&TeamDeleted> for TeamDeleted {
 pub enum TeamDeletedAction {
     #[serde(rename = "deleted")]
     Deleted,
-}
-impl ::std::convert::From<&Self> for TeamDeletedAction {
-    fn from(value: &TeamDeletedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for TeamDeletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -93301,11 +87444,6 @@ pub struct TeamEdited {
     pub sender: User,
     pub team: Team,
 }
-impl ::std::convert::From<&TeamEdited> for TeamEdited {
-    fn from(value: &TeamEdited) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`TeamEditedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -93334,11 +87472,6 @@ impl ::std::convert::From<&TeamEdited> for TeamEdited {
 pub enum TeamEditedAction {
     #[serde(rename = "edited")]
     Edited,
-}
-impl ::std::convert::From<&Self> for TeamEditedAction {
-    fn from(value: &TeamEditedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for TeamEditedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -93479,11 +87612,6 @@ pub struct TeamEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub repository: ::std::option::Option<TeamEditedChangesRepository>,
 }
-impl ::std::convert::From<&TeamEditedChanges> for TeamEditedChanges {
-    fn from(value: &TeamEditedChanges) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for TeamEditedChanges {
     fn default() -> Self {
         Self {
@@ -93520,11 +87648,6 @@ pub struct TeamEditedChangesDescription {
     #[doc = "The previous version of the description if the action was `edited`."]
     pub from: ::std::string::String,
 }
-impl ::std::convert::From<&TeamEditedChangesDescription> for TeamEditedChangesDescription {
-    fn from(value: &TeamEditedChangesDescription) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`TeamEditedChangesName`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -93551,11 +87674,6 @@ pub struct TeamEditedChangesName {
     #[doc = "The previous version of the name if the action was `edited`."]
     pub from: ::std::string::String,
 }
-impl ::std::convert::From<&TeamEditedChangesName> for TeamEditedChangesName {
-    fn from(value: &TeamEditedChangesName) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`TeamEditedChangesPrivacy`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -93581,11 +87699,6 @@ impl ::std::convert::From<&TeamEditedChangesName> for TeamEditedChangesName {
 pub struct TeamEditedChangesPrivacy {
     #[doc = "The previous version of the team's privacy if the action was `edited`."]
     pub from: ::std::string::String,
-}
-impl ::std::convert::From<&TeamEditedChangesPrivacy> for TeamEditedChangesPrivacy {
-    fn from(value: &TeamEditedChangesPrivacy) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`TeamEditedChangesRepository`"]
 #[doc = r""]
@@ -93635,11 +87748,6 @@ impl ::std::convert::From<&TeamEditedChangesPrivacy> for TeamEditedChangesPrivac
 pub struct TeamEditedChangesRepository {
     pub permissions: TeamEditedChangesRepositoryPermissions,
 }
-impl ::std::convert::From<&TeamEditedChangesRepository> for TeamEditedChangesRepository {
-    fn from(value: &TeamEditedChangesRepository) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`TeamEditedChangesRepositoryPermissions`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -93679,13 +87787,6 @@ impl ::std::convert::From<&TeamEditedChangesRepository> for TeamEditedChangesRep
 pub struct TeamEditedChangesRepositoryPermissions {
     pub from: TeamEditedChangesRepositoryPermissionsFrom,
 }
-impl ::std::convert::From<&TeamEditedChangesRepositoryPermissions>
-    for TeamEditedChangesRepositoryPermissions
-{
-    fn from(value: &TeamEditedChangesRepositoryPermissions) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`TeamEditedChangesRepositoryPermissionsFrom`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -93723,13 +87824,6 @@ pub struct TeamEditedChangesRepositoryPermissionsFrom {
     #[doc = "The previous version of the team member's `push` permission on a repository, if the action was `edited`."]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub push: ::std::option::Option<bool>,
-}
-impl ::std::convert::From<&TeamEditedChangesRepositoryPermissionsFrom>
-    for TeamEditedChangesRepositoryPermissionsFrom
-{
-    fn from(value: &TeamEditedChangesRepositoryPermissionsFrom) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for TeamEditedChangesRepositoryPermissionsFrom {
     fn default() -> Self {
@@ -93774,11 +87868,6 @@ pub enum TeamEvent {
     Deleted(TeamDeleted),
     Edited(TeamEdited),
     RemovedFromRepository(TeamRemovedFromRepository),
-}
-impl ::std::convert::From<&Self> for TeamEvent {
-    fn from(value: &TeamEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<TeamAddedToRepository> for TeamEvent {
     fn from(value: TeamAddedToRepository) -> Self {
@@ -93901,11 +87990,6 @@ pub struct TeamParent {
     #[doc = "URL for the team"]
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&TeamParent> for TeamParent {
-    fn from(value: &TeamParent) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`TeamParentPrivacy`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -93940,11 +88024,6 @@ pub enum TeamParentPrivacy {
     Closed,
     #[serde(rename = "secret")]
     Secret,
-}
-impl ::std::convert::From<&Self> for TeamParentPrivacy {
-    fn from(value: &TeamParentPrivacy) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for TeamParentPrivacy {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -94022,11 +88101,6 @@ pub enum TeamPrivacy {
     Closed,
     #[serde(rename = "secret")]
     Secret,
-}
-impl ::std::convert::From<&Self> for TeamPrivacy {
-    fn from(value: &TeamPrivacy) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for TeamPrivacy {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -94124,11 +88198,6 @@ pub struct TeamRemovedFromRepository {
     pub sender: User,
     pub team: Team,
 }
-impl ::std::convert::From<&TeamRemovedFromRepository> for TeamRemovedFromRepository {
-    fn from(value: &TeamRemovedFromRepository) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`TeamRemovedFromRepositoryAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -94157,11 +88226,6 @@ impl ::std::convert::From<&TeamRemovedFromRepository> for TeamRemovedFromReposit
 pub enum TeamRemovedFromRepositoryAction {
     #[serde(rename = "removed_from_repository")]
     RemovedFromRepository,
-}
-impl ::std::convert::From<&Self> for TeamRemovedFromRepositoryAction {
-    fn from(value: &TeamRemovedFromRepositoryAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for TeamRemovedFromRepositoryAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -94343,11 +88407,6 @@ pub struct User {
     pub type_: UserType,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&User> for User {
-    fn from(value: &User) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`UserType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -94379,11 +88438,6 @@ pub enum UserType {
     Bot,
     User,
     Organization,
-}
-impl ::std::convert::From<&Self> for UserType {
-    fn from(value: &UserType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for UserType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -94455,11 +88509,6 @@ impl ::std::convert::From<WatchEvent> for WatchStarted {
         value.0
     }
 }
-impl ::std::convert::From<&WatchEvent> for WatchEvent {
-    fn from(value: &WatchEvent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<WatchStarted> for WatchEvent {
     fn from(value: WatchStarted) -> Self {
         Self(value)
@@ -94514,11 +88563,6 @@ pub struct WatchStarted {
     pub repository: Repository,
     pub sender: User,
 }
-impl ::std::convert::From<&WatchStarted> for WatchStarted {
-    fn from(value: &WatchStarted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`WatchStartedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -94547,11 +88591,6 @@ impl ::std::convert::From<&WatchStarted> for WatchStarted {
 pub enum WatchStartedAction {
     #[serde(rename = "started")]
     Started,
-}
-impl ::std::convert::From<&Self> for WatchStartedAction {
-    fn from(value: &WatchStartedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for WatchStartedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -94673,11 +88712,6 @@ impl ::std::convert::TryFrom<::std::string::String> for WatchStartedAction {
 pub enum WebhookEvents {
     Variant0(::std::vec::Vec<WebhookEventsVariant0Item>),
     Variant1([::std::string::String; 1usize]),
-}
-impl ::std::convert::From<&Self> for WebhookEvents {
-    fn from(value: &WebhookEvents) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<WebhookEventsVariant0Item>> for WebhookEvents {
     fn from(value: ::std::vec::Vec<WebhookEventsVariant0Item>) -> Self {
@@ -94855,11 +88889,6 @@ pub enum WebhookEventsVariant0Item {
     WorkflowDispatch,
     #[serde(rename = "workflow_run")]
     WorkflowRun,
-}
-impl ::std::convert::From<&Self> for WebhookEventsVariant0Item {
-    fn from(value: &WebhookEventsVariant0Item) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for WebhookEventsVariant0Item {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -95065,11 +89094,6 @@ pub struct Workflow {
     pub updated_at: ::std::string::String,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&Workflow> for Workflow {
-    fn from(value: &Workflow) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`WorkflowDispatchEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -95135,11 +89159,6 @@ pub struct WorkflowDispatchEvent {
     pub repository: Repository,
     pub sender: User,
     pub workflow: ::std::string::String,
-}
-impl ::std::convert::From<&WorkflowDispatchEvent> for WorkflowDispatchEvent {
-    fn from(value: &WorkflowDispatchEvent) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`WorkflowJob`"]
 #[doc = r""]
@@ -95264,11 +89283,6 @@ pub struct WorkflowJob {
     pub steps: ::std::vec::Vec<WorkflowStep>,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&WorkflowJob> for WorkflowJob {
-    fn from(value: &WorkflowJob) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`WorkflowJobCompleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -95343,11 +89357,6 @@ pub struct WorkflowJobCompleted {
     pub sender: User,
     pub workflow_job: WorkflowJobCompletedWorkflowJob,
 }
-impl ::std::convert::From<&WorkflowJobCompleted> for WorkflowJobCompleted {
-    fn from(value: &WorkflowJobCompleted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`WorkflowJobCompletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -95376,11 +89385,6 @@ impl ::std::convert::From<&WorkflowJobCompleted> for WorkflowJobCompleted {
 pub enum WorkflowJobCompletedAction {
     #[serde(rename = "completed")]
     Completed,
-}
-impl ::std::convert::From<&Self> for WorkflowJobCompletedAction {
-    fn from(value: &WorkflowJobCompletedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for WorkflowJobCompletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -95469,11 +89473,6 @@ pub struct WorkflowJobCompletedWorkflowJob {
     pub steps: ::std::vec::Vec<WorkflowStep>,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&WorkflowJobCompletedWorkflowJob> for WorkflowJobCompletedWorkflowJob {
-    fn from(value: &WorkflowJobCompletedWorkflowJob) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`WorkflowJobCompletedWorkflowJobConclusion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -95505,11 +89504,6 @@ pub enum WorkflowJobCompletedWorkflowJobConclusion {
     Success,
     #[serde(rename = "failure")]
     Failure,
-}
-impl ::std::convert::From<&Self> for WorkflowJobCompletedWorkflowJobConclusion {
-    fn from(value: &WorkflowJobCompletedWorkflowJobConclusion) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for WorkflowJobCompletedWorkflowJobConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -95586,11 +89580,6 @@ pub enum WorkflowJobCompletedWorkflowJobStatus {
     #[serde(rename = "completed")]
     Completed,
 }
-impl ::std::convert::From<&Self> for WorkflowJobCompletedWorkflowJobStatus {
-    fn from(value: &WorkflowJobCompletedWorkflowJobStatus) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for WorkflowJobCompletedWorkflowJobStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -95665,11 +89654,6 @@ pub enum WorkflowJobConclusion {
     #[serde(rename = "failure")]
     Failure,
 }
-impl ::std::convert::From<&Self> for WorkflowJobConclusion {
-    fn from(value: &WorkflowJobConclusion) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for WorkflowJobConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -95736,11 +89720,6 @@ pub enum WorkflowJobEvent {
     Completed(WorkflowJobCompleted),
     Queued(WorkflowJobQueued),
     Started(WorkflowJobStarted),
-}
-impl ::std::convert::From<&Self> for WorkflowJobEvent {
-    fn from(value: &WorkflowJobEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<WorkflowJobCompleted> for WorkflowJobEvent {
     fn from(value: WorkflowJobCompleted) -> Self {
@@ -95890,11 +89869,6 @@ pub struct WorkflowJobQueued {
     pub sender: User,
     pub workflow_job: WorkflowJobQueuedWorkflowJob,
 }
-impl ::std::convert::From<&WorkflowJobQueued> for WorkflowJobQueued {
-    fn from(value: &WorkflowJobQueued) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`WorkflowJobQueuedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -95923,11 +89897,6 @@ impl ::std::convert::From<&WorkflowJobQueued> for WorkflowJobQueued {
 pub enum WorkflowJobQueuedAction {
     #[serde(rename = "queued")]
     Queued,
-}
-impl ::std::convert::From<&Self> for WorkflowJobQueuedAction {
-    fn from(value: &WorkflowJobQueuedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for WorkflowJobQueuedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -96075,11 +90044,6 @@ pub struct WorkflowJobQueuedWorkflowJob {
     pub steps: ::std::vec::Vec<WorkflowStep>,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&WorkflowJobQueuedWorkflowJob> for WorkflowJobQueuedWorkflowJob {
-    fn from(value: &WorkflowJobQueuedWorkflowJob) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`WorkflowJobQueuedWorkflowJobStatus`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -96108,11 +90072,6 @@ impl ::std::convert::From<&WorkflowJobQueuedWorkflowJob> for WorkflowJobQueuedWo
 pub enum WorkflowJobQueuedWorkflowJobStatus {
     #[serde(rename = "queued")]
     Queued,
-}
-impl ::std::convert::From<&Self> for WorkflowJobQueuedWorkflowJobStatus {
-    fn from(value: &WorkflowJobQueuedWorkflowJobStatus) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for WorkflowJobQueuedWorkflowJobStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -96235,11 +90194,6 @@ pub struct WorkflowJobStarted {
     pub sender: User,
     pub workflow_job: WorkflowJobStartedWorkflowJob,
 }
-impl ::std::convert::From<&WorkflowJobStarted> for WorkflowJobStarted {
-    fn from(value: &WorkflowJobStarted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`WorkflowJobStartedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -96268,11 +90222,6 @@ impl ::std::convert::From<&WorkflowJobStarted> for WorkflowJobStarted {
 pub enum WorkflowJobStartedAction {
     #[serde(rename = "started")]
     Started,
-}
-impl ::std::convert::From<&Self> for WorkflowJobStartedAction {
-    fn from(value: &WorkflowJobStartedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for WorkflowJobStartedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -96370,11 +90319,6 @@ pub struct WorkflowJobStartedWorkflowJob {
     pub steps: [WorkflowStepInProgress; 1usize],
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&WorkflowJobStartedWorkflowJob> for WorkflowJobStartedWorkflowJob {
-    fn from(value: &WorkflowJobStartedWorkflowJob) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`WorkflowJobStartedWorkflowJobConclusion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -96400,13 +90344,6 @@ impl ::std::ops::Deref for WorkflowJobStartedWorkflowJobConclusion {
 impl ::std::convert::From<WorkflowJobStartedWorkflowJobConclusion> for () {
     fn from(value: WorkflowJobStartedWorkflowJobConclusion) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&WorkflowJobStartedWorkflowJobConclusion>
-    for WorkflowJobStartedWorkflowJobConclusion
-{
-    fn from(value: &WorkflowJobStartedWorkflowJobConclusion) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::TryFrom<()> for WorkflowJobStartedWorkflowJobConclusion {
@@ -96462,11 +90399,6 @@ pub enum WorkflowJobStartedWorkflowJobStatus {
     InProgress,
     #[serde(rename = "completed")]
     Completed,
-}
-impl ::std::convert::From<&Self> for WorkflowJobStartedWorkflowJobStatus {
-    fn from(value: &WorkflowJobStartedWorkflowJobStatus) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for WorkflowJobStartedWorkflowJobStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -96544,11 +90476,6 @@ pub enum WorkflowJobStatus {
     InProgress,
     #[serde(rename = "completed")]
     Completed,
-}
-impl ::std::convert::From<&Self> for WorkflowJobStatus {
-    fn from(value: &WorkflowJobStatus) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for WorkflowJobStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -96841,11 +90768,6 @@ pub struct WorkflowRun {
     pub workflow_id: i64,
     pub workflow_url: ::std::string::String,
 }
-impl ::std::convert::From<&WorkflowRun> for WorkflowRun {
-    fn from(value: &WorkflowRun) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`WorkflowRunCompleted`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -96930,11 +90852,6 @@ pub struct WorkflowRunCompleted {
     pub workflow: Workflow,
     pub workflow_run: WorkflowRunCompletedWorkflowRun,
 }
-impl ::std::convert::From<&WorkflowRunCompleted> for WorkflowRunCompleted {
-    fn from(value: &WorkflowRunCompleted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`WorkflowRunCompletedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -96963,11 +90880,6 @@ impl ::std::convert::From<&WorkflowRunCompleted> for WorkflowRunCompleted {
 pub enum WorkflowRunCompletedAction {
     #[serde(rename = "completed")]
     Completed,
-}
-impl ::std::convert::From<&Self> for WorkflowRunCompletedAction {
-    fn from(value: &WorkflowRunCompletedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for WorkflowRunCompletedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -97073,11 +90985,6 @@ pub struct WorkflowRunCompletedWorkflowRun {
     pub workflow_id: i64,
     pub workflow_url: ::std::string::String,
 }
-impl ::std::convert::From<&WorkflowRunCompletedWorkflowRun> for WorkflowRunCompletedWorkflowRun {
-    fn from(value: &WorkflowRunCompletedWorkflowRun) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`WorkflowRunCompletedWorkflowRunConclusion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -97124,11 +91031,6 @@ pub enum WorkflowRunCompletedWorkflowRunConclusion {
     ActionRequired,
     #[serde(rename = "stale")]
     Stale,
-}
-impl ::std::convert::From<&Self> for WorkflowRunCompletedWorkflowRunConclusion {
-    fn from(value: &WorkflowRunCompletedWorkflowRunConclusion) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for WorkflowRunCompletedWorkflowRunConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -97259,13 +91161,6 @@ pub struct WorkflowRunCompletedWorkflowRunPullRequestsItem {
     pub number: f64,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&WorkflowRunCompletedWorkflowRunPullRequestsItem>
-    for WorkflowRunCompletedWorkflowRunPullRequestsItem
-{
-    fn from(value: &WorkflowRunCompletedWorkflowRunPullRequestsItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`WorkflowRunCompletedWorkflowRunPullRequestsItemBase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -97301,13 +91196,6 @@ pub struct WorkflowRunCompletedWorkflowRunPullRequestsItemBase {
     pub repo: RepoRef,
     pub sha: ::std::string::String,
 }
-impl ::std::convert::From<&WorkflowRunCompletedWorkflowRunPullRequestsItemBase>
-    for WorkflowRunCompletedWorkflowRunPullRequestsItemBase
-{
-    fn from(value: &WorkflowRunCompletedWorkflowRunPullRequestsItemBase) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`WorkflowRunCompletedWorkflowRunPullRequestsItemHead`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -97342,13 +91230,6 @@ pub struct WorkflowRunCompletedWorkflowRunPullRequestsItemHead {
     pub ref_: ::std::string::String,
     pub repo: RepoRef,
     pub sha: ::std::string::String,
-}
-impl ::std::convert::From<&WorkflowRunCompletedWorkflowRunPullRequestsItemHead>
-    for WorkflowRunCompletedWorkflowRunPullRequestsItemHead
-{
-    fn from(value: &WorkflowRunCompletedWorkflowRunPullRequestsItemHead) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`WorkflowRunCompletedWorkflowRunStatus`"]
 #[doc = r""]
@@ -97387,11 +91268,6 @@ pub enum WorkflowRunCompletedWorkflowRunStatus {
     Completed,
     #[serde(rename = "queued")]
     Queued,
-}
-impl ::std::convert::From<&Self> for WorkflowRunCompletedWorkflowRunStatus {
-    fn from(value: &WorkflowRunCompletedWorkflowRunStatus) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for WorkflowRunCompletedWorkflowRunStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -97484,11 +91360,6 @@ pub enum WorkflowRunConclusion {
     #[serde(rename = "stale")]
     Stale,
 }
-impl ::std::convert::From<&Self> for WorkflowRunConclusion {
-    fn from(value: &WorkflowRunConclusion) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for WorkflowRunConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -97561,11 +91432,6 @@ impl ::std::convert::TryFrom<::std::string::String> for WorkflowRunConclusion {
 pub enum WorkflowRunEvent {
     Completed(WorkflowRunCompleted),
     Requested(WorkflowRunRequested),
-}
-impl ::std::convert::From<&Self> for WorkflowRunEvent {
-    fn from(value: &WorkflowRunEvent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<WorkflowRunCompleted> for WorkflowRunEvent {
     fn from(value: WorkflowRunCompleted) -> Self {
@@ -97656,11 +91522,6 @@ pub struct WorkflowRunPullRequestsItem {
     pub number: f64,
     pub url: ::std::string::String,
 }
-impl ::std::convert::From<&WorkflowRunPullRequestsItem> for WorkflowRunPullRequestsItem {
-    fn from(value: &WorkflowRunPullRequestsItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`WorkflowRunPullRequestsItemBase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -97696,11 +91557,6 @@ pub struct WorkflowRunPullRequestsItemBase {
     pub repo: RepoRef,
     pub sha: ::std::string::String,
 }
-impl ::std::convert::From<&WorkflowRunPullRequestsItemBase> for WorkflowRunPullRequestsItemBase {
-    fn from(value: &WorkflowRunPullRequestsItemBase) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`WorkflowRunPullRequestsItemHead`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -97735,11 +91591,6 @@ pub struct WorkflowRunPullRequestsItemHead {
     pub ref_: ::std::string::String,
     pub repo: RepoRef,
     pub sha: ::std::string::String,
-}
-impl ::std::convert::From<&WorkflowRunPullRequestsItemHead> for WorkflowRunPullRequestsItemHead {
-    fn from(value: &WorkflowRunPullRequestsItemHead) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`WorkflowRunRequested`"]
 #[doc = r""]
@@ -97800,11 +91651,6 @@ pub struct WorkflowRunRequested {
     pub workflow: Workflow,
     pub workflow_run: WorkflowRun,
 }
-impl ::std::convert::From<&WorkflowRunRequested> for WorkflowRunRequested {
-    fn from(value: &WorkflowRunRequested) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`WorkflowRunRequestedAction`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -97833,11 +91679,6 @@ impl ::std::convert::From<&WorkflowRunRequested> for WorkflowRunRequested {
 pub enum WorkflowRunRequestedAction {
     #[serde(rename = "requested")]
     Requested,
-}
-impl ::std::convert::From<&Self> for WorkflowRunRequestedAction {
-    fn from(value: &WorkflowRunRequestedAction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for WorkflowRunRequestedAction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -97915,11 +91756,6 @@ pub enum WorkflowRunStatus {
     #[serde(rename = "queued")]
     Queued,
 }
-impl ::std::convert::From<&Self> for WorkflowRunStatus {
-    fn from(value: &WorkflowRunStatus) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for WorkflowRunStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -97990,11 +91826,6 @@ pub enum WorkflowStep {
     InProgress(WorkflowStepInProgress),
     Completed(WorkflowStepCompleted),
 }
-impl ::std::convert::From<&Self> for WorkflowStep {
-    fn from(value: &WorkflowStep) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<WorkflowStepInProgress> for WorkflowStep {
     fn from(value: WorkflowStepInProgress) -> Self {
         Self::InProgress(value)
@@ -98064,11 +91895,6 @@ pub struct WorkflowStepCompleted {
     pub started_at: ::std::string::String,
     pub status: WorkflowStepCompletedStatus,
 }
-impl ::std::convert::From<&WorkflowStepCompleted> for WorkflowStepCompleted {
-    fn from(value: &WorkflowStepCompleted) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`WorkflowStepCompletedConclusion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -98103,11 +91929,6 @@ pub enum WorkflowStepCompletedConclusion {
     Skipped,
     #[serde(rename = "success")]
     Success,
-}
-impl ::std::convert::From<&Self> for WorkflowStepCompletedConclusion {
-    fn from(value: &WorkflowStepCompletedConclusion) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for WorkflowStepCompletedConclusion {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -98179,11 +92000,6 @@ impl ::std::convert::TryFrom<::std::string::String> for WorkflowStepCompletedCon
 pub enum WorkflowStepCompletedStatus {
     #[serde(rename = "completed")]
     Completed,
-}
-impl ::std::convert::From<&Self> for WorkflowStepCompletedStatus {
-    fn from(value: &WorkflowStepCompletedStatus) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for WorkflowStepCompletedStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -98277,11 +92093,6 @@ pub struct WorkflowStepInProgress {
     pub started_at: ::std::string::String,
     pub status: WorkflowStepInProgressStatus,
 }
-impl ::std::convert::From<&WorkflowStepInProgress> for WorkflowStepInProgress {
-    fn from(value: &WorkflowStepInProgress) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`WorkflowStepInProgressStatus`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -98310,11 +92121,6 @@ impl ::std::convert::From<&WorkflowStepInProgress> for WorkflowStepInProgress {
 pub enum WorkflowStepInProgressStatus {
     #[serde(rename = "in_progress")]
     InProgress,
-}
-impl ::std::convert::From<&Self> for WorkflowStepInProgressStatus {
-    fn from(value: &WorkflowStepInProgressStatus) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for WorkflowStepInProgressStatus {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {

--- a/typify-impl/tests/vega.out
+++ b/typify-impl/tests/vega.out
@@ -225,11 +225,6 @@ pub struct AggregateTransform {
     #[serde(rename = "type")]
     pub type_: AggregateTransformType,
 }
-impl ::std::convert::From<&AggregateTransform> for AggregateTransform {
-    fn from(value: &AggregateTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`AggregateTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -265,11 +260,6 @@ impl ::std::convert::From<&AggregateTransform> for AggregateTransform {
 pub enum AggregateTransformAs {
     Array(::std::vec::Vec<AggregateTransformAsArrayItem>),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for AggregateTransformAs {
-    fn from(value: &AggregateTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<AggregateTransformAsArrayItem>> for AggregateTransformAs {
     fn from(value: ::std::vec::Vec<AggregateTransformAsArrayItem>) -> Self {
@@ -308,11 +298,6 @@ pub enum AggregateTransformAsArrayItem {
     SignalRef(SignalRef),
     Null,
 }
-impl ::std::convert::From<&Self> for AggregateTransformAsArrayItem {
-    fn from(value: &AggregateTransformAsArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for AggregateTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -340,11 +325,6 @@ impl ::std::convert::From<SignalRef> for AggregateTransformAsArrayItem {
 pub enum AggregateTransformCross {
     Boolean(bool),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for AggregateTransformCross {
-    fn from(value: &AggregateTransformCross) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<bool> for AggregateTransformCross {
     fn from(value: bool) -> Self {
@@ -379,11 +359,6 @@ impl ::std::convert::From<SignalRef> for AggregateTransformCross {
 pub enum AggregateTransformDrop {
     Boolean(bool),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for AggregateTransformDrop {
-    fn from(value: &AggregateTransformDrop) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for AggregateTransformDrop {
     fn default() -> Self {
@@ -439,11 +414,6 @@ pub enum AggregateTransformFields {
     Array(::std::vec::Vec<AggregateTransformFieldsArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for AggregateTransformFields {
-    fn from(value: &AggregateTransformFields) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<AggregateTransformFieldsArrayItem>>
     for AggregateTransformFields
 {
@@ -486,11 +456,6 @@ pub enum AggregateTransformFieldsArrayItem {
     ParamField(ParamField),
     Expr(Expr),
     Null,
-}
-impl ::std::convert::From<&Self> for AggregateTransformFieldsArrayItem {
-    fn from(value: &AggregateTransformFieldsArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for AggregateTransformFieldsArrayItem {
     fn from(value: ScaleField) -> Self {
@@ -543,11 +508,6 @@ pub enum AggregateTransformGroupby {
     Array(::std::vec::Vec<AggregateTransformGroupbyArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for AggregateTransformGroupby {
-    fn from(value: &AggregateTransformGroupby) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<AggregateTransformGroupbyArrayItem>>
     for AggregateTransformGroupby
 {
@@ -586,11 +546,6 @@ pub enum AggregateTransformGroupbyArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for AggregateTransformGroupbyArrayItem {
-    fn from(value: &AggregateTransformGroupbyArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for AggregateTransformGroupbyArrayItem {
     fn from(value: ScaleField) -> Self {
@@ -633,11 +588,6 @@ pub enum AggregateTransformKey {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for AggregateTransformKey {
-    fn from(value: &AggregateTransformKey) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for AggregateTransformKey {
     fn from(value: ScaleField) -> Self {
@@ -712,11 +662,6 @@ pub enum AggregateTransformOps {
     Array(::std::vec::Vec<AggregateTransformOpsArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for AggregateTransformOps {
-    fn from(value: &AggregateTransformOps) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<AggregateTransformOpsArrayItem>>
     for AggregateTransformOps
 {
@@ -776,11 +721,6 @@ impl ::std::convert::From<SignalRef> for AggregateTransformOps {
 pub enum AggregateTransformOpsArrayItem {
     Variant0(AggregateTransformOpsArrayItemVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for AggregateTransformOpsArrayItem {
-    fn from(value: &AggregateTransformOpsArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<AggregateTransformOpsArrayItemVariant0>
     for AggregateTransformOpsArrayItem
@@ -890,11 +830,6 @@ pub enum AggregateTransformOpsArrayItemVariant0 {
     Argmin,
     #[serde(rename = "argmax")]
     Argmax,
-}
-impl ::std::convert::From<&Self> for AggregateTransformOpsArrayItemVariant0 {
-    fn from(value: &AggregateTransformOpsArrayItemVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AggregateTransformOpsArrayItemVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -1007,11 +942,6 @@ impl ::std::convert::TryFrom<::std::string::String> for AggregateTransformOpsArr
 pub enum AggregateTransformType {
     #[serde(rename = "aggregate")]
     Aggregate,
-}
-impl ::std::convert::From<&Self> for AggregateTransformType {
-    fn from(value: &AggregateTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AggregateTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -1242,11 +1172,6 @@ pub enum AlignValue {
     Variant0(::std::vec::Vec<AlignValueVariant0Item>),
     Variant1(AlignValueVariant1),
 }
-impl ::std::convert::From<&Self> for AlignValue {
-    fn from(value: &AlignValue) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<AlignValueVariant0Item>> for AlignValue {
     fn from(value: ::std::vec::Vec<AlignValueVariant0Item>) -> Self {
         Self::Variant0(value)
@@ -1364,11 +1289,6 @@ pub enum AlignValueVariant0Item {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
-}
-impl ::std::convert::From<&Self> for AlignValueVariant0Item {
-    fn from(value: &AlignValueVariant0Item) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<AlignValueVariant0ItemVariant0> for AlignValueVariant0Item {
     fn from(value: AlignValueVariant0ItemVariant0) -> Self {
@@ -1516,11 +1436,6 @@ pub enum AlignValueVariant0ItemVariant0 {
         test: ::std::option::Option<::std::string::String>,
     },
 }
-impl ::std::convert::From<&Self> for AlignValueVariant0ItemVariant0 {
-    fn from(value: &AlignValueVariant0ItemVariant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`AlignValueVariant0ItemVariant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -1554,11 +1469,6 @@ pub enum AlignValueVariant0ItemVariant0Variant1Value {
     Right,
     #[serde(rename = "center")]
     Center,
-}
-impl ::std::convert::From<&Self> for AlignValueVariant0ItemVariant0Variant1Value {
-    fn from(value: &AlignValueVariant0ItemVariant0Variant1Value) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AlignValueVariant0ItemVariant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -1628,11 +1538,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum AlignValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for AlignValueVariant0ItemVariant0Variant3Range {
-    fn from(value: &AlignValueVariant0ItemVariant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for AlignValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -1803,11 +1708,6 @@ impl ::std::convert::From<bool> for AlignValueVariant0ItemVariant0Variant3Range 
 )]
 #[serde(deny_unknown_fields)]
 pub enum AlignValueVariant0ItemVariant1 {}
-impl ::std::convert::From<&Self> for AlignValueVariant0ItemVariant1 {
-    fn from(value: &AlignValueVariant0ItemVariant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`AlignValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -1921,11 +1821,6 @@ impl ::std::convert::From<&Self> for AlignValueVariant0ItemVariant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum AlignValueVariant0ItemVariant2 {}
-impl ::std::convert::From<&Self> for AlignValueVariant0ItemVariant2 {
-    fn from(value: &AlignValueVariant0ItemVariant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`AlignValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -2022,11 +1917,6 @@ pub enum AlignValueVariant1 {
     Variant1(AlignValueVariant1Variant1),
     Variant2(AlignValueVariant1Variant2),
     Variant3 { offset: ::serde_json::Value },
-}
-impl ::std::convert::From<&Self> for AlignValueVariant1 {
-    fn from(value: &AlignValueVariant1) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<AlignValueVariant1Variant0> for AlignValueVariant1 {
     fn from(value: AlignValueVariant1Variant0) -> Self {
@@ -2163,11 +2053,6 @@ pub enum AlignValueVariant1Variant0 {
         scale: ::std::option::Option<Field>,
     },
 }
-impl ::std::convert::From<&Self> for AlignValueVariant1Variant0 {
-    fn from(value: &AlignValueVariant1Variant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`AlignValueVariant1Variant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -2201,11 +2086,6 @@ pub enum AlignValueVariant1Variant0Variant1Value {
     Right,
     #[serde(rename = "center")]
     Center,
-}
-impl ::std::convert::From<&Self> for AlignValueVariant1Variant0Variant1Value {
-    fn from(value: &AlignValueVariant1Variant0Variant1Value) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AlignValueVariant1Variant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -2271,11 +2151,6 @@ impl ::std::convert::TryFrom<::std::string::String> for AlignValueVariant1Varian
 pub enum AlignValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for AlignValueVariant1Variant0Variant3Range {
-    fn from(value: &AlignValueVariant1Variant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for AlignValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -2439,11 +2314,6 @@ impl ::std::convert::From<bool> for AlignValueVariant1Variant0Variant3Range {
 )]
 #[serde(deny_unknown_fields)]
 pub enum AlignValueVariant1Variant1 {}
-impl ::std::convert::From<&Self> for AlignValueVariant1Variant1 {
-    fn from(value: &AlignValueVariant1Variant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`AlignValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -2554,11 +2424,6 @@ impl ::std::convert::From<&Self> for AlignValueVariant1Variant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum AlignValueVariant1Variant2 {}
-impl ::std::convert::From<&Self> for AlignValueVariant1Variant2 {
-    fn from(value: &AlignValueVariant1Variant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`AnchorValue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -2750,11 +2615,6 @@ pub enum AnchorValue {
     Variant0(::std::vec::Vec<AnchorValueVariant0Item>),
     Variant1(AnchorValueVariant1),
 }
-impl ::std::convert::From<&Self> for AnchorValue {
-    fn from(value: &AnchorValue) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<AnchorValueVariant0Item>> for AnchorValue {
     fn from(value: ::std::vec::Vec<AnchorValueVariant0Item>) -> Self {
         Self::Variant0(value)
@@ -2872,11 +2732,6 @@ pub enum AnchorValueVariant0Item {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
-}
-impl ::std::convert::From<&Self> for AnchorValueVariant0Item {
-    fn from(value: &AnchorValueVariant0Item) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<AnchorValueVariant0ItemVariant0> for AnchorValueVariant0Item {
     fn from(value: AnchorValueVariant0ItemVariant0) -> Self {
@@ -3024,11 +2879,6 @@ pub enum AnchorValueVariant0ItemVariant0 {
         test: ::std::option::Option<::std::string::String>,
     },
 }
-impl ::std::convert::From<&Self> for AnchorValueVariant0ItemVariant0 {
-    fn from(value: &AnchorValueVariant0ItemVariant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`AnchorValueVariant0ItemVariant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -3062,11 +2912,6 @@ pub enum AnchorValueVariant0ItemVariant0Variant1Value {
     Middle,
     #[serde(rename = "end")]
     End,
-}
-impl ::std::convert::From<&Self> for AnchorValueVariant0ItemVariant0Variant1Value {
-    fn from(value: &AnchorValueVariant0ItemVariant0Variant1Value) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AnchorValueVariant0ItemVariant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -3136,11 +2981,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum AnchorValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for AnchorValueVariant0ItemVariant0Variant3Range {
-    fn from(value: &AnchorValueVariant0ItemVariant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for AnchorValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -3311,11 +3151,6 @@ impl ::std::convert::From<bool> for AnchorValueVariant0ItemVariant0Variant3Range
 )]
 #[serde(deny_unknown_fields)]
 pub enum AnchorValueVariant0ItemVariant1 {}
-impl ::std::convert::From<&Self> for AnchorValueVariant0ItemVariant1 {
-    fn from(value: &AnchorValueVariant0ItemVariant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`AnchorValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -3429,11 +3264,6 @@ impl ::std::convert::From<&Self> for AnchorValueVariant0ItemVariant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum AnchorValueVariant0ItemVariant2 {}
-impl ::std::convert::From<&Self> for AnchorValueVariant0ItemVariant2 {
-    fn from(value: &AnchorValueVariant0ItemVariant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`AnchorValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -3530,11 +3360,6 @@ pub enum AnchorValueVariant1 {
     Variant1(AnchorValueVariant1Variant1),
     Variant2(AnchorValueVariant1Variant2),
     Variant3 { offset: ::serde_json::Value },
-}
-impl ::std::convert::From<&Self> for AnchorValueVariant1 {
-    fn from(value: &AnchorValueVariant1) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<AnchorValueVariant1Variant0> for AnchorValueVariant1 {
     fn from(value: AnchorValueVariant1Variant0) -> Self {
@@ -3671,11 +3496,6 @@ pub enum AnchorValueVariant1Variant0 {
         scale: ::std::option::Option<Field>,
     },
 }
-impl ::std::convert::From<&Self> for AnchorValueVariant1Variant0 {
-    fn from(value: &AnchorValueVariant1Variant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`AnchorValueVariant1Variant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -3709,11 +3529,6 @@ pub enum AnchorValueVariant1Variant0Variant1Value {
     Middle,
     #[serde(rename = "end")]
     End,
-}
-impl ::std::convert::From<&Self> for AnchorValueVariant1Variant0Variant1Value {
-    fn from(value: &AnchorValueVariant1Variant0Variant1Value) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AnchorValueVariant1Variant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -3779,11 +3594,6 @@ impl ::std::convert::TryFrom<::std::string::String> for AnchorValueVariant1Varia
 pub enum AnchorValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for AnchorValueVariant1Variant0Variant3Range {
-    fn from(value: &AnchorValueVariant1Variant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for AnchorValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -3947,11 +3757,6 @@ impl ::std::convert::From<bool> for AnchorValueVariant1Variant0Variant3Range {
 )]
 #[serde(deny_unknown_fields)]
 pub enum AnchorValueVariant1Variant1 {}
-impl ::std::convert::From<&Self> for AnchorValueVariant1Variant1 {
-    fn from(value: &AnchorValueVariant1Variant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`AnchorValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -4062,11 +3867,6 @@ impl ::std::convert::From<&Self> for AnchorValueVariant1Variant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum AnchorValueVariant1Variant2 {}
-impl ::std::convert::From<&Self> for AnchorValueVariant1Variant2 {
-    fn from(value: &AnchorValueVariant1Variant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`AnyValue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -4246,11 +4046,6 @@ pub enum AnyValue {
     Variant0(::std::vec::Vec<AnyValueVariant0Item>),
     Variant1(AnyValueVariant1),
 }
-impl ::std::convert::From<&Self> for AnyValue {
-    fn from(value: &AnyValue) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<AnyValueVariant0Item>> for AnyValue {
     fn from(value: ::std::vec::Vec<AnyValueVariant0Item>) -> Self {
         Self::Variant0(value)
@@ -4362,11 +4157,6 @@ pub enum AnyValueVariant0Item {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
-}
-impl ::std::convert::From<&Self> for AnyValueVariant0Item {
-    fn from(value: &AnyValueVariant0Item) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<AnyValueVariant0ItemVariant0> for AnyValueVariant0Item {
     fn from(value: AnyValueVariant0ItemVariant0) -> Self {
@@ -4508,11 +4298,6 @@ pub enum AnyValueVariant0ItemVariant0 {
         test: ::std::option::Option<::std::string::String>,
     },
 }
-impl ::std::convert::From<&Self> for AnyValueVariant0ItemVariant0 {
-    fn from(value: &AnyValueVariant0ItemVariant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`AnyValueVariant0ItemVariant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -4535,11 +4320,6 @@ impl ::std::convert::From<&Self> for AnyValueVariant0ItemVariant0 {
 pub enum AnyValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for AnyValueVariant0ItemVariant0Variant3Range {
-    fn from(value: &AnyValueVariant0ItemVariant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for AnyValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -4700,11 +4480,6 @@ impl ::std::convert::From<bool> for AnyValueVariant0ItemVariant0Variant3Range {
 )]
 #[serde(deny_unknown_fields)]
 pub enum AnyValueVariant0ItemVariant1 {}
-impl ::std::convert::From<&Self> for AnyValueVariant0ItemVariant1 {
-    fn from(value: &AnyValueVariant0ItemVariant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`AnyValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -4812,11 +4587,6 @@ impl ::std::convert::From<&Self> for AnyValueVariant0ItemVariant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum AnyValueVariant0ItemVariant2 {}
-impl ::std::convert::From<&Self> for AnyValueVariant0ItemVariant2 {
-    fn from(value: &AnyValueVariant0ItemVariant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`AnyValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -4907,11 +4677,6 @@ pub enum AnyValueVariant1 {
     Variant1(AnyValueVariant1Variant1),
     Variant2(AnyValueVariant1Variant2),
     Variant3 { offset: ::serde_json::Value },
-}
-impl ::std::convert::From<&Self> for AnyValueVariant1 {
-    fn from(value: &AnyValueVariant1) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<AnyValueVariant1Variant0> for AnyValueVariant1 {
     fn from(value: AnyValueVariant1Variant0) -> Self {
@@ -5042,11 +4807,6 @@ pub enum AnyValueVariant1Variant0 {
         scale: ::std::option::Option<Field>,
     },
 }
-impl ::std::convert::From<&Self> for AnyValueVariant1Variant0 {
-    fn from(value: &AnyValueVariant1Variant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`AnyValueVariant1Variant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -5069,11 +4829,6 @@ impl ::std::convert::From<&Self> for AnyValueVariant1Variant0 {
 pub enum AnyValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for AnyValueVariant1Variant0Variant3Range {
-    fn from(value: &AnyValueVariant1Variant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for AnyValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -5231,11 +4986,6 @@ impl ::std::convert::From<bool> for AnyValueVariant1Variant0Variant3Range {
 )]
 #[serde(deny_unknown_fields)]
 pub enum AnyValueVariant1Variant1 {}
-impl ::std::convert::From<&Self> for AnyValueVariant1Variant1 {
-    fn from(value: &AnyValueVariant1Variant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`AnyValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -5340,11 +5090,6 @@ impl ::std::convert::From<&Self> for AnyValueVariant1Variant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum AnyValueVariant1Variant2 {}
-impl ::std::convert::From<&Self> for AnyValueVariant1Variant2 {
-    fn from(value: &AnyValueVariant1Variant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ArrayOrSignal`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -5367,11 +5112,6 @@ impl ::std::convert::From<&Self> for AnyValueVariant1Variant2 {
 pub enum ArrayOrSignal {
     Array(::std::vec::Vec<::serde_json::Value>),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ArrayOrSignal {
-    fn from(value: &ArrayOrSignal) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ArrayOrSignal {
     fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
@@ -5566,11 +5306,6 @@ pub enum ArrayValue {
     Variant0(::std::vec::Vec<ArrayValueVariant0Item>),
     Variant1(ArrayValueVariant1),
 }
-impl ::std::convert::From<&Self> for ArrayValue {
-    fn from(value: &ArrayValue) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ArrayValueVariant0Item>> for ArrayValue {
     fn from(value: ::std::vec::Vec<ArrayValueVariant0Item>) -> Self {
         Self::Variant0(value)
@@ -5684,11 +5419,6 @@ pub enum ArrayValueVariant0Item {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
-}
-impl ::std::convert::From<&Self> for ArrayValueVariant0Item {
-    fn from(value: &ArrayValueVariant0Item) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ArrayValueVariant0ItemVariant0> for ArrayValueVariant0Item {
     fn from(value: ArrayValueVariant0ItemVariant0) -> Self {
@@ -5832,11 +5562,6 @@ pub enum ArrayValueVariant0ItemVariant0 {
         test: ::std::option::Option<::std::string::String>,
     },
 }
-impl ::std::convert::From<&Self> for ArrayValueVariant0ItemVariant0 {
-    fn from(value: &ArrayValueVariant0ItemVariant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ArrayValueVariant0ItemVariant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -5859,11 +5584,6 @@ impl ::std::convert::From<&Self> for ArrayValueVariant0ItemVariant0 {
 pub enum ArrayValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for ArrayValueVariant0ItemVariant0Variant3Range {
-    fn from(value: &ArrayValueVariant0ItemVariant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for ArrayValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -6030,11 +5750,6 @@ impl ::std::convert::From<bool> for ArrayValueVariant0ItemVariant0Variant3Range 
 )]
 #[serde(deny_unknown_fields)]
 pub enum ArrayValueVariant0ItemVariant1 {}
-impl ::std::convert::From<&Self> for ArrayValueVariant0ItemVariant1 {
-    fn from(value: &ArrayValueVariant0ItemVariant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ArrayValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -6144,11 +5859,6 @@ impl ::std::convert::From<&Self> for ArrayValueVariant0ItemVariant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum ArrayValueVariant0ItemVariant2 {}
-impl ::std::convert::From<&Self> for ArrayValueVariant0ItemVariant2 {
-    fn from(value: &ArrayValueVariant0ItemVariant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ArrayValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -6241,11 +5951,6 @@ pub enum ArrayValueVariant1 {
     Variant1(ArrayValueVariant1Variant1),
     Variant2(ArrayValueVariant1Variant2),
     Variant3 { offset: ::serde_json::Value },
-}
-impl ::std::convert::From<&Self> for ArrayValueVariant1 {
-    fn from(value: &ArrayValueVariant1) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ArrayValueVariant1Variant0> for ArrayValueVariant1 {
     fn from(value: ArrayValueVariant1Variant0) -> Self {
@@ -6378,11 +6083,6 @@ pub enum ArrayValueVariant1Variant0 {
         scale: ::std::option::Option<Field>,
     },
 }
-impl ::std::convert::From<&Self> for ArrayValueVariant1Variant0 {
-    fn from(value: &ArrayValueVariant1Variant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ArrayValueVariant1Variant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -6405,11 +6105,6 @@ impl ::std::convert::From<&Self> for ArrayValueVariant1Variant0 {
 pub enum ArrayValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for ArrayValueVariant1Variant0Variant3Range {
-    fn from(value: &ArrayValueVariant1Variant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for ArrayValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -6569,11 +6264,6 @@ impl ::std::convert::From<bool> for ArrayValueVariant1Variant0Variant3Range {
 )]
 #[serde(deny_unknown_fields)]
 pub enum ArrayValueVariant1Variant1 {}
-impl ::std::convert::From<&Self> for ArrayValueVariant1Variant1 {
-    fn from(value: &ArrayValueVariant1Variant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ArrayValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -6680,11 +6370,6 @@ impl ::std::convert::From<&Self> for ArrayValueVariant1Variant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum ArrayValueVariant1Variant2 {}
-impl ::std::convert::From<&Self> for ArrayValueVariant1Variant2 {
-    fn from(value: &ArrayValueVariant1Variant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`Autosize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -6751,11 +6436,6 @@ pub enum Autosize {
     },
     Variant2(SignalRef),
 }
-impl ::std::convert::From<&Self> for Autosize {
-    fn from(value: &Autosize) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<AutosizeVariant0> for Autosize {
     fn from(value: AutosizeVariant0) -> Self {
         Self::Variant0(value)
@@ -6806,11 +6486,6 @@ pub enum AutosizeVariant0 {
     FitY,
     #[serde(rename = "none")]
     None,
-}
-impl ::std::convert::From<&Self> for AutosizeVariant0 {
-    fn from(value: &AutosizeVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AutosizeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -6888,11 +6563,6 @@ pub enum AutosizeVariant1Contains {
     Content,
     #[serde(rename = "padding")]
     Padding,
-}
-impl ::std::convert::From<&Self> for AutosizeVariant1Contains {
-    fn from(value: &AutosizeVariant1Contains) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AutosizeVariant1Contains {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -6974,11 +6644,6 @@ pub enum AutosizeVariant1Type {
     FitY,
     #[serde(rename = "none")]
     None,
-}
-impl ::std::convert::From<&Self> for AutosizeVariant1Type {
-    fn from(value: &AutosizeVariant1Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AutosizeVariant1Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -8288,11 +7953,6 @@ pub struct Axis {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub zindex: ::std::option::Option<f64>,
 }
-impl ::std::convert::From<&Axis> for Axis {
-    fn from(value: &Axis) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`AxisBandPosition`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -8315,11 +7975,6 @@ impl ::std::convert::From<&Axis> for Axis {
 pub enum AxisBandPosition {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for AxisBandPosition {
-    fn from(value: &AxisBandPosition) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for AxisBandPosition {
     fn from(value: f64) -> Self {
@@ -8354,11 +8009,6 @@ pub enum AxisDomainCap {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for AxisDomainCap {
-    fn from(value: &AxisDomainCap) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for AxisDomainCap {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -8391,11 +8041,6 @@ pub enum AxisDomainColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for AxisDomainColor {
-    fn from(value: &AxisDomainColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for AxisDomainColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -8426,11 +8071,6 @@ impl ::std::convert::From<ColorValue> for AxisDomainColor {
 pub enum AxisDomainDash {
     Variant0(::std::vec::Vec<f64>),
     Variant1(ArrayValue),
-}
-impl ::std::convert::From<&Self> for AxisDomainDash {
-    fn from(value: &AxisDomainDash) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<f64>> for AxisDomainDash {
     fn from(value: ::std::vec::Vec<f64>) -> Self {
@@ -8465,11 +8105,6 @@ pub enum AxisDomainDashOffset {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for AxisDomainDashOffset {
-    fn from(value: &AxisDomainDashOffset) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for AxisDomainDashOffset {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -8503,11 +8138,6 @@ pub enum AxisDomainOpacity {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for AxisDomainOpacity {
-    fn from(value: &AxisDomainOpacity) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for AxisDomainOpacity {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -8540,11 +8170,6 @@ impl ::std::convert::From<NumberValue> for AxisDomainOpacity {
 pub enum AxisDomainWidth {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for AxisDomainWidth {
-    fn from(value: &AxisDomainWidth) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for AxisDomainWidth {
     fn from(value: f64) -> Self {
@@ -8602,11 +8227,6 @@ pub struct AxisEncode {
     pub ticks: ::std::option::Option<GuideEncode>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
-}
-impl ::std::convert::From<&AxisEncode> for AxisEncode {
-    fn from(value: &AxisEncode) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for AxisEncode {
     fn default() -> Self {
@@ -8701,11 +8321,6 @@ pub enum AxisFormat {
     },
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for AxisFormat {
-    fn from(value: &AxisFormat) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for AxisFormat {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -8737,11 +8352,6 @@ impl ::std::convert::From<SignalRef> for AxisFormat {
 pub enum AxisFormatType {
     Variant0(AxisFormatTypeVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for AxisFormatType {
-    fn from(value: &AxisFormatType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<AxisFormatTypeVariant0> for AxisFormatType {
     fn from(value: AxisFormatTypeVariant0) -> Self {
@@ -8786,11 +8396,6 @@ pub enum AxisFormatTypeVariant0 {
     Time,
     #[serde(rename = "utc")]
     Utc,
-}
-impl ::std::convert::From<&Self> for AxisFormatTypeVariant0 {
-    fn from(value: &AxisFormatTypeVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AxisFormatTypeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -8857,11 +8462,6 @@ pub enum AxisGridCap {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for AxisGridCap {
-    fn from(value: &AxisGridCap) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for AxisGridCap {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -8894,11 +8494,6 @@ pub enum AxisGridColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for AxisGridColor {
-    fn from(value: &AxisGridColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for AxisGridColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -8929,11 +8524,6 @@ impl ::std::convert::From<ColorValue> for AxisGridColor {
 pub enum AxisGridDash {
     Variant0(::std::vec::Vec<f64>),
     Variant1(ArrayValue),
-}
-impl ::std::convert::From<&Self> for AxisGridDash {
-    fn from(value: &AxisGridDash) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<f64>> for AxisGridDash {
     fn from(value: ::std::vec::Vec<f64>) -> Self {
@@ -8968,11 +8558,6 @@ pub enum AxisGridDashOffset {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for AxisGridDashOffset {
-    fn from(value: &AxisGridDashOffset) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for AxisGridDashOffset {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -9006,11 +8591,6 @@ pub enum AxisGridOpacity {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for AxisGridOpacity {
-    fn from(value: &AxisGridOpacity) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for AxisGridOpacity {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -9043,11 +8623,6 @@ impl ::std::convert::From<NumberValue> for AxisGridOpacity {
 pub enum AxisGridWidth {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for AxisGridWidth {
-    fn from(value: &AxisGridWidth) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for AxisGridWidth {
     fn from(value: f64) -> Self {
@@ -9085,11 +8660,6 @@ impl ::std::convert::From<NumberValue> for AxisGridWidth {
 pub enum AxisLabelAlign {
     Variant0(AxisLabelAlignVariant0),
     Variant1(AlignValue),
-}
-impl ::std::convert::From<&Self> for AxisLabelAlign {
-    fn from(value: &AxisLabelAlign) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<AxisLabelAlignVariant0> for AxisLabelAlign {
     fn from(value: AxisLabelAlignVariant0) -> Self {
@@ -9134,11 +8704,6 @@ pub enum AxisLabelAlignVariant0 {
     Right,
     #[serde(rename = "center")]
     Center,
-}
-impl ::std::convert::From<&Self> for AxisLabelAlignVariant0 {
-    fn from(value: &AxisLabelAlignVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AxisLabelAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -9205,11 +8770,6 @@ pub enum AxisLabelAngle {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for AxisLabelAngle {
-    fn from(value: &AxisLabelAngle) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for AxisLabelAngle {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -9249,11 +8809,6 @@ impl ::std::convert::From<NumberValue> for AxisLabelAngle {
 pub enum AxisLabelBaseline {
     Variant0(AxisLabelBaselineVariant0),
     Variant1(BaselineValue),
-}
-impl ::std::convert::From<&Self> for AxisLabelBaseline {
-    fn from(value: &AxisLabelBaseline) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<AxisLabelBaselineVariant0> for AxisLabelBaseline {
     fn from(value: AxisLabelBaselineVariant0) -> Self {
@@ -9307,11 +8862,6 @@ pub enum AxisLabelBaselineVariant0 {
     LineTop,
     #[serde(rename = "line-bottom")]
     LineBottom,
-}
-impl ::std::convert::From<&Self> for AxisLabelBaselineVariant0 {
-    fn from(value: &AxisLabelBaselineVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AxisLabelBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -9388,11 +8938,6 @@ pub enum AxisLabelBound {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for AxisLabelBound {
-    fn from(value: &AxisLabelBound) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for AxisLabelBound {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -9435,11 +8980,6 @@ pub enum AxisLabelColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for AxisLabelColor {
-    fn from(value: &AxisLabelColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for AxisLabelColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -9471,11 +9011,6 @@ pub enum AxisLabelFlush {
     Boolean(bool),
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for AxisLabelFlush {
-    fn from(value: &AxisLabelFlush) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<bool> for AxisLabelFlush {
     fn from(value: bool) -> Self {
@@ -9515,11 +9050,6 @@ pub enum AxisLabelFont {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for AxisLabelFont {
-    fn from(value: &AxisLabelFont) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for AxisLabelFont {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -9547,11 +9077,6 @@ impl ::std::convert::From<StringValue> for AxisLabelFont {
 pub enum AxisLabelFontSize {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for AxisLabelFontSize {
-    fn from(value: &AxisLabelFontSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for AxisLabelFontSize {
     fn from(value: f64) -> Self {
@@ -9585,11 +9110,6 @@ impl ::std::convert::From<NumberValue> for AxisLabelFontSize {
 pub enum AxisLabelFontStyle {
     Variant0(::std::string::String),
     Variant1(StringValue),
-}
-impl ::std::convert::From<&Self> for AxisLabelFontStyle {
-    fn from(value: &AxisLabelFontStyle) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<StringValue> for AxisLabelFontStyle {
     fn from(value: StringValue) -> Self {
@@ -9643,11 +9163,6 @@ pub enum AxisLabelFontWeight {
     Variant0(MyEnum),
     Variant1(FontWeightValue),
 }
-impl ::std::convert::From<&Self> for AxisLabelFontWeight {
-    fn from(value: &AxisLabelFontWeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<MyEnum> for AxisLabelFontWeight {
     fn from(value: MyEnum) -> Self {
         Self::Variant0(value)
@@ -9680,11 +9195,6 @@ impl ::std::convert::From<FontWeightValue> for AxisLabelFontWeight {
 pub enum AxisLabelLimit {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for AxisLabelLimit {
-    fn from(value: &AxisLabelLimit) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for AxisLabelLimit {
     fn from(value: f64) -> Self {
@@ -9719,11 +9229,6 @@ pub enum AxisLabelLineHeight {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for AxisLabelLineHeight {
-    fn from(value: &AxisLabelLineHeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for AxisLabelLineHeight {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -9756,11 +9261,6 @@ impl ::std::convert::From<NumberValue> for AxisLabelLineHeight {
 pub enum AxisLabelOffset {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for AxisLabelOffset {
-    fn from(value: &AxisLabelOffset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for AxisLabelOffset {
     fn from(value: f64) -> Self {
@@ -9795,11 +9295,6 @@ pub enum AxisLabelOpacity {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for AxisLabelOpacity {
-    fn from(value: &AxisLabelOpacity) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for AxisLabelOpacity {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -9832,11 +9327,6 @@ impl ::std::convert::From<NumberValue> for AxisLabelOpacity {
 pub enum AxisLabelPadding {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for AxisLabelPadding {
-    fn from(value: &AxisLabelPadding) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for AxisLabelPadding {
     fn from(value: f64) -> Self {
@@ -9871,11 +9361,6 @@ pub enum AxisMaxExtent {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for AxisMaxExtent {
-    fn from(value: &AxisMaxExtent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for AxisMaxExtent {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -9909,11 +9394,6 @@ pub enum AxisMinExtent {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for AxisMinExtent {
-    fn from(value: &AxisMinExtent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for AxisMinExtent {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -9946,11 +9426,6 @@ impl ::std::convert::From<NumberValue> for AxisMinExtent {
 pub enum AxisOffset {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for AxisOffset {
-    fn from(value: &AxisOffset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for AxisOffset {
     fn from(value: f64) -> Self {
@@ -9989,11 +9464,6 @@ impl ::std::convert::From<NumberValue> for AxisOffset {
 pub enum AxisOrient {
     Variant0(AxisOrientVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for AxisOrient {
-    fn from(value: &AxisOrient) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<AxisOrientVariant0> for AxisOrient {
     fn from(value: AxisOrientVariant0) -> Self {
@@ -10041,11 +9511,6 @@ pub enum AxisOrientVariant0 {
     Left,
     #[serde(rename = "right")]
     Right,
-}
-impl ::std::convert::From<&Self> for AxisOrientVariant0 {
-    fn from(value: &AxisOrientVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AxisOrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -10114,11 +9579,6 @@ pub enum AxisPosition {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for AxisPosition {
-    fn from(value: &AxisPosition) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for AxisPosition {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -10152,11 +9612,6 @@ pub enum AxisTickCap {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for AxisTickCap {
-    fn from(value: &AxisTickCap) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for AxisTickCap {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -10189,11 +9644,6 @@ pub enum AxisTickColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for AxisTickColor {
-    fn from(value: &AxisTickColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for AxisTickColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -10224,11 +9674,6 @@ impl ::std::convert::From<ColorValue> for AxisTickColor {
 pub enum AxisTickDash {
     Variant0(::std::vec::Vec<f64>),
     Variant1(ArrayValue),
-}
-impl ::std::convert::From<&Self> for AxisTickDash {
-    fn from(value: &AxisTickDash) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<f64>> for AxisTickDash {
     fn from(value: ::std::vec::Vec<f64>) -> Self {
@@ -10263,11 +9708,6 @@ pub enum AxisTickDashOffset {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for AxisTickDashOffset {
-    fn from(value: &AxisTickDashOffset) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for AxisTickDashOffset {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -10300,11 +9740,6 @@ impl ::std::convert::From<NumberValue> for AxisTickDashOffset {
 pub enum AxisTickOffset {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for AxisTickOffset {
-    fn from(value: &AxisTickOffset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for AxisTickOffset {
     fn from(value: f64) -> Self {
@@ -10339,11 +9774,6 @@ pub enum AxisTickOpacity {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for AxisTickOpacity {
-    fn from(value: &AxisTickOpacity) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for AxisTickOpacity {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -10376,11 +9806,6 @@ impl ::std::convert::From<NumberValue> for AxisTickOpacity {
 pub enum AxisTickRound {
     Variant0(bool),
     Variant1(BooleanValue),
-}
-impl ::std::convert::From<&Self> for AxisTickRound {
-    fn from(value: &AxisTickRound) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<bool> for AxisTickRound {
     fn from(value: bool) -> Self {
@@ -10415,11 +9840,6 @@ pub enum AxisTickSize {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for AxisTickSize {
-    fn from(value: &AxisTickSize) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for AxisTickSize {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -10452,11 +9872,6 @@ impl ::std::convert::From<NumberValue> for AxisTickSize {
 pub enum AxisTickWidth {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for AxisTickWidth {
-    fn from(value: &AxisTickWidth) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for AxisTickWidth {
     fn from(value: f64) -> Self {
@@ -10494,11 +9909,6 @@ impl ::std::convert::From<NumberValue> for AxisTickWidth {
 pub enum AxisTitleAlign {
     Variant0(AxisTitleAlignVariant0),
     Variant1(AlignValue),
-}
-impl ::std::convert::From<&Self> for AxisTitleAlign {
-    fn from(value: &AxisTitleAlign) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<AxisTitleAlignVariant0> for AxisTitleAlign {
     fn from(value: AxisTitleAlignVariant0) -> Self {
@@ -10543,11 +9953,6 @@ pub enum AxisTitleAlignVariant0 {
     Right,
     #[serde(rename = "center")]
     Center,
-}
-impl ::std::convert::From<&Self> for AxisTitleAlignVariant0 {
-    fn from(value: &AxisTitleAlignVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AxisTitleAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -10619,11 +10024,6 @@ pub enum AxisTitleAnchor {
     Variant0(::std::option::Option<AxisTitleAnchorVariant0>),
     Variant1(AnchorValue),
 }
-impl ::std::convert::From<&Self> for AxisTitleAnchor {
-    fn from(value: &AxisTitleAnchor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::option::Option<AxisTitleAnchorVariant0>> for AxisTitleAnchor {
     fn from(value: ::std::option::Option<AxisTitleAnchorVariant0>) -> Self {
         Self::Variant0(value)
@@ -10668,11 +10068,6 @@ pub enum AxisTitleAnchorVariant0 {
     Middle,
     #[serde(rename = "end")]
     End,
-}
-impl ::std::convert::From<&Self> for AxisTitleAnchorVariant0 {
-    fn from(value: &AxisTitleAnchorVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AxisTitleAnchorVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -10739,11 +10134,6 @@ pub enum AxisTitleAngle {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for AxisTitleAngle {
-    fn from(value: &AxisTitleAngle) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for AxisTitleAngle {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -10783,11 +10173,6 @@ impl ::std::convert::From<NumberValue> for AxisTitleAngle {
 pub enum AxisTitleBaseline {
     Variant0(AxisTitleBaselineVariant0),
     Variant1(BaselineValue),
-}
-impl ::std::convert::From<&Self> for AxisTitleBaseline {
-    fn from(value: &AxisTitleBaseline) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<AxisTitleBaselineVariant0> for AxisTitleBaseline {
     fn from(value: AxisTitleBaselineVariant0) -> Self {
@@ -10841,11 +10226,6 @@ pub enum AxisTitleBaselineVariant0 {
     LineTop,
     #[serde(rename = "line-bottom")]
     LineBottom,
-}
-impl ::std::convert::From<&Self> for AxisTitleBaselineVariant0 {
-    fn from(value: &AxisTitleBaselineVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for AxisTitleBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -10922,11 +10302,6 @@ pub enum AxisTitleColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for AxisTitleColor {
-    fn from(value: &AxisTitleColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for AxisTitleColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -10955,11 +10330,6 @@ pub enum AxisTitleFont {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for AxisTitleFont {
-    fn from(value: &AxisTitleFont) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for AxisTitleFont {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -10987,11 +10357,6 @@ impl ::std::convert::From<StringValue> for AxisTitleFont {
 pub enum AxisTitleFontSize {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for AxisTitleFontSize {
-    fn from(value: &AxisTitleFontSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for AxisTitleFontSize {
     fn from(value: f64) -> Self {
@@ -11025,11 +10390,6 @@ impl ::std::convert::From<NumberValue> for AxisTitleFontSize {
 pub enum AxisTitleFontStyle {
     Variant0(::std::string::String),
     Variant1(StringValue),
-}
-impl ::std::convert::From<&Self> for AxisTitleFontStyle {
-    fn from(value: &AxisTitleFontStyle) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<StringValue> for AxisTitleFontStyle {
     fn from(value: StringValue) -> Self {
@@ -11083,11 +10443,6 @@ pub enum AxisTitleFontWeight {
     Variant0(MyEnum),
     Variant1(FontWeightValue),
 }
-impl ::std::convert::From<&Self> for AxisTitleFontWeight {
-    fn from(value: &AxisTitleFontWeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<MyEnum> for AxisTitleFontWeight {
     fn from(value: MyEnum) -> Self {
         Self::Variant0(value)
@@ -11120,11 +10475,6 @@ impl ::std::convert::From<FontWeightValue> for AxisTitleFontWeight {
 pub enum AxisTitleLimit {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for AxisTitleLimit {
-    fn from(value: &AxisTitleLimit) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for AxisTitleLimit {
     fn from(value: f64) -> Self {
@@ -11159,11 +10509,6 @@ pub enum AxisTitleLineHeight {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for AxisTitleLineHeight {
-    fn from(value: &AxisTitleLineHeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for AxisTitleLineHeight {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -11196,11 +10541,6 @@ impl ::std::convert::From<NumberValue> for AxisTitleLineHeight {
 pub enum AxisTitleOpacity {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for AxisTitleOpacity {
-    fn from(value: &AxisTitleOpacity) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for AxisTitleOpacity {
     fn from(value: f64) -> Self {
@@ -11235,11 +10575,6 @@ pub enum AxisTitlePadding {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for AxisTitlePadding {
-    fn from(value: &AxisTitlePadding) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for AxisTitlePadding {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -11272,11 +10607,6 @@ impl ::std::convert::From<NumberValue> for AxisTitlePadding {
 pub enum AxisTitleX {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for AxisTitleX {
-    fn from(value: &AxisTitleX) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for AxisTitleX {
     fn from(value: f64) -> Self {
@@ -11311,11 +10641,6 @@ pub enum AxisTitleY {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for AxisTitleY {
-    fn from(value: &AxisTitleY) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for AxisTitleY {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -11349,11 +10674,6 @@ pub enum AxisTranslate {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for AxisTranslate {
-    fn from(value: &AxisTranslate) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for AxisTranslate {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -11386,11 +10706,6 @@ impl ::std::ops::Deref for Background {
 impl ::std::convert::From<Background> for StringOrSignal {
     fn from(value: Background) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&Background> for Background {
-    fn from(value: &Background) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<StringOrSignal> for Background {
@@ -11597,11 +10912,6 @@ pub enum BaseColorValue {
         color: BaseColorValueVariant4Color,
     },
 }
-impl ::std::convert::From<&Self> for BaseColorValue {
-    fn from(value: &BaseColorValue) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<BaseColorValueVariant0> for BaseColorValue {
     fn from(value: BaseColorValueVariant0) -> Self {
         Self::Variant0(value)
@@ -11706,11 +11016,6 @@ pub enum BaseColorValueVariant0 {
     Variant1(BaseColorValueVariant0Variant1),
     Variant2(BaseColorValueVariant0Variant2),
     Variant3 { offset: ::serde_json::Value },
-}
-impl ::std::convert::From<&Self> for BaseColorValueVariant0 {
-    fn from(value: &BaseColorValueVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<BaseColorValueVariant0Variant0> for BaseColorValueVariant0 {
     fn from(value: BaseColorValueVariant0Variant0) -> Self {
@@ -11850,11 +11155,6 @@ pub enum BaseColorValueVariant0Variant0 {
         scale: ::std::option::Option<Field>,
     },
 }
-impl ::std::convert::From<&Self> for BaseColorValueVariant0Variant0 {
-    fn from(value: &BaseColorValueVariant0Variant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BaseColorValueVariant0Variant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -11877,11 +11177,6 @@ impl ::std::convert::From<&Self> for BaseColorValueVariant0Variant0 {
 pub enum BaseColorValueVariant0Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for BaseColorValueVariant0Variant0Variant3Range {
-    fn from(value: &BaseColorValueVariant0Variant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for BaseColorValueVariant0Variant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -12052,11 +11347,6 @@ impl ::std::convert::From<bool> for BaseColorValueVariant0Variant0Variant3Range 
 )]
 #[serde(deny_unknown_fields)]
 pub enum BaseColorValueVariant0Variant1 {}
-impl ::std::convert::From<&Self> for BaseColorValueVariant0Variant1 {
-    fn from(value: &BaseColorValueVariant0Variant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BaseColorValueVariant0Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -12170,11 +11460,6 @@ impl ::std::convert::From<&Self> for BaseColorValueVariant0Variant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum BaseColorValueVariant0Variant2 {}
-impl ::std::convert::From<&Self> for BaseColorValueVariant0Variant2 {
-    fn from(value: &BaseColorValueVariant0Variant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BaseColorValueVariant4Color`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -12205,11 +11490,6 @@ pub enum BaseColorValueVariant4Color {
     Hsl(ColorHsl),
     Lab(ColorLab),
     Hcl(ColorHcl),
-}
-impl ::std::convert::From<&Self> for BaseColorValueVariant4Color {
-    fn from(value: &BaseColorValueVariant4Color) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ColorRgb> for BaseColorValueVariant4Color {
     fn from(value: ColorRgb) -> Self {
@@ -12424,11 +11704,6 @@ pub enum BaselineValue {
     Variant0(::std::vec::Vec<BaselineValueVariant0Item>),
     Variant1(BaselineValueVariant1),
 }
-impl ::std::convert::From<&Self> for BaselineValue {
-    fn from(value: &BaselineValue) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<BaselineValueVariant0Item>> for BaselineValue {
     fn from(value: ::std::vec::Vec<BaselineValueVariant0Item>) -> Self {
         Self::Variant0(value)
@@ -12547,11 +11822,6 @@ pub enum BaselineValueVariant0Item {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
-}
-impl ::std::convert::From<&Self> for BaselineValueVariant0Item {
-    fn from(value: &BaselineValueVariant0Item) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<BaselineValueVariant0ItemVariant0> for BaselineValueVariant0Item {
     fn from(value: BaselineValueVariant0ItemVariant0) -> Self {
@@ -12700,11 +11970,6 @@ pub enum BaselineValueVariant0ItemVariant0 {
         test: ::std::option::Option<::std::string::String>,
     },
 }
-impl ::std::convert::From<&Self> for BaselineValueVariant0ItemVariant0 {
-    fn from(value: &BaselineValueVariant0ItemVariant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BaselineValueVariant0ItemVariant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -12741,11 +12006,6 @@ pub enum BaselineValueVariant0ItemVariant0Variant1Value {
     Bottom,
     #[serde(rename = "alphabetic")]
     Alphabetic,
-}
-impl ::std::convert::From<&Self> for BaselineValueVariant0ItemVariant0Variant1Value {
-    fn from(value: &BaselineValueVariant0ItemVariant0Variant1Value) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for BaselineValueVariant0ItemVariant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -12817,11 +12077,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum BaselineValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for BaselineValueVariant0ItemVariant0Variant3Range {
-    fn from(value: &BaselineValueVariant0ItemVariant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for BaselineValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -12993,11 +12248,6 @@ impl ::std::convert::From<bool> for BaselineValueVariant0ItemVariant0Variant3Ran
 )]
 #[serde(deny_unknown_fields)]
 pub enum BaselineValueVariant0ItemVariant1 {}
-impl ::std::convert::From<&Self> for BaselineValueVariant0ItemVariant1 {
-    fn from(value: &BaselineValueVariant0ItemVariant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BaselineValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -13112,11 +12362,6 @@ impl ::std::convert::From<&Self> for BaselineValueVariant0ItemVariant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum BaselineValueVariant0ItemVariant2 {}
-impl ::std::convert::From<&Self> for BaselineValueVariant0ItemVariant2 {
-    fn from(value: &BaselineValueVariant0ItemVariant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BaselineValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -13214,11 +12459,6 @@ pub enum BaselineValueVariant1 {
     Variant1(BaselineValueVariant1Variant1),
     Variant2(BaselineValueVariant1Variant2),
     Variant3 { offset: ::serde_json::Value },
-}
-impl ::std::convert::From<&Self> for BaselineValueVariant1 {
-    fn from(value: &BaselineValueVariant1) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<BaselineValueVariant1Variant0> for BaselineValueVariant1 {
     fn from(value: BaselineValueVariant1Variant0) -> Self {
@@ -13356,11 +12596,6 @@ pub enum BaselineValueVariant1Variant0 {
         scale: ::std::option::Option<Field>,
     },
 }
-impl ::std::convert::From<&Self> for BaselineValueVariant1Variant0 {
-    fn from(value: &BaselineValueVariant1Variant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BaselineValueVariant1Variant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -13397,11 +12632,6 @@ pub enum BaselineValueVariant1Variant0Variant1Value {
     Bottom,
     #[serde(rename = "alphabetic")]
     Alphabetic,
-}
-impl ::std::convert::From<&Self> for BaselineValueVariant1Variant0Variant1Value {
-    fn from(value: &BaselineValueVariant1Variant0Variant1Value) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for BaselineValueVariant1Variant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -13471,11 +12701,6 @@ impl ::std::convert::TryFrom<::std::string::String> for BaselineValueVariant1Var
 pub enum BaselineValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for BaselineValueVariant1Variant0Variant3Range {
-    fn from(value: &BaselineValueVariant1Variant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for BaselineValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -13642,11 +12867,6 @@ impl ::std::convert::From<bool> for BaselineValueVariant1Variant0Variant3Range {
 )]
 #[serde(deny_unknown_fields)]
 pub enum BaselineValueVariant1Variant1 {}
-impl ::std::convert::From<&Self> for BaselineValueVariant1Variant1 {
-    fn from(value: &BaselineValueVariant1Variant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BaselineValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -13758,11 +12978,6 @@ impl ::std::convert::From<&Self> for BaselineValueVariant1Variant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum BaselineValueVariant1Variant2 {}
-impl ::std::convert::From<&Self> for BaselineValueVariant1Variant2 {
-    fn from(value: &BaselineValueVariant1Variant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BinTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -14022,11 +13237,6 @@ pub struct BinTransform {
     #[serde(rename = "type")]
     pub type_: BinTransformType,
 }
-impl ::std::convert::From<&BinTransform> for BinTransform {
-    fn from(value: &BinTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BinTransformAnchor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -14049,11 +13259,6 @@ impl ::std::convert::From<&BinTransform> for BinTransform {
 pub enum BinTransformAnchor {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for BinTransformAnchor {
-    fn from(value: &BinTransformAnchor) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for BinTransformAnchor {
     fn from(value: f64) -> Self {
@@ -14104,11 +13309,6 @@ pub enum BinTransformAs {
     Array([BinTransformAsArrayItem; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for BinTransformAs {
-    fn from(value: &BinTransformAs) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for BinTransformAs {
     fn default() -> Self {
         BinTransformAs::Array([
@@ -14150,11 +13350,6 @@ pub enum BinTransformAsArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for BinTransformAsArrayItem {
-    fn from(value: &BinTransformAsArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for BinTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -14183,11 +13378,6 @@ impl ::std::convert::From<SignalRef> for BinTransformAsArrayItem {
 pub enum BinTransformBase {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for BinTransformBase {
-    fn from(value: &BinTransformBase) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for BinTransformBase {
     fn default() -> Self {
@@ -14241,11 +13431,6 @@ pub enum BinTransformDivide {
     Array(::std::vec::Vec<BinTransformDivideArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for BinTransformDivide {
-    fn from(value: &BinTransformDivide) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for BinTransformDivide {
     fn default() -> Self {
         BinTransformDivide::Array(vec![
@@ -14286,11 +13471,6 @@ impl ::std::convert::From<SignalRef> for BinTransformDivide {
 pub enum BinTransformDivideArrayItem {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for BinTransformDivideArrayItem {
-    fn from(value: &BinTransformDivideArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for BinTransformDivideArrayItem {
     fn from(value: f64) -> Self {
@@ -14337,11 +13517,6 @@ pub enum BinTransformExtent {
     Array([BinTransformExtentArrayItem; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for BinTransformExtent {
-    fn from(value: &BinTransformExtent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[BinTransformExtentArrayItem; 2usize]> for BinTransformExtent {
     fn from(value: [BinTransformExtentArrayItem; 2usize]) -> Self {
         Self::Array(value)
@@ -14374,11 +13549,6 @@ impl ::std::convert::From<SignalRef> for BinTransformExtent {
 pub enum BinTransformExtentArrayItem {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for BinTransformExtentArrayItem {
-    fn from(value: &BinTransformExtentArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for BinTransformExtentArrayItem {
     fn from(value: f64) -> Self {
@@ -14416,11 +13586,6 @@ pub enum BinTransformField {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for BinTransformField {
-    fn from(value: &BinTransformField) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for BinTransformField {
     fn from(value: ScaleField) -> Self {
@@ -14461,11 +13626,6 @@ pub enum BinTransformInterval {
     Boolean(bool),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for BinTransformInterval {
-    fn from(value: &BinTransformInterval) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for BinTransformInterval {
     fn default() -> Self {
         BinTransformInterval::Boolean(true)
@@ -14505,11 +13665,6 @@ pub enum BinTransformMaxbins {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for BinTransformMaxbins {
-    fn from(value: &BinTransformMaxbins) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for BinTransformMaxbins {
     fn default() -> Self {
         BinTransformMaxbins::Number(20_f64)
@@ -14548,11 +13703,6 @@ pub enum BinTransformMinstep {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for BinTransformMinstep {
-    fn from(value: &BinTransformMinstep) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for BinTransformMinstep {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -14586,11 +13736,6 @@ pub enum BinTransformName {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for BinTransformName {
-    fn from(value: &BinTransformName) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for BinTransformName {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -14619,11 +13764,6 @@ impl ::std::convert::From<SignalRef> for BinTransformName {
 pub enum BinTransformNice {
     Boolean(bool),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for BinTransformNice {
-    fn from(value: &BinTransformNice) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for BinTransformNice {
     fn default() -> Self {
@@ -14663,11 +13803,6 @@ pub enum BinTransformSpan {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for BinTransformSpan {
-    fn from(value: &BinTransformSpan) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for BinTransformSpan {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -14700,11 +13835,6 @@ impl ::std::convert::From<SignalRef> for BinTransformSpan {
 pub enum BinTransformStep {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for BinTransformStep {
-    fn from(value: &BinTransformStep) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for BinTransformStep {
     fn from(value: f64) -> Self {
@@ -14749,11 +13879,6 @@ pub enum BinTransformSteps {
     Array(::std::vec::Vec<BinTransformStepsArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for BinTransformSteps {
-    fn from(value: &BinTransformSteps) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<BinTransformStepsArrayItem>> for BinTransformSteps {
     fn from(value: ::std::vec::Vec<BinTransformStepsArrayItem>) -> Self {
         Self::Array(value)
@@ -14786,11 +13911,6 @@ impl ::std::convert::From<SignalRef> for BinTransformSteps {
 pub enum BinTransformStepsArrayItem {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for BinTransformStepsArrayItem {
-    fn from(value: &BinTransformStepsArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for BinTransformStepsArrayItem {
     fn from(value: f64) -> Self {
@@ -14829,11 +13949,6 @@ impl ::std::convert::From<SignalRef> for BinTransformStepsArrayItem {
 pub enum BinTransformType {
     #[serde(rename = "bin")]
     Bin,
-}
-impl ::std::convert::From<&Self> for BinTransformType {
-    fn from(value: &BinTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for BinTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -15075,11 +14190,6 @@ pub enum Bind {
         event: ::std::option::Option<::std::string::String>,
     },
 }
-impl ::std::convert::From<&Self> for Bind {
-    fn from(value: &Bind) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BindVariant0Input`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -15107,11 +14217,6 @@ impl ::std::convert::From<&Self> for Bind {
 pub enum BindVariant0Input {
     #[serde(rename = "checkbox")]
     Checkbox,
-}
-impl ::std::convert::From<&Self> for BindVariant0Input {
-    fn from(value: &BindVariant0Input) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for BindVariant0Input {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -15182,11 +14287,6 @@ pub enum BindVariant1Input {
     #[serde(rename = "select")]
     Select,
 }
-impl ::std::convert::From<&Self> for BindVariant1Input {
-    fn from(value: &BindVariant1Input) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for BindVariant1Input {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -15255,11 +14355,6 @@ pub enum BindVariant2Input {
     #[serde(rename = "range")]
     Range,
 }
-impl ::std::convert::From<&Self> for BindVariant2Input {
-    fn from(value: &BindVariant2Input) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for BindVariant2Input {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -15327,11 +14422,6 @@ impl ::std::ops::Deref for BindVariant3Input {
 impl ::std::convert::From<BindVariant3Input> for ::std::string::String {
     fn from(value: BindVariant3Input) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&BindVariant3Input> for BindVariant3Input {
-    fn from(value: &BindVariant3Input) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::TryFrom<::std::string::String> for BindVariant3Input {
@@ -15579,11 +14669,6 @@ pub enum BlendValue {
     Variant0(::std::vec::Vec<BlendValueVariant0Item>),
     Variant1(BlendValueVariant1),
 }
-impl ::std::convert::From<&Self> for BlendValue {
-    fn from(value: &BlendValue) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<BlendValueVariant0Item>> for BlendValue {
     fn from(value: ::std::vec::Vec<BlendValueVariant0Item>) -> Self {
         Self::Variant0(value)
@@ -15714,11 +14799,6 @@ pub enum BlendValueVariant0Item {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
-}
-impl ::std::convert::From<&Self> for BlendValueVariant0Item {
-    fn from(value: &BlendValueVariant0Item) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<BlendValueVariant0ItemVariant0> for BlendValueVariant0Item {
     fn from(value: BlendValueVariant0ItemVariant0) -> Self {
@@ -15879,11 +14959,6 @@ pub enum BlendValueVariant0ItemVariant0 {
         test: ::std::option::Option<::std::string::String>,
     },
 }
-impl ::std::convert::From<&Self> for BlendValueVariant0ItemVariant0 {
-    fn from(value: &BlendValueVariant0ItemVariant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BlendValueVariant0ItemVariant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -15954,11 +15029,6 @@ pub enum BlendValueVariant0ItemVariant0Variant1Value {
     Color,
     #[serde(rename = "luminosity")]
     Luminosity,
-}
-impl ::std::convert::From<&Self> for BlendValueVariant0ItemVariant0Variant1Value {
-    fn from(value: &BlendValueVariant0ItemVariant0Variant1Value) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for BlendValueVariant0ItemVariant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -16052,11 +15122,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum BlendValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for BlendValueVariant0ItemVariant0Variant3Range {
-    fn from(value: &BlendValueVariant0ItemVariant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for BlendValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -16240,11 +15305,6 @@ impl ::std::convert::From<bool> for BlendValueVariant0ItemVariant0Variant3Range 
 )]
 #[serde(deny_unknown_fields)]
 pub enum BlendValueVariant0ItemVariant1 {}
-impl ::std::convert::From<&Self> for BlendValueVariant0ItemVariant1 {
-    fn from(value: &BlendValueVariant0ItemVariant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BlendValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -16371,11 +15431,6 @@ impl ::std::convert::From<&Self> for BlendValueVariant0ItemVariant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum BlendValueVariant0ItemVariant2 {}
-impl ::std::convert::From<&Self> for BlendValueVariant0ItemVariant2 {
-    fn from(value: &BlendValueVariant0ItemVariant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BlendValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -16485,11 +15540,6 @@ pub enum BlendValueVariant1 {
     Variant1(BlendValueVariant1Variant1),
     Variant2(BlendValueVariant1Variant2),
     Variant3 { offset: ::serde_json::Value },
-}
-impl ::std::convert::From<&Self> for BlendValueVariant1 {
-    fn from(value: &BlendValueVariant1) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<BlendValueVariant1Variant0> for BlendValueVariant1 {
     fn from(value: BlendValueVariant1Variant0) -> Self {
@@ -16639,11 +15689,6 @@ pub enum BlendValueVariant1Variant0 {
         scale: ::std::option::Option<Field>,
     },
 }
-impl ::std::convert::From<&Self> for BlendValueVariant1Variant0 {
-    fn from(value: &BlendValueVariant1Variant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BlendValueVariant1Variant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -16714,11 +15759,6 @@ pub enum BlendValueVariant1Variant0Variant1Value {
     Color,
     #[serde(rename = "luminosity")]
     Luminosity,
-}
-impl ::std::convert::From<&Self> for BlendValueVariant1Variant0Variant1Value {
-    fn from(value: &BlendValueVariant1Variant0Variant1Value) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for BlendValueVariant1Variant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -16808,11 +15848,6 @@ impl ::std::convert::TryFrom<::std::string::String> for BlendValueVariant1Varian
 pub enum BlendValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for BlendValueVariant1Variant0Variant3Range {
-    fn from(value: &BlendValueVariant1Variant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for BlendValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -16989,11 +16024,6 @@ impl ::std::convert::From<bool> for BlendValueVariant1Variant0Variant3Range {
 )]
 #[serde(deny_unknown_fields)]
 pub enum BlendValueVariant1Variant1 {}
-impl ::std::convert::From<&Self> for BlendValueVariant1Variant1 {
-    fn from(value: &BlendValueVariant1Variant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BlendValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -17117,11 +16147,6 @@ impl ::std::convert::From<&Self> for BlendValueVariant1Variant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum BlendValueVariant1Variant2 {}
-impl ::std::convert::From<&Self> for BlendValueVariant1Variant2 {
-    fn from(value: &BlendValueVariant1Variant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BooleanOrSignal`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -17144,11 +16169,6 @@ impl ::std::convert::From<&Self> for BlendValueVariant1Variant2 {
 pub enum BooleanOrSignal {
     Boolean(bool),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for BooleanOrSignal {
-    fn from(value: &BooleanOrSignal) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<bool> for BooleanOrSignal {
     fn from(value: bool) -> Self {
@@ -17343,11 +16363,6 @@ pub enum BooleanValue {
     Variant0(::std::vec::Vec<BooleanValueVariant0Item>),
     Variant1(BooleanValueVariant1),
 }
-impl ::std::convert::From<&Self> for BooleanValue {
-    fn from(value: &BooleanValue) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<BooleanValueVariant0Item>> for BooleanValue {
     fn from(value: ::std::vec::Vec<BooleanValueVariant0Item>) -> Self {
         Self::Variant0(value)
@@ -17461,11 +16476,6 @@ pub enum BooleanValueVariant0Item {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
-}
-impl ::std::convert::From<&Self> for BooleanValueVariant0Item {
-    fn from(value: &BooleanValueVariant0Item) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<BooleanValueVariant0ItemVariant0> for BooleanValueVariant0Item {
     fn from(value: BooleanValueVariant0ItemVariant0) -> Self {
@@ -17609,11 +16619,6 @@ pub enum BooleanValueVariant0ItemVariant0 {
         test: ::std::option::Option<::std::string::String>,
     },
 }
-impl ::std::convert::From<&Self> for BooleanValueVariant0ItemVariant0 {
-    fn from(value: &BooleanValueVariant0ItemVariant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BooleanValueVariant0ItemVariant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -17636,11 +16641,6 @@ impl ::std::convert::From<&Self> for BooleanValueVariant0ItemVariant0 {
 pub enum BooleanValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for BooleanValueVariant0ItemVariant0Variant3Range {
-    fn from(value: &BooleanValueVariant0ItemVariant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for BooleanValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -17807,11 +16807,6 @@ impl ::std::convert::From<bool> for BooleanValueVariant0ItemVariant0Variant3Rang
 )]
 #[serde(deny_unknown_fields)]
 pub enum BooleanValueVariant0ItemVariant1 {}
-impl ::std::convert::From<&Self> for BooleanValueVariant0ItemVariant1 {
-    fn from(value: &BooleanValueVariant0ItemVariant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BooleanValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -17921,11 +16916,6 @@ impl ::std::convert::From<&Self> for BooleanValueVariant0ItemVariant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum BooleanValueVariant0ItemVariant2 {}
-impl ::std::convert::From<&Self> for BooleanValueVariant0ItemVariant2 {
-    fn from(value: &BooleanValueVariant0ItemVariant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BooleanValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -18018,11 +17008,6 @@ pub enum BooleanValueVariant1 {
     Variant1(BooleanValueVariant1Variant1),
     Variant2(BooleanValueVariant1Variant2),
     Variant3 { offset: ::serde_json::Value },
-}
-impl ::std::convert::From<&Self> for BooleanValueVariant1 {
-    fn from(value: &BooleanValueVariant1) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<BooleanValueVariant1Variant0> for BooleanValueVariant1 {
     fn from(value: BooleanValueVariant1Variant0) -> Self {
@@ -18155,11 +17140,6 @@ pub enum BooleanValueVariant1Variant0 {
         scale: ::std::option::Option<Field>,
     },
 }
-impl ::std::convert::From<&Self> for BooleanValueVariant1Variant0 {
-    fn from(value: &BooleanValueVariant1Variant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BooleanValueVariant1Variant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -18182,11 +17162,6 @@ impl ::std::convert::From<&Self> for BooleanValueVariant1Variant0 {
 pub enum BooleanValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for BooleanValueVariant1Variant0Variant3Range {
-    fn from(value: &BooleanValueVariant1Variant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for BooleanValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -18346,11 +17321,6 @@ impl ::std::convert::From<bool> for BooleanValueVariant1Variant0Variant3Range {
 )]
 #[serde(deny_unknown_fields)]
 pub enum BooleanValueVariant1Variant1 {}
-impl ::std::convert::From<&Self> for BooleanValueVariant1Variant1 {
-    fn from(value: &BooleanValueVariant1Variant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`BooleanValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -18457,11 +17427,6 @@ impl ::std::convert::From<&Self> for BooleanValueVariant1Variant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum BooleanValueVariant1Variant2 {}
-impl ::std::convert::From<&Self> for BooleanValueVariant1Variant2 {
-    fn from(value: &BooleanValueVariant1Variant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CollectTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -18499,11 +17464,6 @@ pub struct CollectTransform {
     #[serde(rename = "type")]
     pub type_: CollectTransformType,
 }
-impl ::std::convert::From<&CollectTransform> for CollectTransform {
-    fn from(value: &CollectTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CollectTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -18531,11 +17491,6 @@ impl ::std::convert::From<&CollectTransform> for CollectTransform {
 pub enum CollectTransformType {
     #[serde(rename = "collect")]
     Collect,
-}
-impl ::std::convert::From<&Self> for CollectTransformType {
-    fn from(value: &CollectTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CollectTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -18607,11 +17562,6 @@ pub struct ColorHcl {
     pub h: NumberValue,
     pub l: NumberValue,
 }
-impl ::std::convert::From<&ColorHcl> for ColorHcl {
-    fn from(value: &ColorHcl) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ColorHsl`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -18643,11 +17593,6 @@ pub struct ColorHsl {
     pub h: NumberValue,
     pub l: NumberValue,
     pub s: NumberValue,
-}
-impl ::std::convert::From<&ColorHsl> for ColorHsl {
-    fn from(value: &ColorHsl) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`ColorLab`"]
 #[doc = r""]
@@ -18681,11 +17626,6 @@ pub struct ColorLab {
     pub b: NumberValue,
     pub l: NumberValue,
 }
-impl ::std::convert::From<&ColorLab> for ColorLab {
-    fn from(value: &ColorLab) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ColorRgb`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -18717,11 +17657,6 @@ pub struct ColorRgb {
     pub b: NumberValue,
     pub g: NumberValue,
     pub r: NumberValue,
-}
-impl ::std::convert::From<&ColorRgb> for ColorRgb {
-    fn from(value: &ColorRgb) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`Compare`"]
 #[doc = r""]
@@ -18794,11 +17729,6 @@ pub enum Compare {
         order: ::std::vec::Vec<SortOrder>,
     },
 }
-impl ::std::convert::From<&Self> for Compare {
-    fn from(value: &Compare) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CompareVariant0Field`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -18821,11 +17751,6 @@ impl ::std::convert::From<&Self> for Compare {
 pub enum CompareVariant0Field {
     ScaleField(ScaleField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for CompareVariant0Field {
-    fn from(value: &CompareVariant0Field) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for CompareVariant0Field {
     fn from(value: ScaleField) -> Self {
@@ -18859,11 +17784,6 @@ impl ::std::convert::From<Expr> for CompareVariant0Field {
 pub enum CompareVariant1FieldItem {
     ScaleField(ScaleField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for CompareVariant1FieldItem {
-    fn from(value: &CompareVariant1FieldItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for CompareVariant1FieldItem {
     fn from(value: ScaleField) -> Self {
@@ -19085,11 +18005,6 @@ pub struct ContourTransform {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub y: ::std::option::Option<ContourTransformY>,
 }
-impl ::std::convert::From<&ContourTransform> for ContourTransform {
-    fn from(value: &ContourTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ContourTransformBandwidth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -19112,11 +18027,6 @@ impl ::std::convert::From<&ContourTransform> for ContourTransform {
 pub enum ContourTransformBandwidth {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ContourTransformBandwidth {
-    fn from(value: &ContourTransformBandwidth) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for ContourTransformBandwidth {
     fn from(value: f64) -> Self {
@@ -19151,11 +18061,6 @@ pub enum ContourTransformCellSize {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ContourTransformCellSize {
-    fn from(value: &ContourTransformCellSize) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for ContourTransformCellSize {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -19189,11 +18094,6 @@ pub enum ContourTransformCount {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ContourTransformCount {
-    fn from(value: &ContourTransformCount) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for ContourTransformCount {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -19226,11 +18126,6 @@ impl ::std::convert::From<SignalRef> for ContourTransformCount {
 pub enum ContourTransformNice {
     Boolean(bool),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ContourTransformNice {
-    fn from(value: &ContourTransformNice) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<bool> for ContourTransformNice {
     fn from(value: bool) -> Self {
@@ -19277,11 +18172,6 @@ pub enum ContourTransformSize {
     Array([ContourTransformSizeArrayItem; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ContourTransformSize {
-    fn from(value: &ContourTransformSize) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[ContourTransformSizeArrayItem; 2usize]> for ContourTransformSize {
     fn from(value: [ContourTransformSizeArrayItem; 2usize]) -> Self {
         Self::Array(value)
@@ -19314,11 +18204,6 @@ impl ::std::convert::From<SignalRef> for ContourTransformSize {
 pub enum ContourTransformSizeArrayItem {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ContourTransformSizeArrayItem {
-    fn from(value: &ContourTransformSizeArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for ContourTransformSizeArrayItem {
     fn from(value: f64) -> Self {
@@ -19353,11 +18238,6 @@ impl ::std::convert::From<SignalRef> for ContourTransformSizeArrayItem {
 pub enum ContourTransformSmooth {
     Boolean(bool),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ContourTransformSmooth {
-    fn from(value: &ContourTransformSmooth) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for ContourTransformSmooth {
     fn default() -> Self {
@@ -19407,11 +18287,6 @@ pub enum ContourTransformThresholds {
     Array(::std::vec::Vec<ContourTransformThresholdsArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ContourTransformThresholds {
-    fn from(value: &ContourTransformThresholds) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ContourTransformThresholdsArrayItem>>
     for ContourTransformThresholds
 {
@@ -19446,11 +18321,6 @@ impl ::std::convert::From<SignalRef> for ContourTransformThresholds {
 pub enum ContourTransformThresholdsArrayItem {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ContourTransformThresholdsArrayItem {
-    fn from(value: &ContourTransformThresholdsArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for ContourTransformThresholdsArrayItem {
     fn from(value: f64) -> Self {
@@ -19489,11 +18359,6 @@ impl ::std::convert::From<SignalRef> for ContourTransformThresholdsArrayItem {
 pub enum ContourTransformType {
     #[serde(rename = "contour")]
     Contour,
-}
-impl ::std::convert::From<&Self> for ContourTransformType {
-    fn from(value: &ContourTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ContourTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -19566,11 +18431,6 @@ pub enum ContourTransformValues {
     Array(::std::vec::Vec<ContourTransformValuesArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ContourTransformValues {
-    fn from(value: &ContourTransformValues) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ContourTransformValuesArrayItem>>
     for ContourTransformValues
 {
@@ -19605,11 +18465,6 @@ impl ::std::convert::From<SignalRef> for ContourTransformValues {
 pub enum ContourTransformValuesArrayItem {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ContourTransformValuesArrayItem {
-    fn from(value: &ContourTransformValuesArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for ContourTransformValuesArrayItem {
     fn from(value: f64) -> Self {
@@ -19647,11 +18502,6 @@ pub enum ContourTransformWeight {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for ContourTransformWeight {
-    fn from(value: &ContourTransformWeight) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for ContourTransformWeight {
     fn from(value: ScaleField) -> Self {
@@ -19695,11 +18545,6 @@ pub enum ContourTransformX {
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for ContourTransformX {
-    fn from(value: &ContourTransformX) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleField> for ContourTransformX {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
@@ -19741,11 +18586,6 @@ pub enum ContourTransformY {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for ContourTransformY {
-    fn from(value: &ContourTransformY) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for ContourTransformY {
     fn from(value: ScaleField) -> Self {
@@ -19879,11 +18719,6 @@ pub struct CountpatternTransform {
     #[serde(rename = "type")]
     pub type_: CountpatternTransformType,
 }
-impl ::std::convert::From<&CountpatternTransform> for CountpatternTransform {
-    fn from(value: &CountpatternTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CountpatternTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -19922,11 +18757,6 @@ impl ::std::convert::From<&CountpatternTransform> for CountpatternTransform {
 pub enum CountpatternTransformAs {
     Array([CountpatternTransformAsArrayItem; 2usize]),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for CountpatternTransformAs {
-    fn from(value: &CountpatternTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for CountpatternTransformAs {
     fn default() -> Self {
@@ -19969,11 +18799,6 @@ pub enum CountpatternTransformAsArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for CountpatternTransformAsArrayItem {
-    fn from(value: &CountpatternTransformAsArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for CountpatternTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -20006,11 +18831,6 @@ impl ::std::convert::From<SignalRef> for CountpatternTransformAsArrayItem {
 pub enum CountpatternTransformCase {
     Variant0(CountpatternTransformCaseVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for CountpatternTransformCase {
-    fn from(value: &CountpatternTransformCase) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for CountpatternTransformCase {
     fn default() -> Self {
@@ -20060,11 +18880,6 @@ pub enum CountpatternTransformCaseVariant0 {
     Lower,
     #[serde(rename = "mixed")]
     Mixed,
-}
-impl ::std::convert::From<&Self> for CountpatternTransformCaseVariant0 {
-    fn from(value: &CountpatternTransformCaseVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CountpatternTransformCaseVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -20135,11 +18950,6 @@ pub enum CountpatternTransformField {
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for CountpatternTransformField {
-    fn from(value: &CountpatternTransformField) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleField> for CountpatternTransformField {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
@@ -20179,11 +18989,6 @@ pub enum CountpatternTransformPattern {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for CountpatternTransformPattern {
-    fn from(value: &CountpatternTransformPattern) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for CountpatternTransformPattern {
     fn default() -> Self {
         CountpatternTransformPattern::String("[\\w\"]+".to_string())
@@ -20217,11 +19022,6 @@ pub enum CountpatternTransformStopwords {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for CountpatternTransformStopwords {
-    fn from(value: &CountpatternTransformStopwords) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for CountpatternTransformStopwords {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -20254,11 +19054,6 @@ impl ::std::convert::From<SignalRef> for CountpatternTransformStopwords {
 pub enum CountpatternTransformType {
     #[serde(rename = "countpattern")]
     Countpattern,
-}
-impl ::std::convert::From<&Self> for CountpatternTransformType {
-    fn from(value: &CountpatternTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CountpatternTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -20363,11 +19158,6 @@ pub struct CrossTransform {
     #[serde(rename = "type")]
     pub type_: CrossTransformType,
 }
-impl ::std::convert::From<&CrossTransform> for CrossTransform {
-    fn from(value: &CrossTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CrossTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -20406,11 +19196,6 @@ impl ::std::convert::From<&CrossTransform> for CrossTransform {
 pub enum CrossTransformAs {
     Array([CrossTransformAsArrayItem; 2usize]),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for CrossTransformAs {
-    fn from(value: &CrossTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for CrossTransformAs {
     fn default() -> Self {
@@ -20453,11 +19238,6 @@ pub enum CrossTransformAsArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for CrossTransformAsArrayItem {
-    fn from(value: &CrossTransformAsArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for CrossTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -20490,11 +19270,6 @@ impl ::std::convert::From<SignalRef> for CrossTransformAsArrayItem {
 pub enum CrossTransformType {
     #[serde(rename = "cross")]
     Cross,
-}
-impl ::std::convert::From<&Self> for CrossTransformType {
-    fn from(value: &CrossTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CrossTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -20604,11 +19379,6 @@ pub struct CrossfilterTransform {
     #[serde(rename = "type")]
     pub type_: CrossfilterTransformType,
 }
-impl ::std::convert::From<&CrossfilterTransform> for CrossfilterTransform {
-    fn from(value: &CrossfilterTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CrossfilterTransformFields`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -20644,11 +19414,6 @@ impl ::std::convert::From<&CrossfilterTransform> for CrossfilterTransform {
 pub enum CrossfilterTransformFields {
     Array(::std::vec::Vec<CrossfilterTransformFieldsArrayItem>),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for CrossfilterTransformFields {
-    fn from(value: &CrossfilterTransformFields) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<CrossfilterTransformFieldsArrayItem>>
     for CrossfilterTransformFields
@@ -20689,11 +19454,6 @@ pub enum CrossfilterTransformFieldsArrayItem {
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for CrossfilterTransformFieldsArrayItem {
-    fn from(value: &CrossfilterTransformFieldsArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleField> for CrossfilterTransformFieldsArrayItem {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
@@ -20733,11 +19493,6 @@ pub enum CrossfilterTransformQuery {
     Array(::std::vec::Vec<::serde_json::Value>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for CrossfilterTransformQuery {
-    fn from(value: &CrossfilterTransformQuery) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for CrossfilterTransformQuery {
     fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
         Self::Array(value)
@@ -20775,11 +19530,6 @@ impl ::std::convert::From<SignalRef> for CrossfilterTransformQuery {
 pub enum CrossfilterTransformType {
     #[serde(rename = "crossfilter")]
     Crossfilter,
-}
-impl ::std::convert::From<&Self> for CrossfilterTransformType {
-    fn from(value: &CrossfilterTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CrossfilterTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -21515,11 +20265,6 @@ pub enum Data {
         values: DataVariant3Values,
     },
 }
-impl ::std::convert::From<&Self> for Data {
-    fn from(value: &Data) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DataVariant1Source`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -21546,11 +20291,6 @@ impl ::std::convert::From<&Self> for Data {
 pub enum DataVariant1Source {
     String(::std::string::String),
     Array(::std::vec::Vec<::std::string::String>),
-}
-impl ::std::convert::From<&Self> for DataVariant1Source {
-    fn from(value: &DataVariant1Source) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<::std::string::String>> for DataVariant1Source {
     fn from(value: ::std::vec::Vec<::std::string::String>) -> Self {
@@ -21859,11 +20599,6 @@ pub enum DataVariant2Format {
     },
     Variant1(SignalRef),
 }
-impl ::std::convert::From<&Self> for DataVariant2Format {
-    fn from(value: &DataVariant2Format) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for DataVariant2Format {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
@@ -21926,13 +20661,6 @@ pub struct DataVariant2FormatVariant0Subtype0 {
     )]
     pub type_: ::std::option::Option<StringOrSignal>,
 }
-impl ::std::convert::From<&DataVariant2FormatVariant0Subtype0>
-    for DataVariant2FormatVariant0Subtype0
-{
-    fn from(value: &DataVariant2FormatVariant0Subtype0) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for DataVariant2FormatVariant0Subtype0 {
     fn default() -> Self {
         Self {
@@ -21991,11 +20719,6 @@ pub enum DataVariant2FormatVariant0Subtype0Parse {
     ),
     Variant2(SignalRef),
 }
-impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype0Parse {
-    fn from(value: &DataVariant2FormatVariant0Subtype0Parse) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<DataVariant2FormatVariant0Subtype0ParseVariant0>
     for DataVariant2FormatVariant0Subtype0Parse
 {
@@ -22052,11 +20775,6 @@ impl ::std::convert::From<SignalRef> for DataVariant2FormatVariant0Subtype0Parse
 pub enum DataVariant2FormatVariant0Subtype0ParseVariant0 {
     #[serde(rename = "auto")]
     Auto,
-}
-impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype0ParseVariant0 {
-    fn from(value: &DataVariant2FormatVariant0Subtype0ParseVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype0ParseVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -22128,11 +20846,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum DataVariant2FormatVariant0Subtype0ParseVariant1Value {
     Variant0(DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0),
     Variant1(DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1),
-}
-impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype0ParseVariant1Value {
-    fn from(value: &DataVariant2FormatVariant0Subtype0ParseVariant1Value) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant1Value {
     type Err = self::error::ConversionError;
@@ -22231,11 +20944,6 @@ pub enum DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0 {
     #[serde(rename = "string")]
     String,
 }
-impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0 {
-    fn from(value: &DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -22311,13 +21019,6 @@ impl ::std::convert::From<DataVariant2FormatVariant0Subtype0ParseVariant1ValueVa
 {
     fn from(value: DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1>
-    for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1
-{
-    fn from(value: &DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1) -> Self {
-        value.clone()
     }
 }
 impl ::std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1 {
@@ -22444,13 +21145,6 @@ pub struct DataVariant2FormatVariant0Subtype1 {
     )]
     pub type_: ::std::option::Option<DataVariant2FormatVariant0Subtype1Type>,
 }
-impl ::std::convert::From<&DataVariant2FormatVariant0Subtype1>
-    for DataVariant2FormatVariant0Subtype1
-{
-    fn from(value: &DataVariant2FormatVariant0Subtype1) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for DataVariant2FormatVariant0Subtype1 {
     fn default() -> Self {
         Self {
@@ -22511,11 +21205,6 @@ pub enum DataVariant2FormatVariant0Subtype1Parse {
     ),
     Variant2(SignalRef),
 }
-impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype1Parse {
-    fn from(value: &DataVariant2FormatVariant0Subtype1Parse) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<DataVariant2FormatVariant0Subtype1ParseVariant0>
     for DataVariant2FormatVariant0Subtype1Parse
 {
@@ -22572,11 +21261,6 @@ impl ::std::convert::From<SignalRef> for DataVariant2FormatVariant0Subtype1Parse
 pub enum DataVariant2FormatVariant0Subtype1ParseVariant0 {
     #[serde(rename = "auto")]
     Auto,
-}
-impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype1ParseVariant0 {
-    fn from(value: &DataVariant2FormatVariant0Subtype1ParseVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype1ParseVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -22648,11 +21332,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum DataVariant2FormatVariant0Subtype1ParseVariant1Value {
     Variant0(DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0),
     Variant1(DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1),
-}
-impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype1ParseVariant1Value {
-    fn from(value: &DataVariant2FormatVariant0Subtype1ParseVariant1Value) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant1Value {
     type Err = self::error::ConversionError;
@@ -22751,11 +21430,6 @@ pub enum DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0 {
     #[serde(rename = "string")]
     String,
 }
-impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0 {
-    fn from(value: &DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -22831,13 +21505,6 @@ impl ::std::convert::From<DataVariant2FormatVariant0Subtype1ParseVariant1ValueVa
 {
     fn from(value: DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1>
-    for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1
-{
-    fn from(value: &DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1) -> Self {
-        value.clone()
     }
 }
 impl ::std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1 {
@@ -22920,11 +21587,6 @@ impl<'de> ::serde::Deserialize<'de>
 pub enum DataVariant2FormatVariant0Subtype1Type {
     #[serde(rename = "json")]
     Json,
-}
-impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype1Type {
-    fn from(value: &DataVariant2FormatVariant0Subtype1Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype1Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -23033,13 +21695,6 @@ pub struct DataVariant2FormatVariant0Subtype2 {
     #[serde(rename = "type")]
     pub type_: DataVariant2FormatVariant0Subtype2Type,
 }
-impl ::std::convert::From<&DataVariant2FormatVariant0Subtype2>
-    for DataVariant2FormatVariant0Subtype2
-{
-    fn from(value: &DataVariant2FormatVariant0Subtype2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DataVariant2FormatVariant0Subtype2Parse`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -23089,11 +21744,6 @@ pub enum DataVariant2FormatVariant0Subtype2Parse {
         >,
     ),
     Variant2(SignalRef),
-}
-impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype2Parse {
-    fn from(value: &DataVariant2FormatVariant0Subtype2Parse) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<DataVariant2FormatVariant0Subtype2ParseVariant0>
     for DataVariant2FormatVariant0Subtype2Parse
@@ -23151,11 +21801,6 @@ impl ::std::convert::From<SignalRef> for DataVariant2FormatVariant0Subtype2Parse
 pub enum DataVariant2FormatVariant0Subtype2ParseVariant0 {
     #[serde(rename = "auto")]
     Auto,
-}
-impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype2ParseVariant0 {
-    fn from(value: &DataVariant2FormatVariant0Subtype2ParseVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype2ParseVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -23227,11 +21872,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum DataVariant2FormatVariant0Subtype2ParseVariant1Value {
     Variant0(DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0),
     Variant1(DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1),
-}
-impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype2ParseVariant1Value {
-    fn from(value: &DataVariant2FormatVariant0Subtype2ParseVariant1Value) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant1Value {
     type Err = self::error::ConversionError;
@@ -23330,11 +21970,6 @@ pub enum DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0 {
     #[serde(rename = "string")]
     String,
 }
-impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0 {
-    fn from(value: &DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -23410,13 +22045,6 @@ impl ::std::convert::From<DataVariant2FormatVariant0Subtype2ParseVariant1ValueVa
 {
     fn from(value: DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1>
-    for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1
-{
-    fn from(value: &DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1) -> Self {
-        value.clone()
     }
 }
 impl ::std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1 {
@@ -23502,11 +22130,6 @@ pub enum DataVariant2FormatVariant0Subtype2Type {
     Csv,
     #[serde(rename = "tsv")]
     Tsv,
-}
-impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype2Type {
-    fn from(value: &DataVariant2FormatVariant0Subtype2Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype2Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -23621,13 +22244,6 @@ pub struct DataVariant2FormatVariant0Subtype3 {
     #[serde(rename = "type")]
     pub type_: DataVariant2FormatVariant0Subtype3Type,
 }
-impl ::std::convert::From<&DataVariant2FormatVariant0Subtype3>
-    for DataVariant2FormatVariant0Subtype3
-{
-    fn from(value: &DataVariant2FormatVariant0Subtype3) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DataVariant2FormatVariant0Subtype3Parse`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -23677,11 +22293,6 @@ pub enum DataVariant2FormatVariant0Subtype3Parse {
         >,
     ),
     Variant2(SignalRef),
-}
-impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype3Parse {
-    fn from(value: &DataVariant2FormatVariant0Subtype3Parse) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<DataVariant2FormatVariant0Subtype3ParseVariant0>
     for DataVariant2FormatVariant0Subtype3Parse
@@ -23739,11 +22350,6 @@ impl ::std::convert::From<SignalRef> for DataVariant2FormatVariant0Subtype3Parse
 pub enum DataVariant2FormatVariant0Subtype3ParseVariant0 {
     #[serde(rename = "auto")]
     Auto,
-}
-impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype3ParseVariant0 {
-    fn from(value: &DataVariant2FormatVariant0Subtype3ParseVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype3ParseVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -23815,11 +22421,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum DataVariant2FormatVariant0Subtype3ParseVariant1Value {
     Variant0(DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0),
     Variant1(DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1),
-}
-impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype3ParseVariant1Value {
-    fn from(value: &DataVariant2FormatVariant0Subtype3ParseVariant1Value) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant1Value {
     type Err = self::error::ConversionError;
@@ -23918,11 +22519,6 @@ pub enum DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0 {
     #[serde(rename = "string")]
     String,
 }
-impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0 {
-    fn from(value: &DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -23998,13 +22594,6 @@ impl ::std::convert::From<DataVariant2FormatVariant0Subtype3ParseVariant1ValueVa
 {
     fn from(value: DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1>
-    for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1
-{
-    fn from(value: &DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1) -> Self {
-        value.clone()
     }
 }
 impl ::std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1 {
@@ -24087,11 +22676,6 @@ impl<'de> ::serde::Deserialize<'de>
 pub enum DataVariant2FormatVariant0Subtype3Type {
     #[serde(rename = "dsv")]
     Dsv,
-}
-impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype3Type {
-    fn from(value: &DataVariant2FormatVariant0Subtype3Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype3Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -24211,11 +22795,6 @@ pub enum DataVariant2FormatVariant0Subtype4 {
         type_: DataVariant2FormatVariant0Subtype4Variant1Type,
     },
 }
-impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype4 {
-    fn from(value: &DataVariant2FormatVariant0Subtype4) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DataVariant2FormatVariant0Subtype4Variant0Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -24243,11 +22822,6 @@ impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype4 {
 pub enum DataVariant2FormatVariant0Subtype4Variant0Type {
     #[serde(rename = "topojson")]
     Topojson,
-}
-impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype4Variant0Type {
-    fn from(value: &DataVariant2FormatVariant0Subtype4Variant0Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype4Variant0Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -24323,11 +22897,6 @@ pub enum DataVariant2FormatVariant0Subtype4Variant1Filter {
     #[serde(rename = "exterior")]
     Exterior,
 }
-impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype4Variant1Filter {
-    fn from(value: &DataVariant2FormatVariant0Subtype4Variant1Filter) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype4Variant1Filter {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -24399,11 +22968,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum DataVariant2FormatVariant0Subtype4Variant1Type {
     #[serde(rename = "topojson")]
     Topojson,
-}
-impl ::std::convert::From<&Self> for DataVariant2FormatVariant0Subtype4Variant1Type {
-    fn from(value: &DataVariant2FormatVariant0Subtype4Variant1Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype4Variant1Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -24749,11 +23313,6 @@ pub enum DataVariant3Format {
     },
     Variant1(SignalRef),
 }
-impl ::std::convert::From<&Self> for DataVariant3Format {
-    fn from(value: &DataVariant3Format) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for DataVariant3Format {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
@@ -24816,13 +23375,6 @@ pub struct DataVariant3FormatVariant0Subtype0 {
     )]
     pub type_: ::std::option::Option<StringOrSignal>,
 }
-impl ::std::convert::From<&DataVariant3FormatVariant0Subtype0>
-    for DataVariant3FormatVariant0Subtype0
-{
-    fn from(value: &DataVariant3FormatVariant0Subtype0) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for DataVariant3FormatVariant0Subtype0 {
     fn default() -> Self {
         Self {
@@ -24881,11 +23433,6 @@ pub enum DataVariant3FormatVariant0Subtype0Parse {
     ),
     Variant2(SignalRef),
 }
-impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype0Parse {
-    fn from(value: &DataVariant3FormatVariant0Subtype0Parse) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<DataVariant3FormatVariant0Subtype0ParseVariant0>
     for DataVariant3FormatVariant0Subtype0Parse
 {
@@ -24942,11 +23489,6 @@ impl ::std::convert::From<SignalRef> for DataVariant3FormatVariant0Subtype0Parse
 pub enum DataVariant3FormatVariant0Subtype0ParseVariant0 {
     #[serde(rename = "auto")]
     Auto,
-}
-impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype0ParseVariant0 {
-    fn from(value: &DataVariant3FormatVariant0Subtype0ParseVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype0ParseVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -25018,11 +23560,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum DataVariant3FormatVariant0Subtype0ParseVariant1Value {
     Variant0(DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0),
     Variant1(DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1),
-}
-impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype0ParseVariant1Value {
-    fn from(value: &DataVariant3FormatVariant0Subtype0ParseVariant1Value) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant1Value {
     type Err = self::error::ConversionError;
@@ -25121,11 +23658,6 @@ pub enum DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0 {
     #[serde(rename = "string")]
     String,
 }
-impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0 {
-    fn from(value: &DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -25201,13 +23733,6 @@ impl ::std::convert::From<DataVariant3FormatVariant0Subtype0ParseVariant1ValueVa
 {
     fn from(value: DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1>
-    for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1
-{
-    fn from(value: &DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1) -> Self {
-        value.clone()
     }
 }
 impl ::std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1 {
@@ -25334,13 +23859,6 @@ pub struct DataVariant3FormatVariant0Subtype1 {
     )]
     pub type_: ::std::option::Option<DataVariant3FormatVariant0Subtype1Type>,
 }
-impl ::std::convert::From<&DataVariant3FormatVariant0Subtype1>
-    for DataVariant3FormatVariant0Subtype1
-{
-    fn from(value: &DataVariant3FormatVariant0Subtype1) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for DataVariant3FormatVariant0Subtype1 {
     fn default() -> Self {
         Self {
@@ -25401,11 +23919,6 @@ pub enum DataVariant3FormatVariant0Subtype1Parse {
     ),
     Variant2(SignalRef),
 }
-impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype1Parse {
-    fn from(value: &DataVariant3FormatVariant0Subtype1Parse) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<DataVariant3FormatVariant0Subtype1ParseVariant0>
     for DataVariant3FormatVariant0Subtype1Parse
 {
@@ -25462,11 +23975,6 @@ impl ::std::convert::From<SignalRef> for DataVariant3FormatVariant0Subtype1Parse
 pub enum DataVariant3FormatVariant0Subtype1ParseVariant0 {
     #[serde(rename = "auto")]
     Auto,
-}
-impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype1ParseVariant0 {
-    fn from(value: &DataVariant3FormatVariant0Subtype1ParseVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype1ParseVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -25538,11 +24046,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum DataVariant3FormatVariant0Subtype1ParseVariant1Value {
     Variant0(DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0),
     Variant1(DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1),
-}
-impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype1ParseVariant1Value {
-    fn from(value: &DataVariant3FormatVariant0Subtype1ParseVariant1Value) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant1Value {
     type Err = self::error::ConversionError;
@@ -25641,11 +24144,6 @@ pub enum DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0 {
     #[serde(rename = "string")]
     String,
 }
-impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0 {
-    fn from(value: &DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -25721,13 +24219,6 @@ impl ::std::convert::From<DataVariant3FormatVariant0Subtype1ParseVariant1ValueVa
 {
     fn from(value: DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1>
-    for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1
-{
-    fn from(value: &DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1) -> Self {
-        value.clone()
     }
 }
 impl ::std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1 {
@@ -25810,11 +24301,6 @@ impl<'de> ::serde::Deserialize<'de>
 pub enum DataVariant3FormatVariant0Subtype1Type {
     #[serde(rename = "json")]
     Json,
-}
-impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype1Type {
-    fn from(value: &DataVariant3FormatVariant0Subtype1Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype1Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -25923,13 +24409,6 @@ pub struct DataVariant3FormatVariant0Subtype2 {
     #[serde(rename = "type")]
     pub type_: DataVariant3FormatVariant0Subtype2Type,
 }
-impl ::std::convert::From<&DataVariant3FormatVariant0Subtype2>
-    for DataVariant3FormatVariant0Subtype2
-{
-    fn from(value: &DataVariant3FormatVariant0Subtype2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DataVariant3FormatVariant0Subtype2Parse`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -25979,11 +24458,6 @@ pub enum DataVariant3FormatVariant0Subtype2Parse {
         >,
     ),
     Variant2(SignalRef),
-}
-impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype2Parse {
-    fn from(value: &DataVariant3FormatVariant0Subtype2Parse) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<DataVariant3FormatVariant0Subtype2ParseVariant0>
     for DataVariant3FormatVariant0Subtype2Parse
@@ -26041,11 +24515,6 @@ impl ::std::convert::From<SignalRef> for DataVariant3FormatVariant0Subtype2Parse
 pub enum DataVariant3FormatVariant0Subtype2ParseVariant0 {
     #[serde(rename = "auto")]
     Auto,
-}
-impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype2ParseVariant0 {
-    fn from(value: &DataVariant3FormatVariant0Subtype2ParseVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype2ParseVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -26117,11 +24586,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum DataVariant3FormatVariant0Subtype2ParseVariant1Value {
     Variant0(DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0),
     Variant1(DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1),
-}
-impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype2ParseVariant1Value {
-    fn from(value: &DataVariant3FormatVariant0Subtype2ParseVariant1Value) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant1Value {
     type Err = self::error::ConversionError;
@@ -26220,11 +24684,6 @@ pub enum DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0 {
     #[serde(rename = "string")]
     String,
 }
-impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0 {
-    fn from(value: &DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -26300,13 +24759,6 @@ impl ::std::convert::From<DataVariant3FormatVariant0Subtype2ParseVariant1ValueVa
 {
     fn from(value: DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1>
-    for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1
-{
-    fn from(value: &DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1) -> Self {
-        value.clone()
     }
 }
 impl ::std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1 {
@@ -26392,11 +24844,6 @@ pub enum DataVariant3FormatVariant0Subtype2Type {
     Csv,
     #[serde(rename = "tsv")]
     Tsv,
-}
-impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype2Type {
-    fn from(value: &DataVariant3FormatVariant0Subtype2Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype2Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -26511,13 +24958,6 @@ pub struct DataVariant3FormatVariant0Subtype3 {
     #[serde(rename = "type")]
     pub type_: DataVariant3FormatVariant0Subtype3Type,
 }
-impl ::std::convert::From<&DataVariant3FormatVariant0Subtype3>
-    for DataVariant3FormatVariant0Subtype3
-{
-    fn from(value: &DataVariant3FormatVariant0Subtype3) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DataVariant3FormatVariant0Subtype3Parse`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -26567,11 +25007,6 @@ pub enum DataVariant3FormatVariant0Subtype3Parse {
         >,
     ),
     Variant2(SignalRef),
-}
-impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype3Parse {
-    fn from(value: &DataVariant3FormatVariant0Subtype3Parse) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<DataVariant3FormatVariant0Subtype3ParseVariant0>
     for DataVariant3FormatVariant0Subtype3Parse
@@ -26629,11 +25064,6 @@ impl ::std::convert::From<SignalRef> for DataVariant3FormatVariant0Subtype3Parse
 pub enum DataVariant3FormatVariant0Subtype3ParseVariant0 {
     #[serde(rename = "auto")]
     Auto,
-}
-impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype3ParseVariant0 {
-    fn from(value: &DataVariant3FormatVariant0Subtype3ParseVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype3ParseVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -26705,11 +25135,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum DataVariant3FormatVariant0Subtype3ParseVariant1Value {
     Variant0(DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0),
     Variant1(DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1),
-}
-impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype3ParseVariant1Value {
-    fn from(value: &DataVariant3FormatVariant0Subtype3ParseVariant1Value) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant1Value {
     type Err = self::error::ConversionError;
@@ -26808,11 +25233,6 @@ pub enum DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0 {
     #[serde(rename = "string")]
     String,
 }
-impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0 {
-    fn from(value: &DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -26888,13 +25308,6 @@ impl ::std::convert::From<DataVariant3FormatVariant0Subtype3ParseVariant1ValueVa
 {
     fn from(value: DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1>
-    for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1
-{
-    fn from(value: &DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1) -> Self {
-        value.clone()
     }
 }
 impl ::std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1 {
@@ -26977,11 +25390,6 @@ impl<'de> ::serde::Deserialize<'de>
 pub enum DataVariant3FormatVariant0Subtype3Type {
     #[serde(rename = "dsv")]
     Dsv,
-}
-impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype3Type {
-    fn from(value: &DataVariant3FormatVariant0Subtype3Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype3Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -27101,11 +25509,6 @@ pub enum DataVariant3FormatVariant0Subtype4 {
         type_: DataVariant3FormatVariant0Subtype4Variant1Type,
     },
 }
-impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype4 {
-    fn from(value: &DataVariant3FormatVariant0Subtype4) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DataVariant3FormatVariant0Subtype4Variant0Type`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -27133,11 +25536,6 @@ impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype4 {
 pub enum DataVariant3FormatVariant0Subtype4Variant0Type {
     #[serde(rename = "topojson")]
     Topojson,
-}
-impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype4Variant0Type {
-    fn from(value: &DataVariant3FormatVariant0Subtype4Variant0Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype4Variant0Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -27213,11 +25611,6 @@ pub enum DataVariant3FormatVariant0Subtype4Variant1Filter {
     #[serde(rename = "exterior")]
     Exterior,
 }
-impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype4Variant1Filter {
-    fn from(value: &DataVariant3FormatVariant0Subtype4Variant1Filter) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype4Variant1Filter {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -27290,11 +25683,6 @@ pub enum DataVariant3FormatVariant0Subtype4Variant1Type {
     #[serde(rename = "topojson")]
     Topojson,
 }
-impl ::std::convert::From<&Self> for DataVariant3FormatVariant0Subtype4Variant1Type {
-    fn from(value: &DataVariant3FormatVariant0Subtype4Variant1Type) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype4Variant1Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -27357,11 +25745,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum DataVariant3Values {
     Variant0(::serde_json::Value),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for DataVariant3Values {
-    fn from(value: &DataVariant3Values) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::serde_json::Value> for DataVariant3Values {
     fn from(value: ::serde_json::Value) -> Self {
@@ -27703,11 +26086,6 @@ pub struct DensityTransform {
     #[serde(rename = "type")]
     pub type_: DensityTransformType,
 }
-impl ::std::convert::From<&DensityTransform> for DensityTransform {
-    fn from(value: &DensityTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DensityTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -27744,11 +26122,6 @@ impl ::std::convert::From<&DensityTransform> for DensityTransform {
 pub enum DensityTransformAs {
     Array(::std::vec::Vec<DensityTransformAsArrayItem>),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for DensityTransformAs {
-    fn from(value: &DensityTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for DensityTransformAs {
     fn default() -> Self {
@@ -27790,11 +26163,6 @@ impl ::std::convert::From<SignalRef> for DensityTransformAs {
 pub enum DensityTransformAsArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for DensityTransformAsArrayItem {
-    fn from(value: &DensityTransformAsArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<SignalRef> for DensityTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
@@ -28043,11 +26411,6 @@ pub enum DensityTransformDistribution {
         weights: ::std::option::Option<DensityTransformDistributionWeights>,
     },
 }
-impl ::std::convert::From<&Self> for DensityTransformDistribution {
-    fn from(value: &DensityTransformDistribution) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DensityTransformDistributionBandwidth`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -28070,11 +26433,6 @@ impl ::std::convert::From<&Self> for DensityTransformDistribution {
 pub enum DensityTransformDistributionBandwidth {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for DensityTransformDistributionBandwidth {
-    fn from(value: &DensityTransformDistributionBandwidth) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for DensityTransformDistributionBandwidth {
     fn from(value: f64) -> Self {
@@ -28109,11 +26467,6 @@ impl ::std::convert::From<SignalRef> for DensityTransformDistributionBandwidth {
 pub enum DensityTransformDistributionDistributions {
     Array(::std::vec::Vec<::serde_json::Value>),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for DensityTransformDistributionDistributions {
-    fn from(value: &DensityTransformDistributionDistributions) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>>
     for DensityTransformDistributionDistributions
@@ -28154,11 +26507,6 @@ pub enum DensityTransformDistributionField {
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for DensityTransformDistributionField {
-    fn from(value: &DensityTransformDistributionField) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleField> for DensityTransformDistributionField {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
@@ -28198,11 +26546,6 @@ pub enum DensityTransformDistributionMax {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for DensityTransformDistributionMax {
-    fn from(value: &DensityTransformDistributionMax) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for DensityTransformDistributionMax {
     fn default() -> Self {
         DensityTransformDistributionMax::Number(1_f64)
@@ -28241,11 +26584,6 @@ pub enum DensityTransformDistributionMean {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for DensityTransformDistributionMean {
-    fn from(value: &DensityTransformDistributionMean) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for DensityTransformDistributionMean {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -28278,11 +26616,6 @@ impl ::std::convert::From<SignalRef> for DensityTransformDistributionMean {
 pub enum DensityTransformDistributionMin {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for DensityTransformDistributionMin {
-    fn from(value: &DensityTransformDistributionMin) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for DensityTransformDistributionMin {
     fn from(value: f64) -> Self {
@@ -28317,11 +26650,6 @@ impl ::std::convert::From<SignalRef> for DensityTransformDistributionMin {
 pub enum DensityTransformDistributionStdev {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for DensityTransformDistributionStdev {
-    fn from(value: &DensityTransformDistributionStdev) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for DensityTransformDistributionStdev {
     fn default() -> Self {
@@ -28371,11 +26699,6 @@ pub enum DensityTransformDistributionWeights {
     Array(::std::vec::Vec<DensityTransformDistributionWeightsArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for DensityTransformDistributionWeights {
-    fn from(value: &DensityTransformDistributionWeights) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<DensityTransformDistributionWeightsArrayItem>>
     for DensityTransformDistributionWeights
 {
@@ -28410,11 +26733,6 @@ impl ::std::convert::From<SignalRef> for DensityTransformDistributionWeights {
 pub enum DensityTransformDistributionWeightsArrayItem {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for DensityTransformDistributionWeightsArrayItem {
-    fn from(value: &DensityTransformDistributionWeightsArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for DensityTransformDistributionWeightsArrayItem {
     fn from(value: f64) -> Self {
@@ -28461,11 +26779,6 @@ pub enum DensityTransformExtent {
     Array([DensityTransformExtentArrayItem; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for DensityTransformExtent {
-    fn from(value: &DensityTransformExtent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[DensityTransformExtentArrayItem; 2usize]> for DensityTransformExtent {
     fn from(value: [DensityTransformExtentArrayItem; 2usize]) -> Self {
         Self::Array(value)
@@ -28498,11 +26811,6 @@ impl ::std::convert::From<SignalRef> for DensityTransformExtent {
 pub enum DensityTransformExtentArrayItem {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for DensityTransformExtentArrayItem {
-    fn from(value: &DensityTransformExtentArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for DensityTransformExtentArrayItem {
     fn from(value: f64) -> Self {
@@ -28537,11 +26845,6 @@ impl ::std::convert::From<SignalRef> for DensityTransformExtentArrayItem {
 pub enum DensityTransformMaxsteps {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for DensityTransformMaxsteps {
-    fn from(value: &DensityTransformMaxsteps) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for DensityTransformMaxsteps {
     fn default() -> Self {
@@ -28582,11 +26885,6 @@ pub enum DensityTransformMethod {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for DensityTransformMethod {
-    fn from(value: &DensityTransformMethod) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for DensityTransformMethod {
     fn default() -> Self {
         DensityTransformMethod::String("pdf".to_string())
@@ -28620,11 +26918,6 @@ impl ::std::convert::From<SignalRef> for DensityTransformMethod {
 pub enum DensityTransformMinsteps {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for DensityTransformMinsteps {
-    fn from(value: &DensityTransformMinsteps) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for DensityTransformMinsteps {
     fn default() -> Self {
@@ -28664,11 +26957,6 @@ pub enum DensityTransformSteps {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for DensityTransformSteps {
-    fn from(value: &DensityTransformSteps) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for DensityTransformSteps {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -28706,11 +26994,6 @@ impl ::std::convert::From<SignalRef> for DensityTransformSteps {
 pub enum DensityTransformType {
     #[serde(rename = "density")]
     Density,
-}
-impl ::std::convert::From<&Self> for DensityTransformType {
-    fn from(value: &DensityTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DensityTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -28939,11 +27222,6 @@ pub enum DirectionValue {
     Variant0(::std::vec::Vec<DirectionValueVariant0Item>),
     Variant1(DirectionValueVariant1),
 }
-impl ::std::convert::From<&Self> for DirectionValue {
-    fn from(value: &DirectionValue) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<DirectionValueVariant0Item>> for DirectionValue {
     fn from(value: ::std::vec::Vec<DirectionValueVariant0Item>) -> Self {
         Self::Variant0(value)
@@ -29060,11 +27338,6 @@ pub enum DirectionValueVariant0Item {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
-}
-impl ::std::convert::From<&Self> for DirectionValueVariant0Item {
-    fn from(value: &DirectionValueVariant0Item) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<DirectionValueVariant0ItemVariant0> for DirectionValueVariant0Item {
     fn from(value: DirectionValueVariant0ItemVariant0) -> Self {
@@ -29211,11 +27484,6 @@ pub enum DirectionValueVariant0ItemVariant0 {
         test: ::std::option::Option<::std::string::String>,
     },
 }
-impl ::std::convert::From<&Self> for DirectionValueVariant0ItemVariant0 {
-    fn from(value: &DirectionValueVariant0ItemVariant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DirectionValueVariant0ItemVariant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -29246,11 +27514,6 @@ pub enum DirectionValueVariant0ItemVariant0Variant1Value {
     Horizontal,
     #[serde(rename = "vertical")]
     Vertical,
-}
-impl ::std::convert::From<&Self> for DirectionValueVariant0ItemVariant0Variant1Value {
-    fn from(value: &DirectionValueVariant0ItemVariant0Variant1Value) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DirectionValueVariant0ItemVariant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -29318,11 +27581,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum DirectionValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for DirectionValueVariant0ItemVariant0Variant3Range {
-    fn from(value: &DirectionValueVariant0ItemVariant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for DirectionValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -29492,11 +27750,6 @@ impl ::std::convert::From<bool> for DirectionValueVariant0ItemVariant0Variant3Ra
 )]
 #[serde(deny_unknown_fields)]
 pub enum DirectionValueVariant0ItemVariant1 {}
-impl ::std::convert::From<&Self> for DirectionValueVariant0ItemVariant1 {
-    fn from(value: &DirectionValueVariant0ItemVariant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DirectionValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -29609,11 +27862,6 @@ impl ::std::convert::From<&Self> for DirectionValueVariant0ItemVariant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum DirectionValueVariant0ItemVariant2 {}
-impl ::std::convert::From<&Self> for DirectionValueVariant0ItemVariant2 {
-    fn from(value: &DirectionValueVariant0ItemVariant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DirectionValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -29709,11 +27957,6 @@ pub enum DirectionValueVariant1 {
     Variant1(DirectionValueVariant1Variant1),
     Variant2(DirectionValueVariant1Variant2),
     Variant3 { offset: ::serde_json::Value },
-}
-impl ::std::convert::From<&Self> for DirectionValueVariant1 {
-    fn from(value: &DirectionValueVariant1) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<DirectionValueVariant1Variant0> for DirectionValueVariant1 {
     fn from(value: DirectionValueVariant1Variant0) -> Self {
@@ -29849,11 +28092,6 @@ pub enum DirectionValueVariant1Variant0 {
         scale: ::std::option::Option<Field>,
     },
 }
-impl ::std::convert::From<&Self> for DirectionValueVariant1Variant0 {
-    fn from(value: &DirectionValueVariant1Variant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DirectionValueVariant1Variant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -29884,11 +28122,6 @@ pub enum DirectionValueVariant1Variant0Variant1Value {
     Horizontal,
     #[serde(rename = "vertical")]
     Vertical,
-}
-impl ::std::convert::From<&Self> for DirectionValueVariant1Variant0Variant1Value {
-    fn from(value: &DirectionValueVariant1Variant0Variant1Value) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DirectionValueVariant1Variant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -29956,11 +28189,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum DirectionValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for DirectionValueVariant1Variant0Variant3Range {
-    fn from(value: &DirectionValueVariant1Variant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for DirectionValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -30127,11 +28355,6 @@ impl ::std::convert::From<bool> for DirectionValueVariant1Variant0Variant3Range 
 )]
 #[serde(deny_unknown_fields)]
 pub enum DirectionValueVariant1Variant1 {}
-impl ::std::convert::From<&Self> for DirectionValueVariant1Variant1 {
-    fn from(value: &DirectionValueVariant1Variant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DirectionValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -30241,11 +28464,6 @@ impl ::std::convert::From<&Self> for DirectionValueVariant1Variant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum DirectionValueVariant1Variant2 {}
-impl ::std::convert::From<&Self> for DirectionValueVariant1Variant2 {
-    fn from(value: &DirectionValueVariant1Variant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DotbinTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -30355,11 +28573,6 @@ pub struct DotbinTransform {
     #[serde(rename = "type")]
     pub type_: DotbinTransformType,
 }
-impl ::std::convert::From<&DotbinTransform> for DotbinTransform {
-    fn from(value: &DotbinTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`DotbinTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -30383,11 +28596,6 @@ impl ::std::convert::From<&DotbinTransform> for DotbinTransform {
 pub enum DotbinTransformAs {
     String(::std::string::String),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for DotbinTransformAs {
-    fn from(value: &DotbinTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for DotbinTransformAs {
     fn default() -> Self {
@@ -30425,11 +28633,6 @@ pub enum DotbinTransformField {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for DotbinTransformField {
-    fn from(value: &DotbinTransformField) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for DotbinTransformField {
     fn from(value: ScaleField) -> Self {
@@ -30482,11 +28685,6 @@ pub enum DotbinTransformGroupby {
     Array(::std::vec::Vec<DotbinTransformGroupbyArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for DotbinTransformGroupby {
-    fn from(value: &DotbinTransformGroupby) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<DotbinTransformGroupbyArrayItem>>
     for DotbinTransformGroupby
 {
@@ -30526,11 +28724,6 @@ pub enum DotbinTransformGroupbyArrayItem {
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for DotbinTransformGroupbyArrayItem {
-    fn from(value: &DotbinTransformGroupbyArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleField> for DotbinTransformGroupbyArrayItem {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
@@ -30569,11 +28762,6 @@ pub enum DotbinTransformSmooth {
     Boolean(bool),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for DotbinTransformSmooth {
-    fn from(value: &DotbinTransformSmooth) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for DotbinTransformSmooth {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -30606,11 +28794,6 @@ impl ::std::convert::From<SignalRef> for DotbinTransformSmooth {
 pub enum DotbinTransformStep {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for DotbinTransformStep {
-    fn from(value: &DotbinTransformStep) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for DotbinTransformStep {
     fn from(value: f64) -> Self {
@@ -30649,11 +28832,6 @@ impl ::std::convert::From<SignalRef> for DotbinTransformStep {
 pub enum DotbinTransformType {
     #[serde(rename = "dotbin")]
     Dotbin,
-}
-impl ::std::convert::From<&Self> for DotbinTransformType {
-    fn from(value: &DotbinTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DotbinTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -30727,11 +28905,6 @@ impl ::std::convert::From<Element> for ::std::string::String {
         value.0
     }
 }
-impl ::std::convert::From<&Element> for Element {
-    fn from(value: &Element) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::string::String> for Element {
     fn from(value: ::std::string::String) -> Self {
         Self(value)
@@ -30776,11 +28949,6 @@ impl ::std::ops::Deref for Encode {
 impl ::std::convert::From<Encode> for ::std::collections::HashMap<EncodeKey, EncodeEntry> {
     fn from(value: Encode) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&Encode> for Encode {
-    fn from(value: &Encode) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<::std::collections::HashMap<EncodeKey, EncodeEntry>> for Encode {
@@ -31265,11 +29433,6 @@ pub struct EncodeEntry {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub zindex: ::std::option::Option<NumberValue>,
 }
-impl ::std::convert::From<&EncodeEntry> for EncodeEntry {
-    fn from(value: &EncodeEntry) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for EncodeEntry {
     fn default() -> Self {
         Self {
@@ -31368,11 +29531,6 @@ impl ::std::ops::Deref for EncodeKey {
 impl ::std::convert::From<EncodeKey> for ::std::string::String {
     fn from(value: EncodeKey) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&EncodeKey> for EncodeKey {
-    fn from(value: &EncodeKey) -> Self {
-        value.clone()
     }
 }
 impl ::std::str::FromStr for EncodeKey {
@@ -31515,11 +29673,6 @@ pub struct Everything {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub width: ::std::option::Option<NumberOrSignal>,
 }
-impl ::std::convert::From<&Everything> for Everything {
-    fn from(value: &Everything) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for Everything {
     fn default() -> Self {
         Self {
@@ -31569,11 +29722,6 @@ pub enum EverythingMarksItem {
     Group(MarkGroup),
     Visual(MarkVisual),
 }
-impl ::std::convert::From<&Self> for EverythingMarksItem {
-    fn from(value: &EverythingMarksItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<MarkGroup> for EverythingMarksItem {
     fn from(value: MarkGroup) -> Self {
         Self::Group(value)
@@ -31615,11 +29763,6 @@ pub struct Expr {
     pub as_: ::std::option::Option<::std::string::String>,
     pub expr: ::std::string::String,
 }
-impl ::std::convert::From<&Expr> for Expr {
-    fn from(value: &Expr) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ExprString`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -31652,11 +29795,6 @@ impl ::std::ops::Deref for ExprString {
 impl ::std::convert::From<ExprString> for ::std::string::String {
     fn from(value: ExprString) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&ExprString> for ExprString {
-    fn from(value: &ExprString) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<::std::string::String> for ExprString {
@@ -31722,11 +29860,6 @@ pub struct ExtentTransform {
     #[serde(rename = "type")]
     pub type_: ExtentTransformType,
 }
-impl ::std::convert::From<&ExtentTransform> for ExtentTransform {
-    fn from(value: &ExtentTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ExtentTransformField`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -31753,11 +29886,6 @@ pub enum ExtentTransformField {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for ExtentTransformField {
-    fn from(value: &ExtentTransformField) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for ExtentTransformField {
     fn from(value: ScaleField) -> Self {
@@ -31801,11 +29929,6 @@ impl ::std::convert::From<Expr> for ExtentTransformField {
 pub enum ExtentTransformType {
     #[serde(rename = "extent")]
     Extent,
-}
-impl ::std::convert::From<&Self> for ExtentTransformType {
-    fn from(value: &ExtentTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ExtentTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -31952,11 +30075,6 @@ pub struct Facet {
     pub data: ::std::option::Option<::std::string::String>,
     pub facet: FacetFacet,
 }
-impl ::std::convert::From<&Facet> for Facet {
-    fn from(value: &Facet) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`FacetFacet`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -32061,11 +30179,6 @@ pub enum FacetFacet {
         name: ::std::string::String,
     },
 }
-impl ::std::convert::From<&Self> for FacetFacet {
-    fn from(value: &FacetFacet) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`FacetFacetVariant1Aggregate`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -32116,11 +30229,6 @@ pub struct FacetFacetVariant1Aggregate {
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub ops: ::std::vec::Vec<::std::string::String>,
 }
-impl ::std::convert::From<&FacetFacetVariant1Aggregate> for FacetFacetVariant1Aggregate {
-    fn from(value: &FacetFacetVariant1Aggregate) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for FacetFacetVariant1Aggregate {
     fn default() -> Self {
         Self {
@@ -32156,11 +30264,6 @@ impl ::std::default::Default for FacetFacetVariant1Aggregate {
 pub enum FacetFacetVariant1Groupby {
     String(::std::string::String),
     Array(::std::vec::Vec<::std::string::String>),
-}
-impl ::std::convert::From<&Self> for FacetFacetVariant1Groupby {
-    fn from(value: &FacetFacetVariant1Groupby) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<::std::string::String>> for FacetFacetVariant1Groupby {
     fn from(value: ::std::vec::Vec<::std::string::String>) -> Self {
@@ -32245,11 +30348,6 @@ pub enum Field {
         parent: ::std::boxed::Box<Field>,
     },
 }
-impl ::std::convert::From<&Self> for Field {
-    fn from(value: &Field) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for Field {
     fn from(value: SignalRef) -> Self {
         Self::Variant1(value)
@@ -32292,11 +30390,6 @@ pub struct FilterTransform {
     #[serde(rename = "type")]
     pub type_: FilterTransformType,
 }
-impl ::std::convert::From<&FilterTransform> for FilterTransform {
-    fn from(value: &FilterTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`FilterTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -32324,11 +30417,6 @@ impl ::std::convert::From<&FilterTransform> for FilterTransform {
 pub enum FilterTransformType {
     #[serde(rename = "filter")]
     Filter,
-}
-impl ::std::convert::From<&Self> for FilterTransformType {
-    fn from(value: &FilterTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for FilterTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -32463,11 +30551,6 @@ pub struct FlattenTransform {
     #[serde(rename = "type")]
     pub type_: FlattenTransformType,
 }
-impl ::std::convert::From<&FlattenTransform> for FlattenTransform {
-    fn from(value: &FlattenTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`FlattenTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -32501,11 +30584,6 @@ pub enum FlattenTransformAs {
     Array(::std::vec::Vec<FlattenTransformAsArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for FlattenTransformAs {
-    fn from(value: &FlattenTransformAs) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<FlattenTransformAsArrayItem>> for FlattenTransformAs {
     fn from(value: ::std::vec::Vec<FlattenTransformAsArrayItem>) -> Self {
         Self::Array(value)
@@ -32538,11 +30616,6 @@ impl ::std::convert::From<SignalRef> for FlattenTransformAs {
 pub enum FlattenTransformAsArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for FlattenTransformAsArrayItem {
-    fn from(value: &FlattenTransformAsArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<SignalRef> for FlattenTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
@@ -32585,11 +30658,6 @@ pub enum FlattenTransformFields {
     Array(::std::vec::Vec<FlattenTransformFieldsArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for FlattenTransformFields {
-    fn from(value: &FlattenTransformFields) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<FlattenTransformFieldsArrayItem>>
     for FlattenTransformFields
 {
@@ -32629,11 +30697,6 @@ pub enum FlattenTransformFieldsArrayItem {
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for FlattenTransformFieldsArrayItem {
-    fn from(value: &FlattenTransformFieldsArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleField> for FlattenTransformFieldsArrayItem {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
@@ -32672,11 +30735,6 @@ pub enum FlattenTransformIndex {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for FlattenTransformIndex {
-    fn from(value: &FlattenTransformIndex) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for FlattenTransformIndex {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -32709,11 +30767,6 @@ impl ::std::convert::From<SignalRef> for FlattenTransformIndex {
 pub enum FlattenTransformType {
     #[serde(rename = "flatten")]
     Flatten,
-}
-impl ::std::convert::From<&Self> for FlattenTransformType {
-    fn from(value: &FlattenTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for FlattenTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -32838,11 +30891,6 @@ pub struct FoldTransform {
     #[serde(rename = "type")]
     pub type_: FoldTransformType,
 }
-impl ::std::convert::From<&FoldTransform> for FoldTransform {
-    fn from(value: &FoldTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`FoldTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -32881,11 +30929,6 @@ impl ::std::convert::From<&FoldTransform> for FoldTransform {
 pub enum FoldTransformAs {
     Array([FoldTransformAsArrayItem; 2usize]),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for FoldTransformAs {
-    fn from(value: &FoldTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for FoldTransformAs {
     fn default() -> Self {
@@ -32928,11 +30971,6 @@ pub enum FoldTransformAsArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for FoldTransformAsArrayItem {
-    fn from(value: &FoldTransformAsArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for FoldTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -32974,11 +31012,6 @@ pub enum FoldTransformFields {
     Array(::std::vec::Vec<FoldTransformFieldsArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for FoldTransformFields {
-    fn from(value: &FoldTransformFields) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<FoldTransformFieldsArrayItem>> for FoldTransformFields {
     fn from(value: ::std::vec::Vec<FoldTransformFieldsArrayItem>) -> Self {
         Self::Array(value)
@@ -33015,11 +31048,6 @@ pub enum FoldTransformFieldsArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for FoldTransformFieldsArrayItem {
-    fn from(value: &FoldTransformFieldsArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for FoldTransformFieldsArrayItem {
     fn from(value: ScaleField) -> Self {
@@ -33063,11 +31091,6 @@ impl ::std::convert::From<Expr> for FoldTransformFieldsArrayItem {
 pub enum FoldTransformType {
     #[serde(rename = "fold")]
     Fold,
-}
-impl ::std::convert::From<&Self> for FoldTransformType {
-    fn from(value: &FoldTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for FoldTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -33338,11 +31361,6 @@ pub enum FontWeightValue {
     Variant0(::std::vec::Vec<FontWeightValueVariant0Item>),
     Variant1(FontWeightValueVariant1),
 }
-impl ::std::convert::From<&Self> for FontWeightValue {
-    fn from(value: &FontWeightValue) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<FontWeightValueVariant0Item>> for FontWeightValue {
     fn from(value: ::std::vec::Vec<FontWeightValueVariant0Item>) -> Self {
         Self::Variant0(value)
@@ -33480,11 +31498,6 @@ pub enum FontWeightValueVariant0Item {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
-}
-impl ::std::convert::From<&Self> for FontWeightValueVariant0Item {
-    fn from(value: &FontWeightValueVariant0Item) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<FontWeightValueVariant0ItemVariant0> for FontWeightValueVariant0Item {
     fn from(value: FontWeightValueVariant0ItemVariant0) -> Self {
@@ -33652,11 +31665,6 @@ pub enum FontWeightValueVariant0ItemVariant0 {
         test: ::std::option::Option<::std::string::String>,
     },
 }
-impl ::std::convert::From<&Self> for FontWeightValueVariant0ItemVariant0 {
-    fn from(value: &FontWeightValueVariant0ItemVariant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`FontWeightValueVariant0ItemVariant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -33679,11 +31687,6 @@ impl ::std::convert::From<&Self> for FontWeightValueVariant0ItemVariant0 {
 pub enum FontWeightValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for FontWeightValueVariant0ItemVariant0Variant3Range {
-    fn from(value: &FontWeightValueVariant0ItemVariant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for FontWeightValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -33874,11 +31877,6 @@ impl ::std::convert::From<bool> for FontWeightValueVariant0ItemVariant0Variant3R
 )]
 #[serde(deny_unknown_fields)]
 pub enum FontWeightValueVariant0ItemVariant1 {}
-impl ::std::convert::From<&Self> for FontWeightValueVariant0ItemVariant1 {
-    fn from(value: &FontWeightValueVariant0ItemVariant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`FontWeightValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -34012,11 +32010,6 @@ impl ::std::convert::From<&Self> for FontWeightValueVariant0ItemVariant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum FontWeightValueVariant0ItemVariant2 {}
-impl ::std::convert::From<&Self> for FontWeightValueVariant0ItemVariant2 {
-    fn from(value: &FontWeightValueVariant0ItemVariant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`FontWeightValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -34133,11 +32126,6 @@ pub enum FontWeightValueVariant1 {
     Variant1(FontWeightValueVariant1Variant1),
     Variant2(FontWeightValueVariant1Variant2),
     Variant3 { offset: ::serde_json::Value },
-}
-impl ::std::convert::From<&Self> for FontWeightValueVariant1 {
-    fn from(value: &FontWeightValueVariant1) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<FontWeightValueVariant1Variant0> for FontWeightValueVariant1 {
     fn from(value: FontWeightValueVariant1Variant0) -> Self {
@@ -34294,11 +32282,6 @@ pub enum FontWeightValueVariant1Variant0 {
         scale: ::std::option::Option<Field>,
     },
 }
-impl ::std::convert::From<&Self> for FontWeightValueVariant1Variant0 {
-    fn from(value: &FontWeightValueVariant1Variant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`FontWeightValueVariant1Variant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -34321,11 +32304,6 @@ impl ::std::convert::From<&Self> for FontWeightValueVariant1Variant0 {
 pub enum FontWeightValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for FontWeightValueVariant1Variant0Variant3Range {
-    fn from(value: &FontWeightValueVariant1Variant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for FontWeightValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -34513,11 +32491,6 @@ impl ::std::convert::From<bool> for FontWeightValueVariant1Variant0Variant3Range
 )]
 #[serde(deny_unknown_fields)]
 pub enum FontWeightValueVariant1Variant1 {}
-impl ::std::convert::From<&Self> for FontWeightValueVariant1Variant1 {
-    fn from(value: &FontWeightValueVariant1Variant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`FontWeightValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -34648,11 +32621,6 @@ impl ::std::convert::From<&Self> for FontWeightValueVariant1Variant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum FontWeightValueVariant1Variant2 {}
-impl ::std::convert::From<&Self> for FontWeightValueVariant1Variant2 {
-    fn from(value: &FontWeightValueVariant1Variant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ForceTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -35114,11 +33082,6 @@ pub struct ForceTransform {
     )]
     pub velocity_decay: ForceTransformVelocityDecay,
 }
-impl ::std::convert::From<&ForceTransform> for ForceTransform {
-    fn from(value: &ForceTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ForceTransformAlpha`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -35142,11 +33105,6 @@ impl ::std::convert::From<&ForceTransform> for ForceTransform {
 pub enum ForceTransformAlpha {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ForceTransformAlpha {
-    fn from(value: &ForceTransformAlpha) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for ForceTransformAlpha {
     fn default() -> Self {
@@ -35187,11 +33145,6 @@ pub enum ForceTransformAlphaMin {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ForceTransformAlphaMin {
-    fn from(value: &ForceTransformAlphaMin) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for ForceTransformAlphaMin {
     fn default() -> Self {
         ForceTransformAlphaMin::Number(0.001_f64)
@@ -35229,11 +33182,6 @@ impl ::std::convert::From<SignalRef> for ForceTransformAlphaMin {
 pub enum ForceTransformAlphaTarget {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ForceTransformAlphaTarget {
-    fn from(value: &ForceTransformAlphaTarget) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for ForceTransformAlphaTarget {
     fn from(value: f64) -> Self {
@@ -35284,11 +33232,6 @@ pub enum ForceTransformAs {
     Array(::std::vec::Vec<ForceTransformAsArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ForceTransformAs {
-    fn from(value: &ForceTransformAs) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for ForceTransformAs {
     fn default() -> Self {
         ForceTransformAs::Array(vec![
@@ -35331,11 +33274,6 @@ impl ::std::convert::From<SignalRef> for ForceTransformAs {
 pub enum ForceTransformAsArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ForceTransformAsArrayItem {
-    fn from(value: &ForceTransformAsArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<SignalRef> for ForceTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
@@ -35711,11 +33649,6 @@ pub enum ForceTransformForcesItem {
         y: ::std::option::Option<ForceTransformForcesItemY>,
     },
 }
-impl ::std::convert::From<&Self> for ForceTransformForcesItem {
-    fn from(value: &ForceTransformForcesItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ForceTransformForcesItemDistance`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -35747,11 +33680,6 @@ pub enum ForceTransformForcesItemDistance {
     SignalRef(SignalRef),
     Expr(Expr),
     ParamField(ParamField),
-}
-impl ::std::convert::From<&Self> for ForceTransformForcesItemDistance {
-    fn from(value: &ForceTransformForcesItemDistance) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for ForceTransformForcesItemDistance {
     fn default() -> Self {
@@ -35801,11 +33729,6 @@ pub enum ForceTransformForcesItemDistanceMax {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ForceTransformForcesItemDistanceMax {
-    fn from(value: &ForceTransformForcesItemDistanceMax) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for ForceTransformForcesItemDistanceMax {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -35839,11 +33762,6 @@ impl ::std::convert::From<SignalRef> for ForceTransformForcesItemDistanceMax {
 pub enum ForceTransformForcesItemDistanceMin {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ForceTransformForcesItemDistanceMin {
-    fn from(value: &ForceTransformForcesItemDistanceMin) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for ForceTransformForcesItemDistanceMin {
     fn default() -> Self {
@@ -35887,11 +33805,6 @@ pub enum ForceTransformForcesItemId {
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for ForceTransformForcesItemId {
-    fn from(value: &ForceTransformForcesItemId) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleField> for ForceTransformForcesItemId {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
@@ -35930,11 +33843,6 @@ impl ::std::convert::From<Expr> for ForceTransformForcesItemId {
 pub enum ForceTransformForcesItemIterations {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ForceTransformForcesItemIterations {
-    fn from(value: &ForceTransformForcesItemIterations) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for ForceTransformForcesItemIterations {
     fn default() -> Self {
@@ -35982,11 +33890,6 @@ pub enum ForceTransformForcesItemRadius {
     Expr(Expr),
     ParamField(ParamField),
 }
-impl ::std::convert::From<&Self> for ForceTransformForcesItemRadius {
-    fn from(value: &ForceTransformForcesItemRadius) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for ForceTransformForcesItemRadius {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -36031,11 +33934,6 @@ pub enum ForceTransformForcesItemStrength {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ForceTransformForcesItemStrength {
-    fn from(value: &ForceTransformForcesItemStrength) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for ForceTransformForcesItemStrength {
     fn default() -> Self {
         ForceTransformForcesItemStrength::Number(0.7_f64)
@@ -36075,11 +33973,6 @@ pub enum ForceTransformForcesItemTheta {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ForceTransformForcesItemTheta {
-    fn from(value: &ForceTransformForcesItemTheta) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for ForceTransformForcesItemTheta {
     fn default() -> Self {
         ForceTransformForcesItemTheta::Number(0.9_f64)
@@ -36118,11 +34011,6 @@ pub enum ForceTransformForcesItemX {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ForceTransformForcesItemX {
-    fn from(value: &ForceTransformForcesItemX) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for ForceTransformForcesItemX {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -36155,11 +34043,6 @@ impl ::std::convert::From<SignalRef> for ForceTransformForcesItemX {
 pub enum ForceTransformForcesItemY {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ForceTransformForcesItemY {
-    fn from(value: &ForceTransformForcesItemY) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for ForceTransformForcesItemY {
     fn from(value: f64) -> Self {
@@ -36194,11 +34077,6 @@ impl ::std::convert::From<SignalRef> for ForceTransformForcesItemY {
 pub enum ForceTransformIterations {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ForceTransformIterations {
-    fn from(value: &ForceTransformIterations) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for ForceTransformIterations {
     fn default() -> Self {
@@ -36238,11 +34116,6 @@ pub enum ForceTransformRestart {
     Boolean(bool),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ForceTransformRestart {
-    fn from(value: &ForceTransformRestart) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ForceTransformRestart {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -36275,11 +34148,6 @@ impl ::std::convert::From<SignalRef> for ForceTransformRestart {
 pub enum ForceTransformStatic {
     Boolean(bool),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ForceTransformStatic {
-    fn from(value: &ForceTransformStatic) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<bool> for ForceTransformStatic {
     fn from(value: bool) -> Self {
@@ -36318,11 +34186,6 @@ impl ::std::convert::From<SignalRef> for ForceTransformStatic {
 pub enum ForceTransformType {
     #[serde(rename = "force")]
     Force,
-}
-impl ::std::convert::From<&Self> for ForceTransformType {
-    fn from(value: &ForceTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ForceTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -36385,11 +34248,6 @@ impl ::std::convert::TryFrom<::std::string::String> for ForceTransformType {
 pub enum ForceTransformVelocityDecay {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ForceTransformVelocityDecay {
-    fn from(value: &ForceTransformVelocityDecay) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for ForceTransformVelocityDecay {
     fn default() -> Self {
@@ -36468,11 +34326,6 @@ pub struct FormulaTransform {
     #[serde(rename = "type")]
     pub type_: FormulaTransformType,
 }
-impl ::std::convert::From<&FormulaTransform> for FormulaTransform {
-    fn from(value: &FormulaTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`FormulaTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -36495,11 +34348,6 @@ impl ::std::convert::From<&FormulaTransform> for FormulaTransform {
 pub enum FormulaTransformAs {
     String(::std::string::String),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for FormulaTransformAs {
-    fn from(value: &FormulaTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<SignalRef> for FormulaTransformAs {
     fn from(value: SignalRef) -> Self {
@@ -36528,11 +34376,6 @@ impl ::std::convert::From<SignalRef> for FormulaTransformAs {
 pub enum FormulaTransformInitonly {
     Boolean(bool),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for FormulaTransformInitonly {
-    fn from(value: &FormulaTransformInitonly) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<bool> for FormulaTransformInitonly {
     fn from(value: bool) -> Self {
@@ -36571,11 +34414,6 @@ impl ::std::convert::From<SignalRef> for FormulaTransformInitonly {
 pub enum FormulaTransformType {
     #[serde(rename = "formula")]
     Formula,
-}
-impl ::std::convert::From<&Self> for FormulaTransformType {
-    fn from(value: &FormulaTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for FormulaTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -36636,11 +34474,6 @@ impl ::std::convert::TryFrom<::std::string::String> for FormulaTransformType {
 pub struct From {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub data: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&From> for From {
-    fn from(value: &From) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for From {
     fn default() -> Self {
@@ -36723,11 +34556,6 @@ pub struct GeojsonTransform {
     #[serde(rename = "type")]
     pub type_: GeojsonTransformType,
 }
-impl ::std::convert::From<&GeojsonTransform> for GeojsonTransform {
-    fn from(value: &GeojsonTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`GeojsonTransformFields`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -36766,11 +34594,6 @@ pub enum GeojsonTransformFields {
     Array([GeojsonTransformFieldsArrayItem; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for GeojsonTransformFields {
-    fn from(value: &GeojsonTransformFields) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[GeojsonTransformFieldsArrayItem; 2usize]> for GeojsonTransformFields {
     fn from(value: [GeojsonTransformFieldsArrayItem; 2usize]) -> Self {
         Self::Array(value)
@@ -36807,11 +34630,6 @@ pub enum GeojsonTransformFieldsArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for GeojsonTransformFieldsArrayItem {
-    fn from(value: &GeojsonTransformFieldsArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for GeojsonTransformFieldsArrayItem {
     fn from(value: ScaleField) -> Self {
@@ -36855,11 +34673,6 @@ pub enum GeojsonTransformGeojson {
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for GeojsonTransformGeojson {
-    fn from(value: &GeojsonTransformGeojson) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleField> for GeojsonTransformGeojson {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
@@ -36902,11 +34715,6 @@ impl ::std::convert::From<Expr> for GeojsonTransformGeojson {
 pub enum GeojsonTransformType {
     #[serde(rename = "geojson")]
     Geojson,
-}
-impl ::std::convert::From<&Self> for GeojsonTransformType {
-    fn from(value: &GeojsonTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for GeojsonTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -37033,11 +34841,6 @@ pub struct GeopathTransform {
     #[serde(rename = "type")]
     pub type_: GeopathTransformType,
 }
-impl ::std::convert::From<&GeopathTransform> for GeopathTransform {
-    fn from(value: &GeopathTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`GeopathTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -37061,11 +34864,6 @@ impl ::std::convert::From<&GeopathTransform> for GeopathTransform {
 pub enum GeopathTransformAs {
     String(::std::string::String),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for GeopathTransformAs {
-    fn from(value: &GeopathTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for GeopathTransformAs {
     fn default() -> Self {
@@ -37103,11 +34901,6 @@ pub enum GeopathTransformField {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for GeopathTransformField {
-    fn from(value: &GeopathTransformField) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for GeopathTransformField {
     fn from(value: ScaleField) -> Self {
@@ -37154,11 +34947,6 @@ pub enum GeopathTransformPointRadius {
     SignalRef(SignalRef),
     Expr(Expr),
     ParamField(ParamField),
-}
-impl ::std::convert::From<&Self> for GeopathTransformPointRadius {
-    fn from(value: &GeopathTransformPointRadius) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for GeopathTransformPointRadius {
     fn from(value: f64) -> Self {
@@ -37207,11 +34995,6 @@ impl ::std::convert::From<ParamField> for GeopathTransformPointRadius {
 pub enum GeopathTransformType {
     #[serde(rename = "geopath")]
     Geopath,
-}
-impl ::std::convert::From<&Self> for GeopathTransformType {
-    fn from(value: &GeopathTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for GeopathTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -37343,11 +35126,6 @@ pub struct GeopointTransform {
     #[serde(rename = "type")]
     pub type_: GeopointTransformType,
 }
-impl ::std::convert::From<&GeopointTransform> for GeopointTransform {
-    fn from(value: &GeopointTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`GeopointTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -37386,11 +35164,6 @@ impl ::std::convert::From<&GeopointTransform> for GeopointTransform {
 pub enum GeopointTransformAs {
     Array([GeopointTransformAsArrayItem; 2usize]),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for GeopointTransformAs {
-    fn from(value: &GeopointTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for GeopointTransformAs {
     fn default() -> Self {
@@ -37432,11 +35205,6 @@ impl ::std::convert::From<SignalRef> for GeopointTransformAs {
 pub enum GeopointTransformAsArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for GeopointTransformAsArrayItem {
-    fn from(value: &GeopointTransformAsArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<SignalRef> for GeopointTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
@@ -37481,11 +35249,6 @@ pub enum GeopointTransformFields {
     Array([GeopointTransformFieldsArrayItem; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for GeopointTransformFields {
-    fn from(value: &GeopointTransformFields) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[GeopointTransformFieldsArrayItem; 2usize]> for GeopointTransformFields {
     fn from(value: [GeopointTransformFieldsArrayItem; 2usize]) -> Self {
         Self::Array(value)
@@ -37522,11 +35285,6 @@ pub enum GeopointTransformFieldsArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for GeopointTransformFieldsArrayItem {
-    fn from(value: &GeopointTransformFieldsArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for GeopointTransformFieldsArrayItem {
     fn from(value: ScaleField) -> Self {
@@ -37570,11 +35328,6 @@ impl ::std::convert::From<Expr> for GeopointTransformFieldsArrayItem {
 pub enum GeopointTransformType {
     #[serde(rename = "geopoint")]
     Geopoint,
-}
-impl ::std::convert::From<&Self> for GeopointTransformType {
-    fn from(value: &GeopointTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for GeopointTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -37702,11 +35455,6 @@ pub struct GeoshapeTransform {
     #[serde(rename = "type")]
     pub type_: GeoshapeTransformType,
 }
-impl ::std::convert::From<&GeoshapeTransform> for GeoshapeTransform {
-    fn from(value: &GeoshapeTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`GeoshapeTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -37730,11 +35478,6 @@ impl ::std::convert::From<&GeoshapeTransform> for GeoshapeTransform {
 pub enum GeoshapeTransformAs {
     String(::std::string::String),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for GeoshapeTransformAs {
-    fn from(value: &GeoshapeTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for GeoshapeTransformAs {
     fn default() -> Self {
@@ -37773,11 +35516,6 @@ pub enum GeoshapeTransformField {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for GeoshapeTransformField {
-    fn from(value: &GeoshapeTransformField) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for GeoshapeTransformField {
     fn default() -> Self {
@@ -37830,11 +35568,6 @@ pub enum GeoshapeTransformPointRadius {
     Expr(Expr),
     ParamField(ParamField),
 }
-impl ::std::convert::From<&Self> for GeoshapeTransformPointRadius {
-    fn from(value: &GeoshapeTransformPointRadius) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for GeoshapeTransformPointRadius {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -37882,11 +35615,6 @@ impl ::std::convert::From<ParamField> for GeoshapeTransformPointRadius {
 pub enum GeoshapeTransformType {
     #[serde(rename = "geoshape")]
     Geoshape,
-}
-impl ::std::convert::From<&Self> for GeoshapeTransformType {
-    fn from(value: &GeoshapeTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for GeoshapeTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -37966,11 +35694,6 @@ impl ::std::convert::From<GradientStops> for ::std::vec::Vec<GradientStopsItem> 
         value.0
     }
 }
-impl ::std::convert::From<&GradientStops> for GradientStops {
-    fn from(value: &GradientStops) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<GradientStopsItem>> for GradientStops {
     fn from(value: ::std::vec::Vec<GradientStopsItem>) -> Self {
         Self(value)
@@ -38004,11 +35727,6 @@ impl ::std::convert::From<::std::vec::Vec<GradientStopsItem>> for GradientStops 
 pub struct GradientStopsItem {
     pub color: ::std::string::String,
     pub offset: f64,
-}
-impl ::std::convert::From<&GradientStopsItem> for GradientStopsItem {
-    fn from(value: &GradientStopsItem) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`GraticuleTransform`"]
 #[doc = r""]
@@ -38194,11 +35912,6 @@ pub struct GraticuleTransform {
     #[serde(rename = "type")]
     pub type_: GraticuleTransformType,
 }
-impl ::std::convert::From<&GraticuleTransform> for GraticuleTransform {
-    fn from(value: &GraticuleTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`GraticuleTransformExtent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -38224,11 +35937,6 @@ impl ::std::convert::From<&GraticuleTransform> for GraticuleTransform {
 pub enum GraticuleTransformExtent {
     Array([::serde_json::Value; 2usize]),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for GraticuleTransformExtent {
-    fn from(value: &GraticuleTransformExtent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<[::serde_json::Value; 2usize]> for GraticuleTransformExtent {
     fn from(value: [::serde_json::Value; 2usize]) -> Self {
@@ -38266,11 +35974,6 @@ pub enum GraticuleTransformExtentMajor {
     Array([::serde_json::Value; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for GraticuleTransformExtentMajor {
-    fn from(value: &GraticuleTransformExtentMajor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[::serde_json::Value; 2usize]> for GraticuleTransformExtentMajor {
     fn from(value: [::serde_json::Value; 2usize]) -> Self {
         Self::Array(value)
@@ -38307,11 +36010,6 @@ pub enum GraticuleTransformExtentMinor {
     Array([::serde_json::Value; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for GraticuleTransformExtentMinor {
-    fn from(value: &GraticuleTransformExtentMinor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[::serde_json::Value; 2usize]> for GraticuleTransformExtentMinor {
     fn from(value: [::serde_json::Value; 2usize]) -> Self {
         Self::Array(value)
@@ -38345,11 +36043,6 @@ impl ::std::convert::From<SignalRef> for GraticuleTransformExtentMinor {
 pub enum GraticuleTransformPrecision {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for GraticuleTransformPrecision {
-    fn from(value: &GraticuleTransformPrecision) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for GraticuleTransformPrecision {
     fn default() -> Self {
@@ -38401,11 +36094,6 @@ pub enum GraticuleTransformStep {
     Array([GraticuleTransformStepArrayItem; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for GraticuleTransformStep {
-    fn from(value: &GraticuleTransformStep) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[GraticuleTransformStepArrayItem; 2usize]> for GraticuleTransformStep {
     fn from(value: [GraticuleTransformStepArrayItem; 2usize]) -> Self {
         Self::Array(value)
@@ -38438,11 +36126,6 @@ impl ::std::convert::From<SignalRef> for GraticuleTransformStep {
 pub enum GraticuleTransformStepArrayItem {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for GraticuleTransformStepArrayItem {
-    fn from(value: &GraticuleTransformStepArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for GraticuleTransformStepArrayItem {
     fn from(value: f64) -> Self {
@@ -38493,11 +36176,6 @@ pub enum GraticuleTransformStepMajor {
     Array([GraticuleTransformStepMajorArrayItem; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for GraticuleTransformStepMajor {
-    fn from(value: &GraticuleTransformStepMajor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for GraticuleTransformStepMajor {
     fn default() -> Self {
         GraticuleTransformStepMajor::Array([
@@ -38540,11 +36218,6 @@ impl ::std::convert::From<SignalRef> for GraticuleTransformStepMajor {
 pub enum GraticuleTransformStepMajorArrayItem {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for GraticuleTransformStepMajorArrayItem {
-    fn from(value: &GraticuleTransformStepMajorArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for GraticuleTransformStepMajorArrayItem {
     fn from(value: f64) -> Self {
@@ -38595,11 +36268,6 @@ pub enum GraticuleTransformStepMinor {
     Array([GraticuleTransformStepMinorArrayItem; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for GraticuleTransformStepMinor {
-    fn from(value: &GraticuleTransformStepMinor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for GraticuleTransformStepMinor {
     fn default() -> Self {
         GraticuleTransformStepMinor::Array([
@@ -38643,11 +36311,6 @@ pub enum GraticuleTransformStepMinorArrayItem {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for GraticuleTransformStepMinorArrayItem {
-    fn from(value: &GraticuleTransformStepMinorArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for GraticuleTransformStepMinorArrayItem {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -38685,11 +36348,6 @@ impl ::std::convert::From<SignalRef> for GraticuleTransformStepMinorArrayItem {
 pub enum GraticuleTransformType {
     #[serde(rename = "graticule")]
     Graticule,
-}
-impl ::std::convert::From<&Self> for GraticuleTransformType {
-    fn from(value: &GraticuleTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for GraticuleTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -38766,11 +36424,6 @@ pub struct GuideEncode {
     pub name: ::std::option::Option<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub style: ::std::option::Option<Style>,
-}
-impl ::std::convert::From<&GuideEncode> for GuideEncode {
-    fn from(value: &GuideEncode) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for GuideEncode {
     fn default() -> Self {
@@ -38893,11 +36546,6 @@ pub struct HeatmapTransform {
     #[serde(rename = "type")]
     pub type_: HeatmapTransformType,
 }
-impl ::std::convert::From<&HeatmapTransform> for HeatmapTransform {
-    fn from(value: &HeatmapTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`HeatmapTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -38921,11 +36569,6 @@ impl ::std::convert::From<&HeatmapTransform> for HeatmapTransform {
 pub enum HeatmapTransformAs {
     String(::std::string::String),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for HeatmapTransformAs {
-    fn from(value: &HeatmapTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for HeatmapTransformAs {
     fn default() -> Self {
@@ -38968,11 +36611,6 @@ pub enum HeatmapTransformColor {
     Expr(Expr),
     ParamField(ParamField),
 }
-impl ::std::convert::From<&Self> for HeatmapTransformColor {
-    fn from(value: &HeatmapTransformColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for HeatmapTransformColor {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -39014,11 +36652,6 @@ pub enum HeatmapTransformField {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for HeatmapTransformField {
-    fn from(value: &HeatmapTransformField) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for HeatmapTransformField {
     fn from(value: ScaleField) -> Self {
@@ -39065,11 +36698,6 @@ pub enum HeatmapTransformOpacity {
     SignalRef(SignalRef),
     Expr(Expr),
     ParamField(ParamField),
-}
-impl ::std::convert::From<&Self> for HeatmapTransformOpacity {
-    fn from(value: &HeatmapTransformOpacity) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for HeatmapTransformOpacity {
     fn from(value: f64) -> Self {
@@ -39118,11 +36746,6 @@ pub enum HeatmapTransformResolve {
     Variant0(HeatmapTransformResolveVariant0),
     Variant1(SignalRef),
 }
-impl ::std::convert::From<&Self> for HeatmapTransformResolve {
-    fn from(value: &HeatmapTransformResolve) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for HeatmapTransformResolve {
     fn default() -> Self {
         HeatmapTransformResolve::Variant0(HeatmapTransformResolveVariant0::Independent)
@@ -39168,11 +36791,6 @@ pub enum HeatmapTransformResolveVariant0 {
     Shared,
     #[serde(rename = "independent")]
     Independent,
-}
-impl ::std::convert::From<&Self> for HeatmapTransformResolveVariant0 {
-    fn from(value: &HeatmapTransformResolveVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for HeatmapTransformResolveVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -39241,11 +36859,6 @@ impl ::std::convert::TryFrom<::std::string::String> for HeatmapTransformResolveV
 pub enum HeatmapTransformType {
     #[serde(rename = "heatmap")]
     Heatmap,
-}
-impl ::std::convert::From<&Self> for HeatmapTransformType {
-    fn from(value: &HeatmapTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for HeatmapTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -39330,11 +36943,6 @@ pub struct IdentifierTransform {
     #[serde(rename = "type")]
     pub type_: IdentifierTransformType,
 }
-impl ::std::convert::From<&IdentifierTransform> for IdentifierTransform {
-    fn from(value: &IdentifierTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IdentifierTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -39357,11 +36965,6 @@ impl ::std::convert::From<&IdentifierTransform> for IdentifierTransform {
 pub enum IdentifierTransformAs {
     String(::std::string::String),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for IdentifierTransformAs {
-    fn from(value: &IdentifierTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<SignalRef> for IdentifierTransformAs {
     fn from(value: SignalRef) -> Self {
@@ -39395,11 +36998,6 @@ impl ::std::convert::From<SignalRef> for IdentifierTransformAs {
 pub enum IdentifierTransformType {
     #[serde(rename = "identifier")]
     Identifier,
-}
-impl ::std::convert::From<&Self> for IdentifierTransformType {
-    fn from(value: &IdentifierTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IdentifierTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -39561,11 +37159,6 @@ pub struct ImputeTransform {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub value: ::std::option::Option<::serde_json::Value>,
 }
-impl ::std::convert::From<&ImputeTransform> for ImputeTransform {
-    fn from(value: &ImputeTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ImputeTransformField`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -39592,11 +37185,6 @@ pub enum ImputeTransformField {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for ImputeTransformField {
-    fn from(value: &ImputeTransformField) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for ImputeTransformField {
     fn from(value: ScaleField) -> Self {
@@ -39649,11 +37237,6 @@ pub enum ImputeTransformGroupby {
     Array(::std::vec::Vec<ImputeTransformGroupbyArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ImputeTransformGroupby {
-    fn from(value: &ImputeTransformGroupby) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ImputeTransformGroupbyArrayItem>>
     for ImputeTransformGroupby
 {
@@ -39692,11 +37275,6 @@ pub enum ImputeTransformGroupbyArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for ImputeTransformGroupbyArrayItem {
-    fn from(value: &ImputeTransformGroupbyArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for ImputeTransformGroupbyArrayItem {
     fn from(value: ScaleField) -> Self {
@@ -39740,11 +37318,6 @@ pub enum ImputeTransformKey {
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for ImputeTransformKey {
-    fn from(value: &ImputeTransformKey) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleField> for ImputeTransformKey {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
@@ -39783,11 +37356,6 @@ impl ::std::convert::From<Expr> for ImputeTransformKey {
 pub enum ImputeTransformKeyvals {
     Array(::std::vec::Vec<::serde_json::Value>),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ImputeTransformKeyvals {
-    fn from(value: &ImputeTransformKeyvals) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ImputeTransformKeyvals {
     fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
@@ -39828,11 +37396,6 @@ impl ::std::convert::From<SignalRef> for ImputeTransformKeyvals {
 pub enum ImputeTransformMethod {
     Variant0(ImputeTransformMethodVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for ImputeTransformMethod {
-    fn from(value: &ImputeTransformMethod) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for ImputeTransformMethod {
     fn default() -> Self {
@@ -39888,11 +37451,6 @@ pub enum ImputeTransformMethodVariant0 {
     Max,
     #[serde(rename = "min")]
     Min,
-}
-impl ::std::convert::From<&Self> for ImputeTransformMethodVariant0 {
-    fn from(value: &ImputeTransformMethodVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ImputeTransformMethodVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -39967,11 +37525,6 @@ impl ::std::convert::TryFrom<::std::string::String> for ImputeTransformMethodVar
 pub enum ImputeTransformType {
     #[serde(rename = "impute")]
     Impute,
-}
-impl ::std::convert::From<&Self> for ImputeTransformType {
-    fn from(value: &ImputeTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ImputeTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -40208,11 +37761,6 @@ pub struct IsocontourTransform {
     #[serde(default = "defaults::isocontour_transform_zero")]
     pub zero: IsocontourTransformZero,
 }
-impl ::std::convert::From<&IsocontourTransform> for IsocontourTransform {
-    fn from(value: &IsocontourTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IsocontourTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -40240,11 +37788,6 @@ pub enum IsocontourTransformAs {
     String(::std::string::String),
     SignalRef(SignalRef),
     Null,
-}
-impl ::std::convert::From<&Self> for IsocontourTransformAs {
-    fn from(value: &IsocontourTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for IsocontourTransformAs {
     fn default() -> Self {
@@ -40282,11 +37825,6 @@ pub enum IsocontourTransformField {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for IsocontourTransformField {
-    fn from(value: &IsocontourTransformField) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for IsocontourTransformField {
     fn from(value: ScaleField) -> Self {
@@ -40326,11 +37864,6 @@ pub enum IsocontourTransformLevels {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for IsocontourTransformLevels {
-    fn from(value: &IsocontourTransformLevels) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for IsocontourTransformLevels {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -40363,11 +37896,6 @@ impl ::std::convert::From<SignalRef> for IsocontourTransformLevels {
 pub enum IsocontourTransformNice {
     Boolean(bool),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for IsocontourTransformNice {
-    fn from(value: &IsocontourTransformNice) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<bool> for IsocontourTransformNice {
     fn from(value: bool) -> Self {
@@ -40405,11 +37933,6 @@ impl ::std::convert::From<SignalRef> for IsocontourTransformNice {
 pub enum IsocontourTransformResolve {
     Variant0(IsocontourTransformResolveVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for IsocontourTransformResolve {
-    fn from(value: &IsocontourTransformResolve) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for IsocontourTransformResolve {
     fn default() -> Self {
@@ -40456,11 +37979,6 @@ pub enum IsocontourTransformResolveVariant0 {
     Shared,
     #[serde(rename = "independent")]
     Independent,
-}
-impl ::std::convert::From<&Self> for IsocontourTransformResolveVariant0 {
-    fn from(value: &IsocontourTransformResolveVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IsocontourTransformResolveVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -40533,11 +38051,6 @@ pub enum IsocontourTransformScale {
     Expr(Expr),
     ParamField(ParamField),
 }
-impl ::std::convert::From<&Self> for IsocontourTransformScale {
-    fn from(value: &IsocontourTransformScale) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for IsocontourTransformScale {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -40581,11 +38094,6 @@ impl ::std::convert::From<ParamField> for IsocontourTransformScale {
 pub enum IsocontourTransformSmooth {
     Boolean(bool),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for IsocontourTransformSmooth {
-    fn from(value: &IsocontourTransformSmooth) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for IsocontourTransformSmooth {
     fn default() -> Self {
@@ -40635,11 +38143,6 @@ pub enum IsocontourTransformThresholds {
     Array(::std::vec::Vec<IsocontourTransformThresholdsArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for IsocontourTransformThresholds {
-    fn from(value: &IsocontourTransformThresholds) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<IsocontourTransformThresholdsArrayItem>>
     for IsocontourTransformThresholds
 {
@@ -40674,11 +38177,6 @@ impl ::std::convert::From<SignalRef> for IsocontourTransformThresholds {
 pub enum IsocontourTransformThresholdsArrayItem {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for IsocontourTransformThresholdsArrayItem {
-    fn from(value: &IsocontourTransformThresholdsArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for IsocontourTransformThresholdsArrayItem {
     fn from(value: f64) -> Self {
@@ -40729,11 +38227,6 @@ pub enum IsocontourTransformTranslate {
     Array(::std::vec::Vec<IsocontourTransformTranslateArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for IsocontourTransformTranslate {
-    fn from(value: &IsocontourTransformTranslate) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<IsocontourTransformTranslateArrayItem>>
     for IsocontourTransformTranslate
 {
@@ -40776,11 +38269,6 @@ pub enum IsocontourTransformTranslateArrayItem {
     SignalRef(SignalRef),
     Expr(Expr),
     ParamField(ParamField),
-}
-impl ::std::convert::From<&Self> for IsocontourTransformTranslateArrayItem {
-    fn from(value: &IsocontourTransformTranslateArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for IsocontourTransformTranslateArrayItem {
     fn from(value: f64) -> Self {
@@ -40829,11 +38317,6 @@ impl ::std::convert::From<ParamField> for IsocontourTransformTranslateArrayItem 
 pub enum IsocontourTransformType {
     #[serde(rename = "isocontour")]
     Isocontour,
-}
-impl ::std::convert::From<&Self> for IsocontourTransformType {
-    fn from(value: &IsocontourTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for IsocontourTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -40896,11 +38379,6 @@ impl ::std::convert::TryFrom<::std::string::String> for IsocontourTransformType 
 pub enum IsocontourTransformZero {
     Boolean(bool),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for IsocontourTransformZero {
-    fn from(value: &IsocontourTransformZero) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for IsocontourTransformZero {
     fn default() -> Self {
@@ -41093,11 +38571,6 @@ pub struct JoinaggregateTransform {
     #[serde(rename = "type")]
     pub type_: JoinaggregateTransformType,
 }
-impl ::std::convert::From<&JoinaggregateTransform> for JoinaggregateTransform {
-    fn from(value: &JoinaggregateTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`JoinaggregateTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -41133,11 +38606,6 @@ impl ::std::convert::From<&JoinaggregateTransform> for JoinaggregateTransform {
 pub enum JoinaggregateTransformAs {
     Array(::std::vec::Vec<JoinaggregateTransformAsArrayItem>),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for JoinaggregateTransformAs {
-    fn from(value: &JoinaggregateTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<JoinaggregateTransformAsArrayItem>>
     for JoinaggregateTransformAs
@@ -41177,11 +38645,6 @@ pub enum JoinaggregateTransformAsArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
     Null,
-}
-impl ::std::convert::From<&Self> for JoinaggregateTransformAsArrayItem {
-    fn from(value: &JoinaggregateTransformAsArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<SignalRef> for JoinaggregateTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
@@ -41227,11 +38690,6 @@ pub enum JoinaggregateTransformFields {
     Array(::std::vec::Vec<JoinaggregateTransformFieldsArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for JoinaggregateTransformFields {
-    fn from(value: &JoinaggregateTransformFields) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<JoinaggregateTransformFieldsArrayItem>>
     for JoinaggregateTransformFields
 {
@@ -41274,11 +38732,6 @@ pub enum JoinaggregateTransformFieldsArrayItem {
     ParamField(ParamField),
     Expr(Expr),
     Null,
-}
-impl ::std::convert::From<&Self> for JoinaggregateTransformFieldsArrayItem {
-    fn from(value: &JoinaggregateTransformFieldsArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for JoinaggregateTransformFieldsArrayItem {
     fn from(value: ScaleField) -> Self {
@@ -41331,11 +38784,6 @@ pub enum JoinaggregateTransformGroupby {
     Array(::std::vec::Vec<JoinaggregateTransformGroupbyArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for JoinaggregateTransformGroupby {
-    fn from(value: &JoinaggregateTransformGroupby) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<JoinaggregateTransformGroupbyArrayItem>>
     for JoinaggregateTransformGroupby
 {
@@ -41374,11 +38822,6 @@ pub enum JoinaggregateTransformGroupbyArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for JoinaggregateTransformGroupbyArrayItem {
-    fn from(value: &JoinaggregateTransformGroupbyArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for JoinaggregateTransformGroupbyArrayItem {
     fn from(value: ScaleField) -> Self {
@@ -41421,11 +38864,6 @@ pub enum JoinaggregateTransformKey {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for JoinaggregateTransformKey {
-    fn from(value: &JoinaggregateTransformKey) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for JoinaggregateTransformKey {
     fn from(value: ScaleField) -> Self {
@@ -41500,11 +38938,6 @@ pub enum JoinaggregateTransformOps {
     Array(::std::vec::Vec<JoinaggregateTransformOpsArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for JoinaggregateTransformOps {
-    fn from(value: &JoinaggregateTransformOps) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<JoinaggregateTransformOpsArrayItem>>
     for JoinaggregateTransformOps
 {
@@ -41564,11 +38997,6 @@ impl ::std::convert::From<SignalRef> for JoinaggregateTransformOps {
 pub enum JoinaggregateTransformOpsArrayItem {
     Variant0(JoinaggregateTransformOpsArrayItemVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for JoinaggregateTransformOpsArrayItem {
-    fn from(value: &JoinaggregateTransformOpsArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<JoinaggregateTransformOpsArrayItemVariant0>
     for JoinaggregateTransformOpsArrayItem
@@ -41678,11 +39106,6 @@ pub enum JoinaggregateTransformOpsArrayItemVariant0 {
     Argmin,
     #[serde(rename = "argmax")]
     Argmax,
-}
-impl ::std::convert::From<&Self> for JoinaggregateTransformOpsArrayItemVariant0 {
-    fn from(value: &JoinaggregateTransformOpsArrayItemVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for JoinaggregateTransformOpsArrayItemVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -41797,11 +39220,6 @@ impl ::std::convert::TryFrom<::std::string::String> for JoinaggregateTransformOp
 pub enum JoinaggregateTransformType {
     #[serde(rename = "joinaggregate")]
     Joinaggregate,
-}
-impl ::std::convert::From<&Self> for JoinaggregateTransformType {
-    fn from(value: &JoinaggregateTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for JoinaggregateTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -42032,11 +39450,6 @@ pub struct Kde2dTransform {
     pub x: Kde2dTransformX,
     pub y: Kde2dTransformY,
 }
-impl ::std::convert::From<&Kde2dTransform> for Kde2dTransform {
-    fn from(value: &Kde2dTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`Kde2dTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -42060,11 +39473,6 @@ impl ::std::convert::From<&Kde2dTransform> for Kde2dTransform {
 pub enum Kde2dTransformAs {
     String(::std::string::String),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for Kde2dTransformAs {
-    fn from(value: &Kde2dTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for Kde2dTransformAs {
     fn default() -> Self {
@@ -42111,11 +39519,6 @@ pub enum Kde2dTransformBandwidth {
     Array([Kde2dTransformBandwidthArrayItem; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for Kde2dTransformBandwidth {
-    fn from(value: &Kde2dTransformBandwidth) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[Kde2dTransformBandwidthArrayItem; 2usize]> for Kde2dTransformBandwidth {
     fn from(value: [Kde2dTransformBandwidthArrayItem; 2usize]) -> Self {
         Self::Array(value)
@@ -42148,11 +39551,6 @@ impl ::std::convert::From<SignalRef> for Kde2dTransformBandwidth {
 pub enum Kde2dTransformBandwidthArrayItem {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for Kde2dTransformBandwidthArrayItem {
-    fn from(value: &Kde2dTransformBandwidthArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for Kde2dTransformBandwidthArrayItem {
     fn from(value: f64) -> Self {
@@ -42187,11 +39585,6 @@ pub enum Kde2dTransformCellSize {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for Kde2dTransformCellSize {
-    fn from(value: &Kde2dTransformCellSize) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for Kde2dTransformCellSize {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -42224,11 +39617,6 @@ impl ::std::convert::From<SignalRef> for Kde2dTransformCellSize {
 pub enum Kde2dTransformCounts {
     Boolean(bool),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for Kde2dTransformCounts {
-    fn from(value: &Kde2dTransformCounts) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<bool> for Kde2dTransformCounts {
     fn from(value: bool) -> Self {
@@ -42276,11 +39664,6 @@ pub enum Kde2dTransformGroupby {
     Array(::std::vec::Vec<Kde2dTransformGroupbyArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for Kde2dTransformGroupby {
-    fn from(value: &Kde2dTransformGroupby) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<Kde2dTransformGroupbyArrayItem>>
     for Kde2dTransformGroupby
 {
@@ -42319,11 +39702,6 @@ pub enum Kde2dTransformGroupbyArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for Kde2dTransformGroupbyArrayItem {
-    fn from(value: &Kde2dTransformGroupbyArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for Kde2dTransformGroupbyArrayItem {
     fn from(value: ScaleField) -> Self {
@@ -42375,11 +39753,6 @@ pub enum Kde2dTransformSize {
     Array([Kde2dTransformSizeArrayItem; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for Kde2dTransformSize {
-    fn from(value: &Kde2dTransformSize) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[Kde2dTransformSizeArrayItem; 2usize]> for Kde2dTransformSize {
     fn from(value: [Kde2dTransformSizeArrayItem; 2usize]) -> Self {
         Self::Array(value)
@@ -42412,11 +39785,6 @@ impl ::std::convert::From<SignalRef> for Kde2dTransformSize {
 pub enum Kde2dTransformSizeArrayItem {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for Kde2dTransformSizeArrayItem {
-    fn from(value: &Kde2dTransformSizeArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for Kde2dTransformSizeArrayItem {
     fn from(value: f64) -> Self {
@@ -42455,11 +39823,6 @@ impl ::std::convert::From<SignalRef> for Kde2dTransformSizeArrayItem {
 pub enum Kde2dTransformType {
     #[serde(rename = "kde2d")]
     Kde2d,
-}
-impl ::std::convert::From<&Self> for Kde2dTransformType {
-    fn from(value: &Kde2dTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for Kde2dTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -42526,11 +39889,6 @@ pub enum Kde2dTransformWeight {
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for Kde2dTransformWeight {
-    fn from(value: &Kde2dTransformWeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleField> for Kde2dTransformWeight {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
@@ -42573,11 +39931,6 @@ pub enum Kde2dTransformX {
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for Kde2dTransformX {
-    fn from(value: &Kde2dTransformX) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleField> for Kde2dTransformX {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
@@ -42619,11 +39972,6 @@ pub enum Kde2dTransformY {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for Kde2dTransformY {
-    fn from(value: &Kde2dTransformY) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for Kde2dTransformY {
     fn from(value: ScaleField) -> Self {
@@ -42852,11 +40200,6 @@ pub struct KdeTransform {
     #[serde(rename = "type")]
     pub type_: KdeTransformType,
 }
-impl ::std::convert::From<&KdeTransform> for KdeTransform {
-    fn from(value: &KdeTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`KdeTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -42893,11 +40236,6 @@ impl ::std::convert::From<&KdeTransform> for KdeTransform {
 pub enum KdeTransformAs {
     Array(::std::vec::Vec<KdeTransformAsArrayItem>),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for KdeTransformAs {
-    fn from(value: &KdeTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for KdeTransformAs {
     fn default() -> Self {
@@ -42940,11 +40278,6 @@ pub enum KdeTransformAsArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for KdeTransformAsArrayItem {
-    fn from(value: &KdeTransformAsArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for KdeTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -42972,11 +40305,6 @@ impl ::std::convert::From<SignalRef> for KdeTransformAsArrayItem {
 pub enum KdeTransformBandwidth {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for KdeTransformBandwidth {
-    fn from(value: &KdeTransformBandwidth) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for KdeTransformBandwidth {
     fn from(value: f64) -> Self {
@@ -43011,11 +40339,6 @@ pub enum KdeTransformCounts {
     Boolean(bool),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for KdeTransformCounts {
-    fn from(value: &KdeTransformCounts) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for KdeTransformCounts {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -43048,11 +40371,6 @@ impl ::std::convert::From<SignalRef> for KdeTransformCounts {
 pub enum KdeTransformCumulative {
     Boolean(bool),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for KdeTransformCumulative {
-    fn from(value: &KdeTransformCumulative) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<bool> for KdeTransformCumulative {
     fn from(value: bool) -> Self {
@@ -43099,11 +40417,6 @@ pub enum KdeTransformExtent {
     Array([KdeTransformExtentArrayItem; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for KdeTransformExtent {
-    fn from(value: &KdeTransformExtent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[KdeTransformExtentArrayItem; 2usize]> for KdeTransformExtent {
     fn from(value: [KdeTransformExtentArrayItem; 2usize]) -> Self {
         Self::Array(value)
@@ -43136,11 +40449,6 @@ impl ::std::convert::From<SignalRef> for KdeTransformExtent {
 pub enum KdeTransformExtentArrayItem {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for KdeTransformExtentArrayItem {
-    fn from(value: &KdeTransformExtentArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for KdeTransformExtentArrayItem {
     fn from(value: f64) -> Self {
@@ -43178,11 +40486,6 @@ pub enum KdeTransformField {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for KdeTransformField {
-    fn from(value: &KdeTransformField) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for KdeTransformField {
     fn from(value: ScaleField) -> Self {
@@ -43235,11 +40538,6 @@ pub enum KdeTransformGroupby {
     Array(::std::vec::Vec<KdeTransformGroupbyArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for KdeTransformGroupby {
-    fn from(value: &KdeTransformGroupby) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<KdeTransformGroupbyArrayItem>> for KdeTransformGroupby {
     fn from(value: ::std::vec::Vec<KdeTransformGroupbyArrayItem>) -> Self {
         Self::Array(value)
@@ -43276,11 +40574,6 @@ pub enum KdeTransformGroupbyArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for KdeTransformGroupbyArrayItem {
-    fn from(value: &KdeTransformGroupbyArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for KdeTransformGroupbyArrayItem {
     fn from(value: ScaleField) -> Self {
@@ -43321,11 +40614,6 @@ pub enum KdeTransformMaxsteps {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for KdeTransformMaxsteps {
-    fn from(value: &KdeTransformMaxsteps) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for KdeTransformMaxsteps {
     fn default() -> Self {
         KdeTransformMaxsteps::Number(200_f64)
@@ -43364,11 +40652,6 @@ impl ::std::convert::From<SignalRef> for KdeTransformMaxsteps {
 pub enum KdeTransformMinsteps {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for KdeTransformMinsteps {
-    fn from(value: &KdeTransformMinsteps) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for KdeTransformMinsteps {
     fn default() -> Self {
@@ -43411,11 +40694,6 @@ impl ::std::convert::From<SignalRef> for KdeTransformMinsteps {
 pub enum KdeTransformResolve {
     Variant0(KdeTransformResolveVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for KdeTransformResolve {
-    fn from(value: &KdeTransformResolve) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for KdeTransformResolve {
     fn default() -> Self {
@@ -43462,11 +40740,6 @@ pub enum KdeTransformResolveVariant0 {
     Shared,
     #[serde(rename = "independent")]
     Independent,
-}
-impl ::std::convert::From<&Self> for KdeTransformResolveVariant0 {
-    fn from(value: &KdeTransformResolveVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for KdeTransformResolveVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -43531,11 +40804,6 @@ pub enum KdeTransformSteps {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for KdeTransformSteps {
-    fn from(value: &KdeTransformSteps) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for KdeTransformSteps {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -43573,11 +40841,6 @@ impl ::std::convert::From<SignalRef> for KdeTransformSteps {
 pub enum KdeTransformType {
     #[serde(rename = "kde")]
     Kde,
-}
-impl ::std::convert::From<&Self> for KdeTransformType {
-    fn from(value: &KdeTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for KdeTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -43647,11 +40910,6 @@ pub enum LabelOverlap {
     Variant1(LabelOverlapVariant1),
     Variant2(SignalRef),
 }
-impl ::std::convert::From<&Self> for LabelOverlap {
-    fn from(value: &LabelOverlap) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for LabelOverlap {
     fn from(value: bool) -> Self {
         Self::Variant0(value)
@@ -43697,11 +40955,6 @@ pub enum LabelOverlapVariant1 {
     Parity,
     #[serde(rename = "greedy")]
     Greedy,
-}
-impl ::std::convert::From<&Self> for LabelOverlapVariant1 {
-    fn from(value: &LabelOverlapVariant1) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LabelOverlapVariant1 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -43987,11 +41240,6 @@ pub struct LabelTransform {
     #[serde(rename = "type")]
     pub type_: LabelTransformType,
 }
-impl ::std::convert::From<&LabelTransform> for LabelTransform {
-    fn from(value: &LabelTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`LabelTransformAnchor`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -44034,11 +41282,6 @@ impl ::std::convert::From<&LabelTransform> for LabelTransform {
 pub enum LabelTransformAnchor {
     Array(::std::vec::Vec<LabelTransformAnchorArrayItem>),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for LabelTransformAnchor {
-    fn from(value: &LabelTransformAnchor) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for LabelTransformAnchor {
     fn default() -> Self {
@@ -44087,11 +41330,6 @@ pub enum LabelTransformAnchorArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for LabelTransformAnchorArrayItem {
-    fn from(value: &LabelTransformAnchorArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for LabelTransformAnchorArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -44139,11 +41377,6 @@ pub enum LabelTransformAs {
     Array([LabelTransformAsArrayItem; 5usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for LabelTransformAs {
-    fn from(value: &LabelTransformAs) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for LabelTransformAs {
     fn default() -> Self {
         LabelTransformAs::Array([
@@ -44188,11 +41421,6 @@ pub enum LabelTransformAsArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for LabelTransformAsArrayItem {
-    fn from(value: &LabelTransformAsArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for LabelTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -44221,11 +41449,6 @@ impl ::std::convert::From<SignalRef> for LabelTransformAsArrayItem {
 pub enum LabelTransformAvoidBaseMark {
     Boolean(bool),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for LabelTransformAvoidBaseMark {
-    fn from(value: &LabelTransformAvoidBaseMark) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for LabelTransformAvoidBaseMark {
     fn default() -> Self {
@@ -44268,11 +41491,6 @@ pub enum LabelTransformAvoidMarks {
     Array(::std::vec::Vec<::std::string::String>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for LabelTransformAvoidMarks {
-    fn from(value: &LabelTransformAvoidMarks) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<::std::string::String>> for LabelTransformAvoidMarks {
     fn from(value: ::std::vec::Vec<::std::string::String>) -> Self {
         Self::Array(value)
@@ -44307,11 +41525,6 @@ pub enum LabelTransformLineAnchor {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for LabelTransformLineAnchor {
-    fn from(value: &LabelTransformLineAnchor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for LabelTransformLineAnchor {
     fn default() -> Self {
         LabelTransformLineAnchor::String("end".to_string())
@@ -44344,11 +41557,6 @@ impl ::std::convert::From<SignalRef> for LabelTransformLineAnchor {
 pub enum LabelTransformMarkIndex {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for LabelTransformMarkIndex {
-    fn from(value: &LabelTransformMarkIndex) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LabelTransformMarkIndex {
     fn from(value: f64) -> Self {
@@ -44383,11 +41591,6 @@ impl ::std::convert::From<SignalRef> for LabelTransformMarkIndex {
 pub enum LabelTransformMethod {
     String(::std::string::String),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for LabelTransformMethod {
-    fn from(value: &LabelTransformMethod) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for LabelTransformMethod {
     fn default() -> Self {
@@ -44435,11 +41638,6 @@ pub enum LabelTransformOffset {
     Array(::std::vec::Vec<LabelTransformOffsetArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for LabelTransformOffset {
-    fn from(value: &LabelTransformOffset) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for LabelTransformOffset {
     fn default() -> Self {
         LabelTransformOffset::Array(vec![LabelTransformOffsetArrayItem::Number(1_f64)])
@@ -44478,11 +41676,6 @@ pub enum LabelTransformOffsetArrayItem {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for LabelTransformOffsetArrayItem {
-    fn from(value: &LabelTransformOffsetArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LabelTransformOffsetArrayItem {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -44519,11 +41712,6 @@ pub enum LabelTransformPadding {
     Number(f64),
     SignalRef(SignalRef),
     Null,
-}
-impl ::std::convert::From<&Self> for LabelTransformPadding {
-    fn from(value: &LabelTransformPadding) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LabelTransformPadding {
     fn from(value: f64) -> Self {
@@ -44570,11 +41758,6 @@ pub enum LabelTransformSize {
     Array([LabelTransformSizeArrayItem; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for LabelTransformSize {
-    fn from(value: &LabelTransformSize) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[LabelTransformSizeArrayItem; 2usize]> for LabelTransformSize {
     fn from(value: [LabelTransformSizeArrayItem; 2usize]) -> Self {
         Self::Array(value)
@@ -44607,11 +41790,6 @@ impl ::std::convert::From<SignalRef> for LabelTransformSize {
 pub enum LabelTransformSizeArrayItem {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for LabelTransformSizeArrayItem {
-    fn from(value: &LabelTransformSizeArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LabelTransformSizeArrayItem {
     fn from(value: f64) -> Self {
@@ -44650,11 +41828,6 @@ impl ::std::convert::From<SignalRef> for LabelTransformSizeArrayItem {
 pub enum LabelTransformType {
     #[serde(rename = "label")]
     Label,
-}
-impl ::std::convert::From<&Self> for LabelTransformType {
-    fn from(value: &LabelTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LabelTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -45018,11 +42191,6 @@ pub enum Layout {
     },
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for Layout {
-    fn from(value: &Layout) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for Layout {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -45098,11 +42266,6 @@ pub enum LayoutObjectAlign {
         row: ::std::option::Option<LayoutObjectAlignVariant1Row>,
     },
 }
-impl ::std::convert::From<&Self> for LayoutObjectAlign {
-    fn from(value: &LayoutObjectAlign) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LayoutObjectAlignVariant0> for LayoutObjectAlign {
     fn from(value: LayoutObjectAlignVariant0) -> Self {
         Self::Variant0(value)
@@ -45134,11 +42297,6 @@ impl ::std::convert::From<LayoutObjectAlignVariant0> for LayoutObjectAlign {
 pub enum LayoutObjectAlignVariant0 {
     Variant0(LayoutObjectAlignVariant0Variant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for LayoutObjectAlignVariant0 {
-    fn from(value: &LayoutObjectAlignVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LayoutObjectAlignVariant0Variant0> for LayoutObjectAlignVariant0 {
     fn from(value: LayoutObjectAlignVariant0Variant0) -> Self {
@@ -45183,11 +42341,6 @@ pub enum LayoutObjectAlignVariant0Variant0 {
     Each,
     #[serde(rename = "none")]
     None,
-}
-impl ::std::convert::From<&Self> for LayoutObjectAlignVariant0Variant0 {
-    fn from(value: &LayoutObjectAlignVariant0Variant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LayoutObjectAlignVariant0Variant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -45258,11 +42411,6 @@ pub enum LayoutObjectAlignVariant1Column {
     Variant0(LayoutObjectAlignVariant1ColumnVariant0),
     Variant1(SignalRef),
 }
-impl ::std::convert::From<&Self> for LayoutObjectAlignVariant1Column {
-    fn from(value: &LayoutObjectAlignVariant1Column) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LayoutObjectAlignVariant1ColumnVariant0>
     for LayoutObjectAlignVariant1Column
 {
@@ -45308,11 +42456,6 @@ pub enum LayoutObjectAlignVariant1ColumnVariant0 {
     Each,
     #[serde(rename = "none")]
     None,
-}
-impl ::std::convert::From<&Self> for LayoutObjectAlignVariant1ColumnVariant0 {
-    fn from(value: &LayoutObjectAlignVariant1ColumnVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LayoutObjectAlignVariant1ColumnVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -45383,11 +42526,6 @@ pub enum LayoutObjectAlignVariant1Row {
     Variant0(LayoutObjectAlignVariant1RowVariant0),
     Variant1(SignalRef),
 }
-impl ::std::convert::From<&Self> for LayoutObjectAlignVariant1Row {
-    fn from(value: &LayoutObjectAlignVariant1Row) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LayoutObjectAlignVariant1RowVariant0> for LayoutObjectAlignVariant1Row {
     fn from(value: LayoutObjectAlignVariant1RowVariant0) -> Self {
         Self::Variant0(value)
@@ -45431,11 +42569,6 @@ pub enum LayoutObjectAlignVariant1RowVariant0 {
     Each,
     #[serde(rename = "none")]
     None,
-}
-impl ::std::convert::From<&Self> for LayoutObjectAlignVariant1RowVariant0 {
-    fn from(value: &LayoutObjectAlignVariant1RowVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LayoutObjectAlignVariant1RowVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -45505,11 +42638,6 @@ pub enum LayoutObjectBounds {
     Variant0(LayoutObjectBoundsVariant0),
     Variant1(SignalRef),
 }
-impl ::std::convert::From<&Self> for LayoutObjectBounds {
-    fn from(value: &LayoutObjectBounds) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LayoutObjectBoundsVariant0> for LayoutObjectBounds {
     fn from(value: LayoutObjectBoundsVariant0) -> Self {
         Self::Variant0(value)
@@ -45550,11 +42678,6 @@ pub enum LayoutObjectBoundsVariant0 {
     Full,
     #[serde(rename = "flush")]
     Flush,
-}
-impl ::std::convert::From<&Self> for LayoutObjectBoundsVariant0 {
-    fn from(value: &LayoutObjectBoundsVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LayoutObjectBoundsVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -45637,11 +42760,6 @@ pub enum LayoutObjectCenter {
         row: ::std::option::Option<BooleanOrSignal>,
     },
 }
-impl ::std::convert::From<&Self> for LayoutObjectCenter {
-    fn from(value: &LayoutObjectCenter) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for LayoutObjectCenter {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -45693,11 +42811,6 @@ pub enum LayoutObjectFooterBand {
         row: ::std::option::Option<NumberOrSignal>,
     },
 }
-impl ::std::convert::From<&Self> for LayoutObjectFooterBand {
-    fn from(value: &LayoutObjectFooterBand) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<NumberOrSignal> for LayoutObjectFooterBand {
     fn from(value: NumberOrSignal) -> Self {
         Self::NumberOrSignal(value)
@@ -45743,11 +42856,6 @@ pub enum LayoutObjectHeaderBand {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         row: ::std::option::Option<NumberOrSignal>,
     },
-}
-impl ::std::convert::From<&Self> for LayoutObjectHeaderBand {
-    fn from(value: &LayoutObjectHeaderBand) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<NumberOrSignal> for LayoutObjectHeaderBand {
     fn from(value: NumberOrSignal) -> Self {
@@ -45839,11 +42947,6 @@ pub enum LayoutObjectOffset {
         row_title: ::std::option::Option<NumberOrSignal>,
     },
 }
-impl ::std::convert::From<&Self> for LayoutObjectOffset {
-    fn from(value: &LayoutObjectOffset) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LayoutObjectOffset {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -45894,11 +42997,6 @@ pub enum LayoutObjectPadding {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         row: ::std::option::Option<NumberOrSignal>,
     },
-}
-impl ::std::convert::From<&Self> for LayoutObjectPadding {
-    fn from(value: &LayoutObjectPadding) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LayoutObjectPadding {
     fn from(value: f64) -> Self {
@@ -45977,11 +43075,6 @@ pub enum LayoutObjectTitleAnchor {
         row: ::std::option::Option<LayoutObjectTitleAnchorVariant1Row>,
     },
 }
-impl ::std::convert::From<&Self> for LayoutObjectTitleAnchor {
-    fn from(value: &LayoutObjectTitleAnchor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LayoutObjectTitleAnchorVariant0> for LayoutObjectTitleAnchor {
     fn from(value: LayoutObjectTitleAnchorVariant0) -> Self {
         Self::Variant0(value)
@@ -46012,11 +43105,6 @@ impl ::std::convert::From<LayoutObjectTitleAnchorVariant0> for LayoutObjectTitle
 pub enum LayoutObjectTitleAnchorVariant0 {
     Variant0(LayoutObjectTitleAnchorVariant0Variant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for LayoutObjectTitleAnchorVariant0 {
-    fn from(value: &LayoutObjectTitleAnchorVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LayoutObjectTitleAnchorVariant0Variant0>
     for LayoutObjectTitleAnchorVariant0
@@ -46060,11 +43148,6 @@ pub enum LayoutObjectTitleAnchorVariant0Variant0 {
     Start,
     #[serde(rename = "end")]
     End,
-}
-impl ::std::convert::From<&Self> for LayoutObjectTitleAnchorVariant0Variant0 {
-    fn from(value: &LayoutObjectTitleAnchorVariant0Variant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LayoutObjectTitleAnchorVariant0Variant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -46132,11 +43215,6 @@ pub enum LayoutObjectTitleAnchorVariant1Column {
     Variant0(LayoutObjectTitleAnchorVariant1ColumnVariant0),
     Variant1(SignalRef),
 }
-impl ::std::convert::From<&Self> for LayoutObjectTitleAnchorVariant1Column {
-    fn from(value: &LayoutObjectTitleAnchorVariant1Column) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LayoutObjectTitleAnchorVariant1ColumnVariant0>
     for LayoutObjectTitleAnchorVariant1Column
 {
@@ -46179,11 +43257,6 @@ pub enum LayoutObjectTitleAnchorVariant1ColumnVariant0 {
     Start,
     #[serde(rename = "end")]
     End,
-}
-impl ::std::convert::From<&Self> for LayoutObjectTitleAnchorVariant1ColumnVariant0 {
-    fn from(value: &LayoutObjectTitleAnchorVariant1ColumnVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LayoutObjectTitleAnchorVariant1ColumnVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -46255,11 +43328,6 @@ pub enum LayoutObjectTitleAnchorVariant1Row {
     Variant0(LayoutObjectTitleAnchorVariant1RowVariant0),
     Variant1(SignalRef),
 }
-impl ::std::convert::From<&Self> for LayoutObjectTitleAnchorVariant1Row {
-    fn from(value: &LayoutObjectTitleAnchorVariant1Row) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LayoutObjectTitleAnchorVariant1RowVariant0>
     for LayoutObjectTitleAnchorVariant1Row
 {
@@ -46302,11 +43370,6 @@ pub enum LayoutObjectTitleAnchorVariant1RowVariant0 {
     Start,
     #[serde(rename = "end")]
     End,
-}
-impl ::std::convert::From<&Self> for LayoutObjectTitleAnchorVariant1RowVariant0 {
-    fn from(value: &LayoutObjectTitleAnchorVariant1RowVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LayoutObjectTitleAnchorVariant1RowVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -46390,11 +43453,6 @@ pub enum LayoutObjectTitleBand {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         row: ::std::option::Option<NumberOrSignal>,
     },
-}
-impl ::std::convert::From<&Self> for LayoutObjectTitleBand {
-    fn from(value: &LayoutObjectTitleBand) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<NumberOrSignal> for LayoutObjectTitleBand {
     fn from(value: NumberOrSignal) -> Self {
@@ -49609,11 +46667,6 @@ pub enum Legend {
         zindex: ::std::option::Option<f64>,
     },
 }
-impl ::std::convert::From<&Self> for Legend {
-    fn from(value: &Legend) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`LegendVariant0CornerRadius`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -49636,11 +46689,6 @@ impl ::std::convert::From<&Self> for Legend {
 pub enum LegendVariant0CornerRadius {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant0CornerRadius {
-    fn from(value: &LegendVariant0CornerRadius) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant0CornerRadius {
     fn from(value: f64) -> Self {
@@ -49682,11 +46730,6 @@ pub enum LegendVariant0Direction {
     Vertical,
     #[serde(rename = "horizontal")]
     Horizontal,
-}
-impl ::std::convert::From<&Self> for LegendVariant0Direction {
-    fn from(value: &LegendVariant0Direction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant0Direction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -49775,11 +46818,6 @@ pub struct LegendVariant0Encode {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
 }
-impl ::std::convert::From<&LegendVariant0Encode> for LegendVariant0Encode {
-    fn from(value: &LegendVariant0Encode) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for LegendVariant0Encode {
     fn default() -> Self {
         Self {
@@ -49818,11 +46856,6 @@ pub enum LegendVariant0FillColor {
     Null,
     String(::std::string::String),
     ColorValue(ColorValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant0FillColor {
-    fn from(value: &LegendVariant0FillColor) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ColorValue> for LegendVariant0FillColor {
     fn from(value: ColorValue) -> Self {
@@ -49910,11 +46943,6 @@ pub enum LegendVariant0Format {
     },
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for LegendVariant0Format {
-    fn from(value: &LegendVariant0Format) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for LegendVariant0Format {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -49946,11 +46974,6 @@ impl ::std::convert::From<SignalRef> for LegendVariant0Format {
 pub enum LegendVariant0FormatType {
     Variant0(LegendVariant0FormatTypeVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for LegendVariant0FormatType {
-    fn from(value: &LegendVariant0FormatType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant0FormatTypeVariant0> for LegendVariant0FormatType {
     fn from(value: LegendVariant0FormatTypeVariant0) -> Self {
@@ -49995,11 +47018,6 @@ pub enum LegendVariant0FormatTypeVariant0 {
     Time,
     #[serde(rename = "utc")]
     Utc,
-}
-impl ::std::convert::From<&Self> for LegendVariant0FormatTypeVariant0 {
-    fn from(value: &LegendVariant0FormatTypeVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant0FormatTypeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -50066,11 +47084,6 @@ pub enum LegendVariant0GradientOpacity {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant0GradientOpacity {
-    fn from(value: &LegendVariant0GradientOpacity) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant0GradientOpacity {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -50108,11 +47121,6 @@ pub enum LegendVariant0GradientStrokeColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant0GradientStrokeColor {
-    fn from(value: &LegendVariant0GradientStrokeColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant0GradientStrokeColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -50140,11 +47148,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant0GradientStrokeColor {
 pub enum LegendVariant0GradientStrokeWidth {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant0GradientStrokeWidth {
-    fn from(value: &LegendVariant0GradientStrokeWidth) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant0GradientStrokeWidth {
     fn from(value: f64) -> Self {
@@ -50182,11 +47185,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant0GradientStrokeWidth {
 pub enum LegendVariant0GridAlign {
     Variant0(LegendVariant0GridAlignVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for LegendVariant0GridAlign {
-    fn from(value: &LegendVariant0GridAlign) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant0GridAlignVariant0> for LegendVariant0GridAlign {
     fn from(value: LegendVariant0GridAlignVariant0) -> Self {
@@ -50231,11 +47229,6 @@ pub enum LegendVariant0GridAlignVariant0 {
     Each,
     #[serde(rename = "none")]
     None,
-}
-impl ::std::convert::From<&Self> for LegendVariant0GridAlignVariant0 {
-    fn from(value: &LegendVariant0GridAlignVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant0GridAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -50306,11 +47299,6 @@ pub enum LegendVariant0LabelAlign {
     Variant0(LegendVariant0LabelAlignVariant0),
     Variant1(AlignValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant0LabelAlign {
-    fn from(value: &LegendVariant0LabelAlign) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LegendVariant0LabelAlignVariant0> for LegendVariant0LabelAlign {
     fn from(value: LegendVariant0LabelAlignVariant0) -> Self {
         Self::Variant0(value)
@@ -50354,11 +47342,6 @@ pub enum LegendVariant0LabelAlignVariant0 {
     Right,
     #[serde(rename = "center")]
     Center,
-}
-impl ::std::convert::From<&Self> for LegendVariant0LabelAlignVariant0 {
-    fn from(value: &LegendVariant0LabelAlignVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant0LabelAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -50432,11 +47415,6 @@ pub enum LegendVariant0LabelBaseline {
     Variant0(LegendVariant0LabelBaselineVariant0),
     Variant1(BaselineValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant0LabelBaseline {
-    fn from(value: &LegendVariant0LabelBaseline) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LegendVariant0LabelBaselineVariant0> for LegendVariant0LabelBaseline {
     fn from(value: LegendVariant0LabelBaselineVariant0) -> Self {
         Self::Variant0(value)
@@ -50489,11 +47467,6 @@ pub enum LegendVariant0LabelBaselineVariant0 {
     LineTop,
     #[serde(rename = "line-bottom")]
     LineBottom,
-}
-impl ::std::convert::From<&Self> for LegendVariant0LabelBaselineVariant0 {
-    fn from(value: &LegendVariant0LabelBaselineVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant0LabelBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -50570,11 +47543,6 @@ pub enum LegendVariant0LabelColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant0LabelColor {
-    fn from(value: &LegendVariant0LabelColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant0LabelColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -50603,11 +47571,6 @@ pub enum LegendVariant0LabelFont {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant0LabelFont {
-    fn from(value: &LegendVariant0LabelFont) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for LegendVariant0LabelFont {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -50635,11 +47598,6 @@ impl ::std::convert::From<StringValue> for LegendVariant0LabelFont {
 pub enum LegendVariant0LabelFontSize {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant0LabelFontSize {
-    fn from(value: &LegendVariant0LabelFontSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant0LabelFontSize {
     fn from(value: f64) -> Self {
@@ -50673,11 +47631,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant0LabelFontSize {
 pub enum LegendVariant0LabelFontStyle {
     Variant0(::std::string::String),
     Variant1(StringValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant0LabelFontStyle {
-    fn from(value: &LegendVariant0LabelFontStyle) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<StringValue> for LegendVariant0LabelFontStyle {
     fn from(value: StringValue) -> Self {
@@ -50731,11 +47684,6 @@ pub enum LegendVariant0LabelFontWeight {
     Variant0(MyEnum),
     Variant1(FontWeightValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant0LabelFontWeight {
-    fn from(value: &LegendVariant0LabelFontWeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<MyEnum> for LegendVariant0LabelFontWeight {
     fn from(value: MyEnum) -> Self {
         Self::Variant0(value)
@@ -50768,11 +47716,6 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant0LabelFontWeight {
 pub enum LegendVariant0LabelLimit {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant0LabelLimit {
-    fn from(value: &LegendVariant0LabelLimit) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant0LabelLimit {
     fn from(value: f64) -> Self {
@@ -50807,11 +47750,6 @@ pub enum LegendVariant0LabelOffset {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant0LabelOffset {
-    fn from(value: &LegendVariant0LabelOffset) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant0LabelOffset {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -50844,11 +47782,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant0LabelOffset {
 pub enum LegendVariant0LabelOpacity {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant0LabelOpacity {
-    fn from(value: &LegendVariant0LabelOpacity) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant0LabelOpacity {
     fn from(value: f64) -> Self {
@@ -50883,11 +47816,6 @@ pub enum LegendVariant0LegendX {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant0LegendX {
-    fn from(value: &LegendVariant0LegendX) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant0LegendX {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -50921,11 +47849,6 @@ pub enum LegendVariant0LegendY {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant0LegendY {
-    fn from(value: &LegendVariant0LegendY) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant0LegendY {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -50958,11 +47881,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant0LegendY {
 pub enum LegendVariant0Offset {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant0Offset {
-    fn from(value: &LegendVariant0Offset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant0Offset {
     fn from(value: f64) -> Self {
@@ -51007,11 +47925,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant0Offset {
 pub enum LegendVariant0Orient {
     Variant0(LegendVariant0OrientVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for LegendVariant0Orient {
-    fn from(value: &LegendVariant0Orient) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant0OrientVariant0> for LegendVariant0Orient {
     fn from(value: LegendVariant0OrientVariant0) -> Self {
@@ -51075,11 +47988,6 @@ pub enum LegendVariant0OrientVariant0 {
     BottomLeft,
     #[serde(rename = "bottom-right")]
     BottomRight,
-}
-impl ::std::convert::From<&Self> for LegendVariant0OrientVariant0 {
-    fn from(value: &LegendVariant0OrientVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant0OrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -51158,11 +48066,6 @@ pub enum LegendVariant0Padding {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant0Padding {
-    fn from(value: &LegendVariant0Padding) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant0Padding {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -51200,11 +48103,6 @@ pub enum LegendVariant0StrokeColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant0StrokeColor {
-    fn from(value: &LegendVariant0StrokeColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant0StrokeColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -51235,11 +48133,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant0StrokeColor {
 pub enum LegendVariant0SymbolDash {
     Variant0(::std::vec::Vec<f64>),
     Variant1(ArrayValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant0SymbolDash {
-    fn from(value: &LegendVariant0SymbolDash) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<f64>> for LegendVariant0SymbolDash {
     fn from(value: ::std::vec::Vec<f64>) -> Self {
@@ -51273,11 +48166,6 @@ impl ::std::convert::From<ArrayValue> for LegendVariant0SymbolDash {
 pub enum LegendVariant0SymbolDashOffset {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant0SymbolDashOffset {
-    fn from(value: &LegendVariant0SymbolDashOffset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant0SymbolDashOffset {
     fn from(value: f64) -> Self {
@@ -51316,11 +48204,6 @@ pub enum LegendVariant0SymbolFillColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant0SymbolFillColor {
-    fn from(value: &LegendVariant0SymbolFillColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant0SymbolFillColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -51348,11 +48231,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant0SymbolFillColor {
 pub enum LegendVariant0SymbolOffset {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant0SymbolOffset {
-    fn from(value: &LegendVariant0SymbolOffset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant0SymbolOffset {
     fn from(value: f64) -> Self {
@@ -51387,11 +48265,6 @@ pub enum LegendVariant0SymbolOpacity {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant0SymbolOpacity {
-    fn from(value: &LegendVariant0SymbolOpacity) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant0SymbolOpacity {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -51424,11 +48297,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant0SymbolOpacity {
 pub enum LegendVariant0SymbolSize {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant0SymbolSize {
-    fn from(value: &LegendVariant0SymbolSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant0SymbolSize {
     fn from(value: f64) -> Self {
@@ -51467,11 +48335,6 @@ pub enum LegendVariant0SymbolStrokeColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant0SymbolStrokeColor {
-    fn from(value: &LegendVariant0SymbolStrokeColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant0SymbolStrokeColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -51499,11 +48362,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant0SymbolStrokeColor {
 pub enum LegendVariant0SymbolStrokeWidth {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant0SymbolStrokeWidth {
-    fn from(value: &LegendVariant0SymbolStrokeWidth) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant0SymbolStrokeWidth {
     fn from(value: f64) -> Self {
@@ -51538,11 +48396,6 @@ pub enum LegendVariant0SymbolType {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant0SymbolType {
-    fn from(value: &LegendVariant0SymbolType) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for LegendVariant0SymbolType {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -51574,11 +48427,6 @@ impl ::std::convert::From<StringValue> for LegendVariant0SymbolType {
 pub enum LegendVariant0TitleAlign {
     Variant0(LegendVariant0TitleAlignVariant0),
     Variant1(AlignValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant0TitleAlign {
-    fn from(value: &LegendVariant0TitleAlign) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant0TitleAlignVariant0> for LegendVariant0TitleAlign {
     fn from(value: LegendVariant0TitleAlignVariant0) -> Self {
@@ -51623,11 +48471,6 @@ pub enum LegendVariant0TitleAlignVariant0 {
     Right,
     #[serde(rename = "center")]
     Center,
-}
-impl ::std::convert::From<&Self> for LegendVariant0TitleAlignVariant0 {
-    fn from(value: &LegendVariant0TitleAlignVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant0TitleAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -51699,11 +48542,6 @@ pub enum LegendVariant0TitleAnchor {
     Variant0(::std::option::Option<LegendVariant0TitleAnchorVariant0>),
     Variant1(AnchorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant0TitleAnchor {
-    fn from(value: &LegendVariant0TitleAnchor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::option::Option<LegendVariant0TitleAnchorVariant0>>
     for LegendVariant0TitleAnchor
 {
@@ -51750,11 +48588,6 @@ pub enum LegendVariant0TitleAnchorVariant0 {
     Middle,
     #[serde(rename = "end")]
     End,
-}
-impl ::std::convert::From<&Self> for LegendVariant0TitleAnchorVariant0 {
-    fn from(value: &LegendVariant0TitleAnchorVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant0TitleAnchorVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -51828,11 +48661,6 @@ pub enum LegendVariant0TitleBaseline {
     Variant0(LegendVariant0TitleBaselineVariant0),
     Variant1(BaselineValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant0TitleBaseline {
-    fn from(value: &LegendVariant0TitleBaseline) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LegendVariant0TitleBaselineVariant0> for LegendVariant0TitleBaseline {
     fn from(value: LegendVariant0TitleBaselineVariant0) -> Self {
         Self::Variant0(value)
@@ -51885,11 +48713,6 @@ pub enum LegendVariant0TitleBaselineVariant0 {
     LineTop,
     #[serde(rename = "line-bottom")]
     LineBottom,
-}
-impl ::std::convert::From<&Self> for LegendVariant0TitleBaselineVariant0 {
-    fn from(value: &LegendVariant0TitleBaselineVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant0TitleBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -51966,11 +48789,6 @@ pub enum LegendVariant0TitleColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant0TitleColor {
-    fn from(value: &LegendVariant0TitleColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant0TitleColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -51999,11 +48817,6 @@ pub enum LegendVariant0TitleFont {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant0TitleFont {
-    fn from(value: &LegendVariant0TitleFont) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for LegendVariant0TitleFont {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -52031,11 +48844,6 @@ impl ::std::convert::From<StringValue> for LegendVariant0TitleFont {
 pub enum LegendVariant0TitleFontSize {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant0TitleFontSize {
-    fn from(value: &LegendVariant0TitleFontSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant0TitleFontSize {
     fn from(value: f64) -> Self {
@@ -52069,11 +48877,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant0TitleFontSize {
 pub enum LegendVariant0TitleFontStyle {
     Variant0(::std::string::String),
     Variant1(StringValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant0TitleFontStyle {
-    fn from(value: &LegendVariant0TitleFontStyle) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<StringValue> for LegendVariant0TitleFontStyle {
     fn from(value: StringValue) -> Self {
@@ -52127,11 +48930,6 @@ pub enum LegendVariant0TitleFontWeight {
     Variant0(MyEnum),
     Variant1(FontWeightValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant0TitleFontWeight {
-    fn from(value: &LegendVariant0TitleFontWeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<MyEnum> for LegendVariant0TitleFontWeight {
     fn from(value: MyEnum) -> Self {
         Self::Variant0(value)
@@ -52164,11 +48962,6 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant0TitleFontWeight {
 pub enum LegendVariant0TitleLimit {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant0TitleLimit {
-    fn from(value: &LegendVariant0TitleLimit) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant0TitleLimit {
     fn from(value: f64) -> Self {
@@ -52203,11 +48996,6 @@ pub enum LegendVariant0TitleLineHeight {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant0TitleLineHeight {
-    fn from(value: &LegendVariant0TitleLineHeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant0TitleLineHeight {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -52240,11 +49028,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant0TitleLineHeight {
 pub enum LegendVariant0TitleOpacity {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant0TitleOpacity {
-    fn from(value: &LegendVariant0TitleOpacity) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant0TitleOpacity {
     fn from(value: f64) -> Self {
@@ -52283,11 +49066,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant0TitleOpacity {
 pub enum LegendVariant0TitleOrient {
     Variant0(LegendVariant0TitleOrientVariant0),
     Variant1(OrientValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant0TitleOrient {
-    fn from(value: &LegendVariant0TitleOrient) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant0TitleOrientVariant0> for LegendVariant0TitleOrient {
     fn from(value: LegendVariant0TitleOrientVariant0) -> Self {
@@ -52335,11 +49113,6 @@ pub enum LegendVariant0TitleOrientVariant0 {
     Top,
     #[serde(rename = "bottom")]
     Bottom,
-}
-impl ::std::convert::From<&Self> for LegendVariant0TitleOrientVariant0 {
-    fn from(value: &LegendVariant0TitleOrientVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant0TitleOrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -52408,11 +49181,6 @@ pub enum LegendVariant0TitlePadding {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant0TitlePadding {
-    fn from(value: &LegendVariant0TitlePadding) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant0TitlePadding {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -52453,11 +49221,6 @@ pub enum LegendVariant0Type {
     Gradient,
     #[serde(rename = "symbol")]
     Symbol,
-}
-impl ::std::convert::From<&Self> for LegendVariant0Type {
-    fn from(value: &LegendVariant0Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant0Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -52522,11 +49285,6 @@ pub enum LegendVariant1CornerRadius {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant1CornerRadius {
-    fn from(value: &LegendVariant1CornerRadius) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant1CornerRadius {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -52567,11 +49325,6 @@ pub enum LegendVariant1Direction {
     Vertical,
     #[serde(rename = "horizontal")]
     Horizontal,
-}
-impl ::std::convert::From<&Self> for LegendVariant1Direction {
-    fn from(value: &LegendVariant1Direction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant1Direction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -52660,11 +49413,6 @@ pub struct LegendVariant1Encode {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
 }
-impl ::std::convert::From<&LegendVariant1Encode> for LegendVariant1Encode {
-    fn from(value: &LegendVariant1Encode) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for LegendVariant1Encode {
     fn default() -> Self {
         Self {
@@ -52703,11 +49451,6 @@ pub enum LegendVariant1FillColor {
     Null,
     String(::std::string::String),
     ColorValue(ColorValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant1FillColor {
-    fn from(value: &LegendVariant1FillColor) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ColorValue> for LegendVariant1FillColor {
     fn from(value: ColorValue) -> Self {
@@ -52795,11 +49538,6 @@ pub enum LegendVariant1Format {
     },
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for LegendVariant1Format {
-    fn from(value: &LegendVariant1Format) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for LegendVariant1Format {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -52831,11 +49569,6 @@ impl ::std::convert::From<SignalRef> for LegendVariant1Format {
 pub enum LegendVariant1FormatType {
     Variant0(LegendVariant1FormatTypeVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for LegendVariant1FormatType {
-    fn from(value: &LegendVariant1FormatType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant1FormatTypeVariant0> for LegendVariant1FormatType {
     fn from(value: LegendVariant1FormatTypeVariant0) -> Self {
@@ -52880,11 +49613,6 @@ pub enum LegendVariant1FormatTypeVariant0 {
     Time,
     #[serde(rename = "utc")]
     Utc,
-}
-impl ::std::convert::From<&Self> for LegendVariant1FormatTypeVariant0 {
-    fn from(value: &LegendVariant1FormatTypeVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant1FormatTypeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -52951,11 +49679,6 @@ pub enum LegendVariant1GradientOpacity {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant1GradientOpacity {
-    fn from(value: &LegendVariant1GradientOpacity) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant1GradientOpacity {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -52993,11 +49716,6 @@ pub enum LegendVariant1GradientStrokeColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant1GradientStrokeColor {
-    fn from(value: &LegendVariant1GradientStrokeColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant1GradientStrokeColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -53025,11 +49743,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant1GradientStrokeColor {
 pub enum LegendVariant1GradientStrokeWidth {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant1GradientStrokeWidth {
-    fn from(value: &LegendVariant1GradientStrokeWidth) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant1GradientStrokeWidth {
     fn from(value: f64) -> Self {
@@ -53067,11 +49780,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant1GradientStrokeWidth {
 pub enum LegendVariant1GridAlign {
     Variant0(LegendVariant1GridAlignVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for LegendVariant1GridAlign {
-    fn from(value: &LegendVariant1GridAlign) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant1GridAlignVariant0> for LegendVariant1GridAlign {
     fn from(value: LegendVariant1GridAlignVariant0) -> Self {
@@ -53116,11 +49824,6 @@ pub enum LegendVariant1GridAlignVariant0 {
     Each,
     #[serde(rename = "none")]
     None,
-}
-impl ::std::convert::From<&Self> for LegendVariant1GridAlignVariant0 {
-    fn from(value: &LegendVariant1GridAlignVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant1GridAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -53191,11 +49894,6 @@ pub enum LegendVariant1LabelAlign {
     Variant0(LegendVariant1LabelAlignVariant0),
     Variant1(AlignValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant1LabelAlign {
-    fn from(value: &LegendVariant1LabelAlign) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LegendVariant1LabelAlignVariant0> for LegendVariant1LabelAlign {
     fn from(value: LegendVariant1LabelAlignVariant0) -> Self {
         Self::Variant0(value)
@@ -53239,11 +49937,6 @@ pub enum LegendVariant1LabelAlignVariant0 {
     Right,
     #[serde(rename = "center")]
     Center,
-}
-impl ::std::convert::From<&Self> for LegendVariant1LabelAlignVariant0 {
-    fn from(value: &LegendVariant1LabelAlignVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant1LabelAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -53317,11 +50010,6 @@ pub enum LegendVariant1LabelBaseline {
     Variant0(LegendVariant1LabelBaselineVariant0),
     Variant1(BaselineValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant1LabelBaseline {
-    fn from(value: &LegendVariant1LabelBaseline) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LegendVariant1LabelBaselineVariant0> for LegendVariant1LabelBaseline {
     fn from(value: LegendVariant1LabelBaselineVariant0) -> Self {
         Self::Variant0(value)
@@ -53374,11 +50062,6 @@ pub enum LegendVariant1LabelBaselineVariant0 {
     LineTop,
     #[serde(rename = "line-bottom")]
     LineBottom,
-}
-impl ::std::convert::From<&Self> for LegendVariant1LabelBaselineVariant0 {
-    fn from(value: &LegendVariant1LabelBaselineVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant1LabelBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -53455,11 +50138,6 @@ pub enum LegendVariant1LabelColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant1LabelColor {
-    fn from(value: &LegendVariant1LabelColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant1LabelColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -53488,11 +50166,6 @@ pub enum LegendVariant1LabelFont {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant1LabelFont {
-    fn from(value: &LegendVariant1LabelFont) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for LegendVariant1LabelFont {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -53520,11 +50193,6 @@ impl ::std::convert::From<StringValue> for LegendVariant1LabelFont {
 pub enum LegendVariant1LabelFontSize {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant1LabelFontSize {
-    fn from(value: &LegendVariant1LabelFontSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant1LabelFontSize {
     fn from(value: f64) -> Self {
@@ -53558,11 +50226,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant1LabelFontSize {
 pub enum LegendVariant1LabelFontStyle {
     Variant0(::std::string::String),
     Variant1(StringValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant1LabelFontStyle {
-    fn from(value: &LegendVariant1LabelFontStyle) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<StringValue> for LegendVariant1LabelFontStyle {
     fn from(value: StringValue) -> Self {
@@ -53616,11 +50279,6 @@ pub enum LegendVariant1LabelFontWeight {
     Variant0(MyEnum),
     Variant1(FontWeightValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant1LabelFontWeight {
-    fn from(value: &LegendVariant1LabelFontWeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<MyEnum> for LegendVariant1LabelFontWeight {
     fn from(value: MyEnum) -> Self {
         Self::Variant0(value)
@@ -53653,11 +50311,6 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant1LabelFontWeight {
 pub enum LegendVariant1LabelLimit {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant1LabelLimit {
-    fn from(value: &LegendVariant1LabelLimit) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant1LabelLimit {
     fn from(value: f64) -> Self {
@@ -53692,11 +50345,6 @@ pub enum LegendVariant1LabelOffset {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant1LabelOffset {
-    fn from(value: &LegendVariant1LabelOffset) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant1LabelOffset {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -53729,11 +50377,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant1LabelOffset {
 pub enum LegendVariant1LabelOpacity {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant1LabelOpacity {
-    fn from(value: &LegendVariant1LabelOpacity) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant1LabelOpacity {
     fn from(value: f64) -> Self {
@@ -53768,11 +50411,6 @@ pub enum LegendVariant1LegendX {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant1LegendX {
-    fn from(value: &LegendVariant1LegendX) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant1LegendX {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -53806,11 +50444,6 @@ pub enum LegendVariant1LegendY {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant1LegendY {
-    fn from(value: &LegendVariant1LegendY) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant1LegendY {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -53843,11 +50476,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant1LegendY {
 pub enum LegendVariant1Offset {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant1Offset {
-    fn from(value: &LegendVariant1Offset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant1Offset {
     fn from(value: f64) -> Self {
@@ -53892,11 +50520,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant1Offset {
 pub enum LegendVariant1Orient {
     Variant0(LegendVariant1OrientVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for LegendVariant1Orient {
-    fn from(value: &LegendVariant1Orient) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant1OrientVariant0> for LegendVariant1Orient {
     fn from(value: LegendVariant1OrientVariant0) -> Self {
@@ -53960,11 +50583,6 @@ pub enum LegendVariant1OrientVariant0 {
     BottomLeft,
     #[serde(rename = "bottom-right")]
     BottomRight,
-}
-impl ::std::convert::From<&Self> for LegendVariant1OrientVariant0 {
-    fn from(value: &LegendVariant1OrientVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant1OrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -54043,11 +50661,6 @@ pub enum LegendVariant1Padding {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant1Padding {
-    fn from(value: &LegendVariant1Padding) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant1Padding {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -54085,11 +50698,6 @@ pub enum LegendVariant1StrokeColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant1StrokeColor {
-    fn from(value: &LegendVariant1StrokeColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant1StrokeColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -54120,11 +50728,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant1StrokeColor {
 pub enum LegendVariant1SymbolDash {
     Variant0(::std::vec::Vec<f64>),
     Variant1(ArrayValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant1SymbolDash {
-    fn from(value: &LegendVariant1SymbolDash) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<f64>> for LegendVariant1SymbolDash {
     fn from(value: ::std::vec::Vec<f64>) -> Self {
@@ -54158,11 +50761,6 @@ impl ::std::convert::From<ArrayValue> for LegendVariant1SymbolDash {
 pub enum LegendVariant1SymbolDashOffset {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant1SymbolDashOffset {
-    fn from(value: &LegendVariant1SymbolDashOffset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant1SymbolDashOffset {
     fn from(value: f64) -> Self {
@@ -54201,11 +50799,6 @@ pub enum LegendVariant1SymbolFillColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant1SymbolFillColor {
-    fn from(value: &LegendVariant1SymbolFillColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant1SymbolFillColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -54233,11 +50826,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant1SymbolFillColor {
 pub enum LegendVariant1SymbolOffset {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant1SymbolOffset {
-    fn from(value: &LegendVariant1SymbolOffset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant1SymbolOffset {
     fn from(value: f64) -> Self {
@@ -54272,11 +50860,6 @@ pub enum LegendVariant1SymbolOpacity {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant1SymbolOpacity {
-    fn from(value: &LegendVariant1SymbolOpacity) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant1SymbolOpacity {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -54309,11 +50892,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant1SymbolOpacity {
 pub enum LegendVariant1SymbolSize {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant1SymbolSize {
-    fn from(value: &LegendVariant1SymbolSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant1SymbolSize {
     fn from(value: f64) -> Self {
@@ -54352,11 +50930,6 @@ pub enum LegendVariant1SymbolStrokeColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant1SymbolStrokeColor {
-    fn from(value: &LegendVariant1SymbolStrokeColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant1SymbolStrokeColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -54384,11 +50957,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant1SymbolStrokeColor {
 pub enum LegendVariant1SymbolStrokeWidth {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant1SymbolStrokeWidth {
-    fn from(value: &LegendVariant1SymbolStrokeWidth) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant1SymbolStrokeWidth {
     fn from(value: f64) -> Self {
@@ -54423,11 +50991,6 @@ pub enum LegendVariant1SymbolType {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant1SymbolType {
-    fn from(value: &LegendVariant1SymbolType) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for LegendVariant1SymbolType {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -54459,11 +51022,6 @@ impl ::std::convert::From<StringValue> for LegendVariant1SymbolType {
 pub enum LegendVariant1TitleAlign {
     Variant0(LegendVariant1TitleAlignVariant0),
     Variant1(AlignValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant1TitleAlign {
-    fn from(value: &LegendVariant1TitleAlign) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant1TitleAlignVariant0> for LegendVariant1TitleAlign {
     fn from(value: LegendVariant1TitleAlignVariant0) -> Self {
@@ -54508,11 +51066,6 @@ pub enum LegendVariant1TitleAlignVariant0 {
     Right,
     #[serde(rename = "center")]
     Center,
-}
-impl ::std::convert::From<&Self> for LegendVariant1TitleAlignVariant0 {
-    fn from(value: &LegendVariant1TitleAlignVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant1TitleAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -54584,11 +51137,6 @@ pub enum LegendVariant1TitleAnchor {
     Variant0(::std::option::Option<LegendVariant1TitleAnchorVariant0>),
     Variant1(AnchorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant1TitleAnchor {
-    fn from(value: &LegendVariant1TitleAnchor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::option::Option<LegendVariant1TitleAnchorVariant0>>
     for LegendVariant1TitleAnchor
 {
@@ -54635,11 +51183,6 @@ pub enum LegendVariant1TitleAnchorVariant0 {
     Middle,
     #[serde(rename = "end")]
     End,
-}
-impl ::std::convert::From<&Self> for LegendVariant1TitleAnchorVariant0 {
-    fn from(value: &LegendVariant1TitleAnchorVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant1TitleAnchorVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -54713,11 +51256,6 @@ pub enum LegendVariant1TitleBaseline {
     Variant0(LegendVariant1TitleBaselineVariant0),
     Variant1(BaselineValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant1TitleBaseline {
-    fn from(value: &LegendVariant1TitleBaseline) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LegendVariant1TitleBaselineVariant0> for LegendVariant1TitleBaseline {
     fn from(value: LegendVariant1TitleBaselineVariant0) -> Self {
         Self::Variant0(value)
@@ -54770,11 +51308,6 @@ pub enum LegendVariant1TitleBaselineVariant0 {
     LineTop,
     #[serde(rename = "line-bottom")]
     LineBottom,
-}
-impl ::std::convert::From<&Self> for LegendVariant1TitleBaselineVariant0 {
-    fn from(value: &LegendVariant1TitleBaselineVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant1TitleBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -54851,11 +51384,6 @@ pub enum LegendVariant1TitleColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant1TitleColor {
-    fn from(value: &LegendVariant1TitleColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant1TitleColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -54884,11 +51412,6 @@ pub enum LegendVariant1TitleFont {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant1TitleFont {
-    fn from(value: &LegendVariant1TitleFont) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for LegendVariant1TitleFont {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -54916,11 +51439,6 @@ impl ::std::convert::From<StringValue> for LegendVariant1TitleFont {
 pub enum LegendVariant1TitleFontSize {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant1TitleFontSize {
-    fn from(value: &LegendVariant1TitleFontSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant1TitleFontSize {
     fn from(value: f64) -> Self {
@@ -54954,11 +51472,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant1TitleFontSize {
 pub enum LegendVariant1TitleFontStyle {
     Variant0(::std::string::String),
     Variant1(StringValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant1TitleFontStyle {
-    fn from(value: &LegendVariant1TitleFontStyle) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<StringValue> for LegendVariant1TitleFontStyle {
     fn from(value: StringValue) -> Self {
@@ -55012,11 +51525,6 @@ pub enum LegendVariant1TitleFontWeight {
     Variant0(MyEnum),
     Variant1(FontWeightValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant1TitleFontWeight {
-    fn from(value: &LegendVariant1TitleFontWeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<MyEnum> for LegendVariant1TitleFontWeight {
     fn from(value: MyEnum) -> Self {
         Self::Variant0(value)
@@ -55049,11 +51557,6 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant1TitleFontWeight {
 pub enum LegendVariant1TitleLimit {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant1TitleLimit {
-    fn from(value: &LegendVariant1TitleLimit) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant1TitleLimit {
     fn from(value: f64) -> Self {
@@ -55088,11 +51591,6 @@ pub enum LegendVariant1TitleLineHeight {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant1TitleLineHeight {
-    fn from(value: &LegendVariant1TitleLineHeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant1TitleLineHeight {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -55125,11 +51623,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant1TitleLineHeight {
 pub enum LegendVariant1TitleOpacity {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant1TitleOpacity {
-    fn from(value: &LegendVariant1TitleOpacity) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant1TitleOpacity {
     fn from(value: f64) -> Self {
@@ -55168,11 +51661,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant1TitleOpacity {
 pub enum LegendVariant1TitleOrient {
     Variant0(LegendVariant1TitleOrientVariant0),
     Variant1(OrientValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant1TitleOrient {
-    fn from(value: &LegendVariant1TitleOrient) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant1TitleOrientVariant0> for LegendVariant1TitleOrient {
     fn from(value: LegendVariant1TitleOrientVariant0) -> Self {
@@ -55220,11 +51708,6 @@ pub enum LegendVariant1TitleOrientVariant0 {
     Top,
     #[serde(rename = "bottom")]
     Bottom,
-}
-impl ::std::convert::From<&Self> for LegendVariant1TitleOrientVariant0 {
-    fn from(value: &LegendVariant1TitleOrientVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant1TitleOrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -55293,11 +51776,6 @@ pub enum LegendVariant1TitlePadding {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant1TitlePadding {
-    fn from(value: &LegendVariant1TitlePadding) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant1TitlePadding {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -55338,11 +51816,6 @@ pub enum LegendVariant1Type {
     Gradient,
     #[serde(rename = "symbol")]
     Symbol,
-}
-impl ::std::convert::From<&Self> for LegendVariant1Type {
-    fn from(value: &LegendVariant1Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant1Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -55407,11 +51880,6 @@ pub enum LegendVariant2CornerRadius {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant2CornerRadius {
-    fn from(value: &LegendVariant2CornerRadius) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant2CornerRadius {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -55452,11 +51920,6 @@ pub enum LegendVariant2Direction {
     Vertical,
     #[serde(rename = "horizontal")]
     Horizontal,
-}
-impl ::std::convert::From<&Self> for LegendVariant2Direction {
-    fn from(value: &LegendVariant2Direction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant2Direction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -55545,11 +52008,6 @@ pub struct LegendVariant2Encode {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
 }
-impl ::std::convert::From<&LegendVariant2Encode> for LegendVariant2Encode {
-    fn from(value: &LegendVariant2Encode) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for LegendVariant2Encode {
     fn default() -> Self {
         Self {
@@ -55588,11 +52046,6 @@ pub enum LegendVariant2FillColor {
     Null,
     String(::std::string::String),
     ColorValue(ColorValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant2FillColor {
-    fn from(value: &LegendVariant2FillColor) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ColorValue> for LegendVariant2FillColor {
     fn from(value: ColorValue) -> Self {
@@ -55680,11 +52133,6 @@ pub enum LegendVariant2Format {
     },
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for LegendVariant2Format {
-    fn from(value: &LegendVariant2Format) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for LegendVariant2Format {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -55716,11 +52164,6 @@ impl ::std::convert::From<SignalRef> for LegendVariant2Format {
 pub enum LegendVariant2FormatType {
     Variant0(LegendVariant2FormatTypeVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for LegendVariant2FormatType {
-    fn from(value: &LegendVariant2FormatType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant2FormatTypeVariant0> for LegendVariant2FormatType {
     fn from(value: LegendVariant2FormatTypeVariant0) -> Self {
@@ -55765,11 +52208,6 @@ pub enum LegendVariant2FormatTypeVariant0 {
     Time,
     #[serde(rename = "utc")]
     Utc,
-}
-impl ::std::convert::From<&Self> for LegendVariant2FormatTypeVariant0 {
-    fn from(value: &LegendVariant2FormatTypeVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant2FormatTypeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -55836,11 +52274,6 @@ pub enum LegendVariant2GradientOpacity {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant2GradientOpacity {
-    fn from(value: &LegendVariant2GradientOpacity) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant2GradientOpacity {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -55878,11 +52311,6 @@ pub enum LegendVariant2GradientStrokeColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant2GradientStrokeColor {
-    fn from(value: &LegendVariant2GradientStrokeColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant2GradientStrokeColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -55910,11 +52338,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant2GradientStrokeColor {
 pub enum LegendVariant2GradientStrokeWidth {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant2GradientStrokeWidth {
-    fn from(value: &LegendVariant2GradientStrokeWidth) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant2GradientStrokeWidth {
     fn from(value: f64) -> Self {
@@ -55952,11 +52375,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant2GradientStrokeWidth {
 pub enum LegendVariant2GridAlign {
     Variant0(LegendVariant2GridAlignVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for LegendVariant2GridAlign {
-    fn from(value: &LegendVariant2GridAlign) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant2GridAlignVariant0> for LegendVariant2GridAlign {
     fn from(value: LegendVariant2GridAlignVariant0) -> Self {
@@ -56001,11 +52419,6 @@ pub enum LegendVariant2GridAlignVariant0 {
     Each,
     #[serde(rename = "none")]
     None,
-}
-impl ::std::convert::From<&Self> for LegendVariant2GridAlignVariant0 {
-    fn from(value: &LegendVariant2GridAlignVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant2GridAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -56076,11 +52489,6 @@ pub enum LegendVariant2LabelAlign {
     Variant0(LegendVariant2LabelAlignVariant0),
     Variant1(AlignValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant2LabelAlign {
-    fn from(value: &LegendVariant2LabelAlign) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LegendVariant2LabelAlignVariant0> for LegendVariant2LabelAlign {
     fn from(value: LegendVariant2LabelAlignVariant0) -> Self {
         Self::Variant0(value)
@@ -56124,11 +52532,6 @@ pub enum LegendVariant2LabelAlignVariant0 {
     Right,
     #[serde(rename = "center")]
     Center,
-}
-impl ::std::convert::From<&Self> for LegendVariant2LabelAlignVariant0 {
-    fn from(value: &LegendVariant2LabelAlignVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant2LabelAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -56202,11 +52605,6 @@ pub enum LegendVariant2LabelBaseline {
     Variant0(LegendVariant2LabelBaselineVariant0),
     Variant1(BaselineValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant2LabelBaseline {
-    fn from(value: &LegendVariant2LabelBaseline) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LegendVariant2LabelBaselineVariant0> for LegendVariant2LabelBaseline {
     fn from(value: LegendVariant2LabelBaselineVariant0) -> Self {
         Self::Variant0(value)
@@ -56259,11 +52657,6 @@ pub enum LegendVariant2LabelBaselineVariant0 {
     LineTop,
     #[serde(rename = "line-bottom")]
     LineBottom,
-}
-impl ::std::convert::From<&Self> for LegendVariant2LabelBaselineVariant0 {
-    fn from(value: &LegendVariant2LabelBaselineVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant2LabelBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -56340,11 +52733,6 @@ pub enum LegendVariant2LabelColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant2LabelColor {
-    fn from(value: &LegendVariant2LabelColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant2LabelColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -56373,11 +52761,6 @@ pub enum LegendVariant2LabelFont {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant2LabelFont {
-    fn from(value: &LegendVariant2LabelFont) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for LegendVariant2LabelFont {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -56405,11 +52788,6 @@ impl ::std::convert::From<StringValue> for LegendVariant2LabelFont {
 pub enum LegendVariant2LabelFontSize {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant2LabelFontSize {
-    fn from(value: &LegendVariant2LabelFontSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant2LabelFontSize {
     fn from(value: f64) -> Self {
@@ -56443,11 +52821,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant2LabelFontSize {
 pub enum LegendVariant2LabelFontStyle {
     Variant0(::std::string::String),
     Variant1(StringValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant2LabelFontStyle {
-    fn from(value: &LegendVariant2LabelFontStyle) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<StringValue> for LegendVariant2LabelFontStyle {
     fn from(value: StringValue) -> Self {
@@ -56501,11 +52874,6 @@ pub enum LegendVariant2LabelFontWeight {
     Variant0(MyEnum),
     Variant1(FontWeightValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant2LabelFontWeight {
-    fn from(value: &LegendVariant2LabelFontWeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<MyEnum> for LegendVariant2LabelFontWeight {
     fn from(value: MyEnum) -> Self {
         Self::Variant0(value)
@@ -56538,11 +52906,6 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant2LabelFontWeight {
 pub enum LegendVariant2LabelLimit {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant2LabelLimit {
-    fn from(value: &LegendVariant2LabelLimit) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant2LabelLimit {
     fn from(value: f64) -> Self {
@@ -56577,11 +52940,6 @@ pub enum LegendVariant2LabelOffset {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant2LabelOffset {
-    fn from(value: &LegendVariant2LabelOffset) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant2LabelOffset {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -56614,11 +52972,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant2LabelOffset {
 pub enum LegendVariant2LabelOpacity {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant2LabelOpacity {
-    fn from(value: &LegendVariant2LabelOpacity) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant2LabelOpacity {
     fn from(value: f64) -> Self {
@@ -56653,11 +53006,6 @@ pub enum LegendVariant2LegendX {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant2LegendX {
-    fn from(value: &LegendVariant2LegendX) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant2LegendX {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -56691,11 +53039,6 @@ pub enum LegendVariant2LegendY {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant2LegendY {
-    fn from(value: &LegendVariant2LegendY) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant2LegendY {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -56728,11 +53071,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant2LegendY {
 pub enum LegendVariant2Offset {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant2Offset {
-    fn from(value: &LegendVariant2Offset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant2Offset {
     fn from(value: f64) -> Self {
@@ -56777,11 +53115,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant2Offset {
 pub enum LegendVariant2Orient {
     Variant0(LegendVariant2OrientVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for LegendVariant2Orient {
-    fn from(value: &LegendVariant2Orient) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant2OrientVariant0> for LegendVariant2Orient {
     fn from(value: LegendVariant2OrientVariant0) -> Self {
@@ -56845,11 +53178,6 @@ pub enum LegendVariant2OrientVariant0 {
     BottomLeft,
     #[serde(rename = "bottom-right")]
     BottomRight,
-}
-impl ::std::convert::From<&Self> for LegendVariant2OrientVariant0 {
-    fn from(value: &LegendVariant2OrientVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant2OrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -56928,11 +53256,6 @@ pub enum LegendVariant2Padding {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant2Padding {
-    fn from(value: &LegendVariant2Padding) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant2Padding {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -56970,11 +53293,6 @@ pub enum LegendVariant2StrokeColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant2StrokeColor {
-    fn from(value: &LegendVariant2StrokeColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant2StrokeColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -57005,11 +53323,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant2StrokeColor {
 pub enum LegendVariant2SymbolDash {
     Variant0(::std::vec::Vec<f64>),
     Variant1(ArrayValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant2SymbolDash {
-    fn from(value: &LegendVariant2SymbolDash) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<f64>> for LegendVariant2SymbolDash {
     fn from(value: ::std::vec::Vec<f64>) -> Self {
@@ -57043,11 +53356,6 @@ impl ::std::convert::From<ArrayValue> for LegendVariant2SymbolDash {
 pub enum LegendVariant2SymbolDashOffset {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant2SymbolDashOffset {
-    fn from(value: &LegendVariant2SymbolDashOffset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant2SymbolDashOffset {
     fn from(value: f64) -> Self {
@@ -57086,11 +53394,6 @@ pub enum LegendVariant2SymbolFillColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant2SymbolFillColor {
-    fn from(value: &LegendVariant2SymbolFillColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant2SymbolFillColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -57118,11 +53421,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant2SymbolFillColor {
 pub enum LegendVariant2SymbolOffset {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant2SymbolOffset {
-    fn from(value: &LegendVariant2SymbolOffset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant2SymbolOffset {
     fn from(value: f64) -> Self {
@@ -57157,11 +53455,6 @@ pub enum LegendVariant2SymbolOpacity {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant2SymbolOpacity {
-    fn from(value: &LegendVariant2SymbolOpacity) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant2SymbolOpacity {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -57194,11 +53487,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant2SymbolOpacity {
 pub enum LegendVariant2SymbolSize {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant2SymbolSize {
-    fn from(value: &LegendVariant2SymbolSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant2SymbolSize {
     fn from(value: f64) -> Self {
@@ -57237,11 +53525,6 @@ pub enum LegendVariant2SymbolStrokeColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant2SymbolStrokeColor {
-    fn from(value: &LegendVariant2SymbolStrokeColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant2SymbolStrokeColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -57269,11 +53552,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant2SymbolStrokeColor {
 pub enum LegendVariant2SymbolStrokeWidth {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant2SymbolStrokeWidth {
-    fn from(value: &LegendVariant2SymbolStrokeWidth) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant2SymbolStrokeWidth {
     fn from(value: f64) -> Self {
@@ -57308,11 +53586,6 @@ pub enum LegendVariant2SymbolType {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant2SymbolType {
-    fn from(value: &LegendVariant2SymbolType) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for LegendVariant2SymbolType {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -57344,11 +53617,6 @@ impl ::std::convert::From<StringValue> for LegendVariant2SymbolType {
 pub enum LegendVariant2TitleAlign {
     Variant0(LegendVariant2TitleAlignVariant0),
     Variant1(AlignValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant2TitleAlign {
-    fn from(value: &LegendVariant2TitleAlign) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant2TitleAlignVariant0> for LegendVariant2TitleAlign {
     fn from(value: LegendVariant2TitleAlignVariant0) -> Self {
@@ -57393,11 +53661,6 @@ pub enum LegendVariant2TitleAlignVariant0 {
     Right,
     #[serde(rename = "center")]
     Center,
-}
-impl ::std::convert::From<&Self> for LegendVariant2TitleAlignVariant0 {
-    fn from(value: &LegendVariant2TitleAlignVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant2TitleAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -57469,11 +53732,6 @@ pub enum LegendVariant2TitleAnchor {
     Variant0(::std::option::Option<LegendVariant2TitleAnchorVariant0>),
     Variant1(AnchorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant2TitleAnchor {
-    fn from(value: &LegendVariant2TitleAnchor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::option::Option<LegendVariant2TitleAnchorVariant0>>
     for LegendVariant2TitleAnchor
 {
@@ -57520,11 +53778,6 @@ pub enum LegendVariant2TitleAnchorVariant0 {
     Middle,
     #[serde(rename = "end")]
     End,
-}
-impl ::std::convert::From<&Self> for LegendVariant2TitleAnchorVariant0 {
-    fn from(value: &LegendVariant2TitleAnchorVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant2TitleAnchorVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -57598,11 +53851,6 @@ pub enum LegendVariant2TitleBaseline {
     Variant0(LegendVariant2TitleBaselineVariant0),
     Variant1(BaselineValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant2TitleBaseline {
-    fn from(value: &LegendVariant2TitleBaseline) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LegendVariant2TitleBaselineVariant0> for LegendVariant2TitleBaseline {
     fn from(value: LegendVariant2TitleBaselineVariant0) -> Self {
         Self::Variant0(value)
@@ -57655,11 +53903,6 @@ pub enum LegendVariant2TitleBaselineVariant0 {
     LineTop,
     #[serde(rename = "line-bottom")]
     LineBottom,
-}
-impl ::std::convert::From<&Self> for LegendVariant2TitleBaselineVariant0 {
-    fn from(value: &LegendVariant2TitleBaselineVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant2TitleBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -57736,11 +53979,6 @@ pub enum LegendVariant2TitleColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant2TitleColor {
-    fn from(value: &LegendVariant2TitleColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant2TitleColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -57769,11 +54007,6 @@ pub enum LegendVariant2TitleFont {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant2TitleFont {
-    fn from(value: &LegendVariant2TitleFont) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for LegendVariant2TitleFont {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -57801,11 +54034,6 @@ impl ::std::convert::From<StringValue> for LegendVariant2TitleFont {
 pub enum LegendVariant2TitleFontSize {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant2TitleFontSize {
-    fn from(value: &LegendVariant2TitleFontSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant2TitleFontSize {
     fn from(value: f64) -> Self {
@@ -57839,11 +54067,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant2TitleFontSize {
 pub enum LegendVariant2TitleFontStyle {
     Variant0(::std::string::String),
     Variant1(StringValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant2TitleFontStyle {
-    fn from(value: &LegendVariant2TitleFontStyle) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<StringValue> for LegendVariant2TitleFontStyle {
     fn from(value: StringValue) -> Self {
@@ -57897,11 +54120,6 @@ pub enum LegendVariant2TitleFontWeight {
     Variant0(MyEnum),
     Variant1(FontWeightValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant2TitleFontWeight {
-    fn from(value: &LegendVariant2TitleFontWeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<MyEnum> for LegendVariant2TitleFontWeight {
     fn from(value: MyEnum) -> Self {
         Self::Variant0(value)
@@ -57934,11 +54152,6 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant2TitleFontWeight {
 pub enum LegendVariant2TitleLimit {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant2TitleLimit {
-    fn from(value: &LegendVariant2TitleLimit) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant2TitleLimit {
     fn from(value: f64) -> Self {
@@ -57973,11 +54186,6 @@ pub enum LegendVariant2TitleLineHeight {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant2TitleLineHeight {
-    fn from(value: &LegendVariant2TitleLineHeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant2TitleLineHeight {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -58010,11 +54218,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant2TitleLineHeight {
 pub enum LegendVariant2TitleOpacity {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant2TitleOpacity {
-    fn from(value: &LegendVariant2TitleOpacity) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant2TitleOpacity {
     fn from(value: f64) -> Self {
@@ -58053,11 +54256,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant2TitleOpacity {
 pub enum LegendVariant2TitleOrient {
     Variant0(LegendVariant2TitleOrientVariant0),
     Variant1(OrientValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant2TitleOrient {
-    fn from(value: &LegendVariant2TitleOrient) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant2TitleOrientVariant0> for LegendVariant2TitleOrient {
     fn from(value: LegendVariant2TitleOrientVariant0) -> Self {
@@ -58105,11 +54303,6 @@ pub enum LegendVariant2TitleOrientVariant0 {
     Top,
     #[serde(rename = "bottom")]
     Bottom,
-}
-impl ::std::convert::From<&Self> for LegendVariant2TitleOrientVariant0 {
-    fn from(value: &LegendVariant2TitleOrientVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant2TitleOrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -58178,11 +54371,6 @@ pub enum LegendVariant2TitlePadding {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant2TitlePadding {
-    fn from(value: &LegendVariant2TitlePadding) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant2TitlePadding {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -58223,11 +54411,6 @@ pub enum LegendVariant2Type {
     Gradient,
     #[serde(rename = "symbol")]
     Symbol,
-}
-impl ::std::convert::From<&Self> for LegendVariant2Type {
-    fn from(value: &LegendVariant2Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant2Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -58292,11 +54475,6 @@ pub enum LegendVariant3CornerRadius {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant3CornerRadius {
-    fn from(value: &LegendVariant3CornerRadius) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant3CornerRadius {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -58337,11 +54515,6 @@ pub enum LegendVariant3Direction {
     Vertical,
     #[serde(rename = "horizontal")]
     Horizontal,
-}
-impl ::std::convert::From<&Self> for LegendVariant3Direction {
-    fn from(value: &LegendVariant3Direction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant3Direction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -58430,11 +54603,6 @@ pub struct LegendVariant3Encode {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
 }
-impl ::std::convert::From<&LegendVariant3Encode> for LegendVariant3Encode {
-    fn from(value: &LegendVariant3Encode) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for LegendVariant3Encode {
     fn default() -> Self {
         Self {
@@ -58473,11 +54641,6 @@ pub enum LegendVariant3FillColor {
     Null,
     String(::std::string::String),
     ColorValue(ColorValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant3FillColor {
-    fn from(value: &LegendVariant3FillColor) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ColorValue> for LegendVariant3FillColor {
     fn from(value: ColorValue) -> Self {
@@ -58565,11 +54728,6 @@ pub enum LegendVariant3Format {
     },
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for LegendVariant3Format {
-    fn from(value: &LegendVariant3Format) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for LegendVariant3Format {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -58601,11 +54759,6 @@ impl ::std::convert::From<SignalRef> for LegendVariant3Format {
 pub enum LegendVariant3FormatType {
     Variant0(LegendVariant3FormatTypeVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for LegendVariant3FormatType {
-    fn from(value: &LegendVariant3FormatType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant3FormatTypeVariant0> for LegendVariant3FormatType {
     fn from(value: LegendVariant3FormatTypeVariant0) -> Self {
@@ -58650,11 +54803,6 @@ pub enum LegendVariant3FormatTypeVariant0 {
     Time,
     #[serde(rename = "utc")]
     Utc,
-}
-impl ::std::convert::From<&Self> for LegendVariant3FormatTypeVariant0 {
-    fn from(value: &LegendVariant3FormatTypeVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant3FormatTypeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -58721,11 +54869,6 @@ pub enum LegendVariant3GradientOpacity {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant3GradientOpacity {
-    fn from(value: &LegendVariant3GradientOpacity) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant3GradientOpacity {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -58763,11 +54906,6 @@ pub enum LegendVariant3GradientStrokeColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant3GradientStrokeColor {
-    fn from(value: &LegendVariant3GradientStrokeColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant3GradientStrokeColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -58795,11 +54933,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant3GradientStrokeColor {
 pub enum LegendVariant3GradientStrokeWidth {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant3GradientStrokeWidth {
-    fn from(value: &LegendVariant3GradientStrokeWidth) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant3GradientStrokeWidth {
     fn from(value: f64) -> Self {
@@ -58837,11 +54970,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant3GradientStrokeWidth {
 pub enum LegendVariant3GridAlign {
     Variant0(LegendVariant3GridAlignVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for LegendVariant3GridAlign {
-    fn from(value: &LegendVariant3GridAlign) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant3GridAlignVariant0> for LegendVariant3GridAlign {
     fn from(value: LegendVariant3GridAlignVariant0) -> Self {
@@ -58886,11 +55014,6 @@ pub enum LegendVariant3GridAlignVariant0 {
     Each,
     #[serde(rename = "none")]
     None,
-}
-impl ::std::convert::From<&Self> for LegendVariant3GridAlignVariant0 {
-    fn from(value: &LegendVariant3GridAlignVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant3GridAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -58961,11 +55084,6 @@ pub enum LegendVariant3LabelAlign {
     Variant0(LegendVariant3LabelAlignVariant0),
     Variant1(AlignValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant3LabelAlign {
-    fn from(value: &LegendVariant3LabelAlign) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LegendVariant3LabelAlignVariant0> for LegendVariant3LabelAlign {
     fn from(value: LegendVariant3LabelAlignVariant0) -> Self {
         Self::Variant0(value)
@@ -59009,11 +55127,6 @@ pub enum LegendVariant3LabelAlignVariant0 {
     Right,
     #[serde(rename = "center")]
     Center,
-}
-impl ::std::convert::From<&Self> for LegendVariant3LabelAlignVariant0 {
-    fn from(value: &LegendVariant3LabelAlignVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant3LabelAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -59087,11 +55200,6 @@ pub enum LegendVariant3LabelBaseline {
     Variant0(LegendVariant3LabelBaselineVariant0),
     Variant1(BaselineValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant3LabelBaseline {
-    fn from(value: &LegendVariant3LabelBaseline) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LegendVariant3LabelBaselineVariant0> for LegendVariant3LabelBaseline {
     fn from(value: LegendVariant3LabelBaselineVariant0) -> Self {
         Self::Variant0(value)
@@ -59144,11 +55252,6 @@ pub enum LegendVariant3LabelBaselineVariant0 {
     LineTop,
     #[serde(rename = "line-bottom")]
     LineBottom,
-}
-impl ::std::convert::From<&Self> for LegendVariant3LabelBaselineVariant0 {
-    fn from(value: &LegendVariant3LabelBaselineVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant3LabelBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -59225,11 +55328,6 @@ pub enum LegendVariant3LabelColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant3LabelColor {
-    fn from(value: &LegendVariant3LabelColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant3LabelColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -59258,11 +55356,6 @@ pub enum LegendVariant3LabelFont {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant3LabelFont {
-    fn from(value: &LegendVariant3LabelFont) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for LegendVariant3LabelFont {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -59290,11 +55383,6 @@ impl ::std::convert::From<StringValue> for LegendVariant3LabelFont {
 pub enum LegendVariant3LabelFontSize {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant3LabelFontSize {
-    fn from(value: &LegendVariant3LabelFontSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant3LabelFontSize {
     fn from(value: f64) -> Self {
@@ -59328,11 +55416,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant3LabelFontSize {
 pub enum LegendVariant3LabelFontStyle {
     Variant0(::std::string::String),
     Variant1(StringValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant3LabelFontStyle {
-    fn from(value: &LegendVariant3LabelFontStyle) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<StringValue> for LegendVariant3LabelFontStyle {
     fn from(value: StringValue) -> Self {
@@ -59386,11 +55469,6 @@ pub enum LegendVariant3LabelFontWeight {
     Variant0(MyEnum),
     Variant1(FontWeightValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant3LabelFontWeight {
-    fn from(value: &LegendVariant3LabelFontWeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<MyEnum> for LegendVariant3LabelFontWeight {
     fn from(value: MyEnum) -> Self {
         Self::Variant0(value)
@@ -59423,11 +55501,6 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant3LabelFontWeight {
 pub enum LegendVariant3LabelLimit {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant3LabelLimit {
-    fn from(value: &LegendVariant3LabelLimit) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant3LabelLimit {
     fn from(value: f64) -> Self {
@@ -59462,11 +55535,6 @@ pub enum LegendVariant3LabelOffset {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant3LabelOffset {
-    fn from(value: &LegendVariant3LabelOffset) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant3LabelOffset {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -59499,11 +55567,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant3LabelOffset {
 pub enum LegendVariant3LabelOpacity {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant3LabelOpacity {
-    fn from(value: &LegendVariant3LabelOpacity) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant3LabelOpacity {
     fn from(value: f64) -> Self {
@@ -59538,11 +55601,6 @@ pub enum LegendVariant3LegendX {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant3LegendX {
-    fn from(value: &LegendVariant3LegendX) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant3LegendX {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -59576,11 +55634,6 @@ pub enum LegendVariant3LegendY {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant3LegendY {
-    fn from(value: &LegendVariant3LegendY) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant3LegendY {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -59613,11 +55666,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant3LegendY {
 pub enum LegendVariant3Offset {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant3Offset {
-    fn from(value: &LegendVariant3Offset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant3Offset {
     fn from(value: f64) -> Self {
@@ -59662,11 +55710,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant3Offset {
 pub enum LegendVariant3Orient {
     Variant0(LegendVariant3OrientVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for LegendVariant3Orient {
-    fn from(value: &LegendVariant3Orient) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant3OrientVariant0> for LegendVariant3Orient {
     fn from(value: LegendVariant3OrientVariant0) -> Self {
@@ -59730,11 +55773,6 @@ pub enum LegendVariant3OrientVariant0 {
     BottomLeft,
     #[serde(rename = "bottom-right")]
     BottomRight,
-}
-impl ::std::convert::From<&Self> for LegendVariant3OrientVariant0 {
-    fn from(value: &LegendVariant3OrientVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant3OrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -59813,11 +55851,6 @@ pub enum LegendVariant3Padding {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant3Padding {
-    fn from(value: &LegendVariant3Padding) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant3Padding {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -59855,11 +55888,6 @@ pub enum LegendVariant3StrokeColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant3StrokeColor {
-    fn from(value: &LegendVariant3StrokeColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant3StrokeColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -59890,11 +55918,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant3StrokeColor {
 pub enum LegendVariant3SymbolDash {
     Variant0(::std::vec::Vec<f64>),
     Variant1(ArrayValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant3SymbolDash {
-    fn from(value: &LegendVariant3SymbolDash) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<f64>> for LegendVariant3SymbolDash {
     fn from(value: ::std::vec::Vec<f64>) -> Self {
@@ -59928,11 +55951,6 @@ impl ::std::convert::From<ArrayValue> for LegendVariant3SymbolDash {
 pub enum LegendVariant3SymbolDashOffset {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant3SymbolDashOffset {
-    fn from(value: &LegendVariant3SymbolDashOffset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant3SymbolDashOffset {
     fn from(value: f64) -> Self {
@@ -59971,11 +55989,6 @@ pub enum LegendVariant3SymbolFillColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant3SymbolFillColor {
-    fn from(value: &LegendVariant3SymbolFillColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant3SymbolFillColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -60003,11 +56016,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant3SymbolFillColor {
 pub enum LegendVariant3SymbolOffset {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant3SymbolOffset {
-    fn from(value: &LegendVariant3SymbolOffset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant3SymbolOffset {
     fn from(value: f64) -> Self {
@@ -60042,11 +56050,6 @@ pub enum LegendVariant3SymbolOpacity {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant3SymbolOpacity {
-    fn from(value: &LegendVariant3SymbolOpacity) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant3SymbolOpacity {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -60079,11 +56082,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant3SymbolOpacity {
 pub enum LegendVariant3SymbolSize {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant3SymbolSize {
-    fn from(value: &LegendVariant3SymbolSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant3SymbolSize {
     fn from(value: f64) -> Self {
@@ -60122,11 +56120,6 @@ pub enum LegendVariant3SymbolStrokeColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant3SymbolStrokeColor {
-    fn from(value: &LegendVariant3SymbolStrokeColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant3SymbolStrokeColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -60154,11 +56147,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant3SymbolStrokeColor {
 pub enum LegendVariant3SymbolStrokeWidth {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant3SymbolStrokeWidth {
-    fn from(value: &LegendVariant3SymbolStrokeWidth) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant3SymbolStrokeWidth {
     fn from(value: f64) -> Self {
@@ -60193,11 +56181,6 @@ pub enum LegendVariant3SymbolType {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant3SymbolType {
-    fn from(value: &LegendVariant3SymbolType) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for LegendVariant3SymbolType {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -60229,11 +56212,6 @@ impl ::std::convert::From<StringValue> for LegendVariant3SymbolType {
 pub enum LegendVariant3TitleAlign {
     Variant0(LegendVariant3TitleAlignVariant0),
     Variant1(AlignValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant3TitleAlign {
-    fn from(value: &LegendVariant3TitleAlign) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant3TitleAlignVariant0> for LegendVariant3TitleAlign {
     fn from(value: LegendVariant3TitleAlignVariant0) -> Self {
@@ -60278,11 +56256,6 @@ pub enum LegendVariant3TitleAlignVariant0 {
     Right,
     #[serde(rename = "center")]
     Center,
-}
-impl ::std::convert::From<&Self> for LegendVariant3TitleAlignVariant0 {
-    fn from(value: &LegendVariant3TitleAlignVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant3TitleAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -60354,11 +56327,6 @@ pub enum LegendVariant3TitleAnchor {
     Variant0(::std::option::Option<LegendVariant3TitleAnchorVariant0>),
     Variant1(AnchorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant3TitleAnchor {
-    fn from(value: &LegendVariant3TitleAnchor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::option::Option<LegendVariant3TitleAnchorVariant0>>
     for LegendVariant3TitleAnchor
 {
@@ -60405,11 +56373,6 @@ pub enum LegendVariant3TitleAnchorVariant0 {
     Middle,
     #[serde(rename = "end")]
     End,
-}
-impl ::std::convert::From<&Self> for LegendVariant3TitleAnchorVariant0 {
-    fn from(value: &LegendVariant3TitleAnchorVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant3TitleAnchorVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -60483,11 +56446,6 @@ pub enum LegendVariant3TitleBaseline {
     Variant0(LegendVariant3TitleBaselineVariant0),
     Variant1(BaselineValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant3TitleBaseline {
-    fn from(value: &LegendVariant3TitleBaseline) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LegendVariant3TitleBaselineVariant0> for LegendVariant3TitleBaseline {
     fn from(value: LegendVariant3TitleBaselineVariant0) -> Self {
         Self::Variant0(value)
@@ -60540,11 +56498,6 @@ pub enum LegendVariant3TitleBaselineVariant0 {
     LineTop,
     #[serde(rename = "line-bottom")]
     LineBottom,
-}
-impl ::std::convert::From<&Self> for LegendVariant3TitleBaselineVariant0 {
-    fn from(value: &LegendVariant3TitleBaselineVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant3TitleBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -60621,11 +56574,6 @@ pub enum LegendVariant3TitleColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant3TitleColor {
-    fn from(value: &LegendVariant3TitleColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant3TitleColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -60654,11 +56602,6 @@ pub enum LegendVariant3TitleFont {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant3TitleFont {
-    fn from(value: &LegendVariant3TitleFont) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for LegendVariant3TitleFont {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -60686,11 +56629,6 @@ impl ::std::convert::From<StringValue> for LegendVariant3TitleFont {
 pub enum LegendVariant3TitleFontSize {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant3TitleFontSize {
-    fn from(value: &LegendVariant3TitleFontSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant3TitleFontSize {
     fn from(value: f64) -> Self {
@@ -60724,11 +56662,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant3TitleFontSize {
 pub enum LegendVariant3TitleFontStyle {
     Variant0(::std::string::String),
     Variant1(StringValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant3TitleFontStyle {
-    fn from(value: &LegendVariant3TitleFontStyle) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<StringValue> for LegendVariant3TitleFontStyle {
     fn from(value: StringValue) -> Self {
@@ -60782,11 +56715,6 @@ pub enum LegendVariant3TitleFontWeight {
     Variant0(MyEnum),
     Variant1(FontWeightValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant3TitleFontWeight {
-    fn from(value: &LegendVariant3TitleFontWeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<MyEnum> for LegendVariant3TitleFontWeight {
     fn from(value: MyEnum) -> Self {
         Self::Variant0(value)
@@ -60819,11 +56747,6 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant3TitleFontWeight {
 pub enum LegendVariant3TitleLimit {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant3TitleLimit {
-    fn from(value: &LegendVariant3TitleLimit) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant3TitleLimit {
     fn from(value: f64) -> Self {
@@ -60858,11 +56781,6 @@ pub enum LegendVariant3TitleLineHeight {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant3TitleLineHeight {
-    fn from(value: &LegendVariant3TitleLineHeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant3TitleLineHeight {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -60895,11 +56813,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant3TitleLineHeight {
 pub enum LegendVariant3TitleOpacity {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant3TitleOpacity {
-    fn from(value: &LegendVariant3TitleOpacity) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant3TitleOpacity {
     fn from(value: f64) -> Self {
@@ -60938,11 +56851,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant3TitleOpacity {
 pub enum LegendVariant3TitleOrient {
     Variant0(LegendVariant3TitleOrientVariant0),
     Variant1(OrientValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant3TitleOrient {
-    fn from(value: &LegendVariant3TitleOrient) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant3TitleOrientVariant0> for LegendVariant3TitleOrient {
     fn from(value: LegendVariant3TitleOrientVariant0) -> Self {
@@ -60990,11 +56898,6 @@ pub enum LegendVariant3TitleOrientVariant0 {
     Top,
     #[serde(rename = "bottom")]
     Bottom,
-}
-impl ::std::convert::From<&Self> for LegendVariant3TitleOrientVariant0 {
-    fn from(value: &LegendVariant3TitleOrientVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant3TitleOrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -61063,11 +56966,6 @@ pub enum LegendVariant3TitlePadding {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant3TitlePadding {
-    fn from(value: &LegendVariant3TitlePadding) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant3TitlePadding {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -61108,11 +57006,6 @@ pub enum LegendVariant3Type {
     Gradient,
     #[serde(rename = "symbol")]
     Symbol,
-}
-impl ::std::convert::From<&Self> for LegendVariant3Type {
-    fn from(value: &LegendVariant3Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant3Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -61177,11 +57070,6 @@ pub enum LegendVariant4CornerRadius {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant4CornerRadius {
-    fn from(value: &LegendVariant4CornerRadius) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant4CornerRadius {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -61222,11 +57110,6 @@ pub enum LegendVariant4Direction {
     Vertical,
     #[serde(rename = "horizontal")]
     Horizontal,
-}
-impl ::std::convert::From<&Self> for LegendVariant4Direction {
-    fn from(value: &LegendVariant4Direction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant4Direction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -61315,11 +57198,6 @@ pub struct LegendVariant4Encode {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
 }
-impl ::std::convert::From<&LegendVariant4Encode> for LegendVariant4Encode {
-    fn from(value: &LegendVariant4Encode) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for LegendVariant4Encode {
     fn default() -> Self {
         Self {
@@ -61358,11 +57236,6 @@ pub enum LegendVariant4FillColor {
     Null,
     String(::std::string::String),
     ColorValue(ColorValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant4FillColor {
-    fn from(value: &LegendVariant4FillColor) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ColorValue> for LegendVariant4FillColor {
     fn from(value: ColorValue) -> Self {
@@ -61450,11 +57323,6 @@ pub enum LegendVariant4Format {
     },
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for LegendVariant4Format {
-    fn from(value: &LegendVariant4Format) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for LegendVariant4Format {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -61486,11 +57354,6 @@ impl ::std::convert::From<SignalRef> for LegendVariant4Format {
 pub enum LegendVariant4FormatType {
     Variant0(LegendVariant4FormatTypeVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for LegendVariant4FormatType {
-    fn from(value: &LegendVariant4FormatType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant4FormatTypeVariant0> for LegendVariant4FormatType {
     fn from(value: LegendVariant4FormatTypeVariant0) -> Self {
@@ -61535,11 +57398,6 @@ pub enum LegendVariant4FormatTypeVariant0 {
     Time,
     #[serde(rename = "utc")]
     Utc,
-}
-impl ::std::convert::From<&Self> for LegendVariant4FormatTypeVariant0 {
-    fn from(value: &LegendVariant4FormatTypeVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant4FormatTypeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -61606,11 +57464,6 @@ pub enum LegendVariant4GradientOpacity {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant4GradientOpacity {
-    fn from(value: &LegendVariant4GradientOpacity) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant4GradientOpacity {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -61648,11 +57501,6 @@ pub enum LegendVariant4GradientStrokeColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant4GradientStrokeColor {
-    fn from(value: &LegendVariant4GradientStrokeColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant4GradientStrokeColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -61680,11 +57528,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant4GradientStrokeColor {
 pub enum LegendVariant4GradientStrokeWidth {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant4GradientStrokeWidth {
-    fn from(value: &LegendVariant4GradientStrokeWidth) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant4GradientStrokeWidth {
     fn from(value: f64) -> Self {
@@ -61722,11 +57565,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant4GradientStrokeWidth {
 pub enum LegendVariant4GridAlign {
     Variant0(LegendVariant4GridAlignVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for LegendVariant4GridAlign {
-    fn from(value: &LegendVariant4GridAlign) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant4GridAlignVariant0> for LegendVariant4GridAlign {
     fn from(value: LegendVariant4GridAlignVariant0) -> Self {
@@ -61771,11 +57609,6 @@ pub enum LegendVariant4GridAlignVariant0 {
     Each,
     #[serde(rename = "none")]
     None,
-}
-impl ::std::convert::From<&Self> for LegendVariant4GridAlignVariant0 {
-    fn from(value: &LegendVariant4GridAlignVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant4GridAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -61846,11 +57679,6 @@ pub enum LegendVariant4LabelAlign {
     Variant0(LegendVariant4LabelAlignVariant0),
     Variant1(AlignValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant4LabelAlign {
-    fn from(value: &LegendVariant4LabelAlign) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LegendVariant4LabelAlignVariant0> for LegendVariant4LabelAlign {
     fn from(value: LegendVariant4LabelAlignVariant0) -> Self {
         Self::Variant0(value)
@@ -61894,11 +57722,6 @@ pub enum LegendVariant4LabelAlignVariant0 {
     Right,
     #[serde(rename = "center")]
     Center,
-}
-impl ::std::convert::From<&Self> for LegendVariant4LabelAlignVariant0 {
-    fn from(value: &LegendVariant4LabelAlignVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant4LabelAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -61972,11 +57795,6 @@ pub enum LegendVariant4LabelBaseline {
     Variant0(LegendVariant4LabelBaselineVariant0),
     Variant1(BaselineValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant4LabelBaseline {
-    fn from(value: &LegendVariant4LabelBaseline) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LegendVariant4LabelBaselineVariant0> for LegendVariant4LabelBaseline {
     fn from(value: LegendVariant4LabelBaselineVariant0) -> Self {
         Self::Variant0(value)
@@ -62029,11 +57847,6 @@ pub enum LegendVariant4LabelBaselineVariant0 {
     LineTop,
     #[serde(rename = "line-bottom")]
     LineBottom,
-}
-impl ::std::convert::From<&Self> for LegendVariant4LabelBaselineVariant0 {
-    fn from(value: &LegendVariant4LabelBaselineVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant4LabelBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -62110,11 +57923,6 @@ pub enum LegendVariant4LabelColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant4LabelColor {
-    fn from(value: &LegendVariant4LabelColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant4LabelColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -62143,11 +57951,6 @@ pub enum LegendVariant4LabelFont {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant4LabelFont {
-    fn from(value: &LegendVariant4LabelFont) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for LegendVariant4LabelFont {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -62175,11 +57978,6 @@ impl ::std::convert::From<StringValue> for LegendVariant4LabelFont {
 pub enum LegendVariant4LabelFontSize {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant4LabelFontSize {
-    fn from(value: &LegendVariant4LabelFontSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant4LabelFontSize {
     fn from(value: f64) -> Self {
@@ -62213,11 +58011,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant4LabelFontSize {
 pub enum LegendVariant4LabelFontStyle {
     Variant0(::std::string::String),
     Variant1(StringValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant4LabelFontStyle {
-    fn from(value: &LegendVariant4LabelFontStyle) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<StringValue> for LegendVariant4LabelFontStyle {
     fn from(value: StringValue) -> Self {
@@ -62271,11 +58064,6 @@ pub enum LegendVariant4LabelFontWeight {
     Variant0(MyEnum),
     Variant1(FontWeightValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant4LabelFontWeight {
-    fn from(value: &LegendVariant4LabelFontWeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<MyEnum> for LegendVariant4LabelFontWeight {
     fn from(value: MyEnum) -> Self {
         Self::Variant0(value)
@@ -62308,11 +58096,6 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant4LabelFontWeight {
 pub enum LegendVariant4LabelLimit {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant4LabelLimit {
-    fn from(value: &LegendVariant4LabelLimit) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant4LabelLimit {
     fn from(value: f64) -> Self {
@@ -62347,11 +58130,6 @@ pub enum LegendVariant4LabelOffset {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant4LabelOffset {
-    fn from(value: &LegendVariant4LabelOffset) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant4LabelOffset {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -62384,11 +58162,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant4LabelOffset {
 pub enum LegendVariant4LabelOpacity {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant4LabelOpacity {
-    fn from(value: &LegendVariant4LabelOpacity) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant4LabelOpacity {
     fn from(value: f64) -> Self {
@@ -62423,11 +58196,6 @@ pub enum LegendVariant4LegendX {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant4LegendX {
-    fn from(value: &LegendVariant4LegendX) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant4LegendX {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -62461,11 +58229,6 @@ pub enum LegendVariant4LegendY {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant4LegendY {
-    fn from(value: &LegendVariant4LegendY) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant4LegendY {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -62498,11 +58261,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant4LegendY {
 pub enum LegendVariant4Offset {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant4Offset {
-    fn from(value: &LegendVariant4Offset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant4Offset {
     fn from(value: f64) -> Self {
@@ -62547,11 +58305,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant4Offset {
 pub enum LegendVariant4Orient {
     Variant0(LegendVariant4OrientVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for LegendVariant4Orient {
-    fn from(value: &LegendVariant4Orient) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant4OrientVariant0> for LegendVariant4Orient {
     fn from(value: LegendVariant4OrientVariant0) -> Self {
@@ -62615,11 +58368,6 @@ pub enum LegendVariant4OrientVariant0 {
     BottomLeft,
     #[serde(rename = "bottom-right")]
     BottomRight,
-}
-impl ::std::convert::From<&Self> for LegendVariant4OrientVariant0 {
-    fn from(value: &LegendVariant4OrientVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant4OrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -62698,11 +58446,6 @@ pub enum LegendVariant4Padding {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant4Padding {
-    fn from(value: &LegendVariant4Padding) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant4Padding {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -62740,11 +58483,6 @@ pub enum LegendVariant4StrokeColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant4StrokeColor {
-    fn from(value: &LegendVariant4StrokeColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant4StrokeColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -62775,11 +58513,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant4StrokeColor {
 pub enum LegendVariant4SymbolDash {
     Variant0(::std::vec::Vec<f64>),
     Variant1(ArrayValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant4SymbolDash {
-    fn from(value: &LegendVariant4SymbolDash) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<f64>> for LegendVariant4SymbolDash {
     fn from(value: ::std::vec::Vec<f64>) -> Self {
@@ -62813,11 +58546,6 @@ impl ::std::convert::From<ArrayValue> for LegendVariant4SymbolDash {
 pub enum LegendVariant4SymbolDashOffset {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant4SymbolDashOffset {
-    fn from(value: &LegendVariant4SymbolDashOffset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant4SymbolDashOffset {
     fn from(value: f64) -> Self {
@@ -62856,11 +58584,6 @@ pub enum LegendVariant4SymbolFillColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant4SymbolFillColor {
-    fn from(value: &LegendVariant4SymbolFillColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant4SymbolFillColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -62888,11 +58611,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant4SymbolFillColor {
 pub enum LegendVariant4SymbolOffset {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant4SymbolOffset {
-    fn from(value: &LegendVariant4SymbolOffset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant4SymbolOffset {
     fn from(value: f64) -> Self {
@@ -62927,11 +58645,6 @@ pub enum LegendVariant4SymbolOpacity {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant4SymbolOpacity {
-    fn from(value: &LegendVariant4SymbolOpacity) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant4SymbolOpacity {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -62964,11 +58677,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant4SymbolOpacity {
 pub enum LegendVariant4SymbolSize {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant4SymbolSize {
-    fn from(value: &LegendVariant4SymbolSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant4SymbolSize {
     fn from(value: f64) -> Self {
@@ -63007,11 +58715,6 @@ pub enum LegendVariant4SymbolStrokeColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant4SymbolStrokeColor {
-    fn from(value: &LegendVariant4SymbolStrokeColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant4SymbolStrokeColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -63039,11 +58742,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant4SymbolStrokeColor {
 pub enum LegendVariant4SymbolStrokeWidth {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant4SymbolStrokeWidth {
-    fn from(value: &LegendVariant4SymbolStrokeWidth) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant4SymbolStrokeWidth {
     fn from(value: f64) -> Self {
@@ -63078,11 +58776,6 @@ pub enum LegendVariant4SymbolType {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant4SymbolType {
-    fn from(value: &LegendVariant4SymbolType) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for LegendVariant4SymbolType {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -63114,11 +58807,6 @@ impl ::std::convert::From<StringValue> for LegendVariant4SymbolType {
 pub enum LegendVariant4TitleAlign {
     Variant0(LegendVariant4TitleAlignVariant0),
     Variant1(AlignValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant4TitleAlign {
-    fn from(value: &LegendVariant4TitleAlign) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant4TitleAlignVariant0> for LegendVariant4TitleAlign {
     fn from(value: LegendVariant4TitleAlignVariant0) -> Self {
@@ -63163,11 +58851,6 @@ pub enum LegendVariant4TitleAlignVariant0 {
     Right,
     #[serde(rename = "center")]
     Center,
-}
-impl ::std::convert::From<&Self> for LegendVariant4TitleAlignVariant0 {
-    fn from(value: &LegendVariant4TitleAlignVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant4TitleAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -63239,11 +58922,6 @@ pub enum LegendVariant4TitleAnchor {
     Variant0(::std::option::Option<LegendVariant4TitleAnchorVariant0>),
     Variant1(AnchorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant4TitleAnchor {
-    fn from(value: &LegendVariant4TitleAnchor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::option::Option<LegendVariant4TitleAnchorVariant0>>
     for LegendVariant4TitleAnchor
 {
@@ -63290,11 +58968,6 @@ pub enum LegendVariant4TitleAnchorVariant0 {
     Middle,
     #[serde(rename = "end")]
     End,
-}
-impl ::std::convert::From<&Self> for LegendVariant4TitleAnchorVariant0 {
-    fn from(value: &LegendVariant4TitleAnchorVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant4TitleAnchorVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -63368,11 +59041,6 @@ pub enum LegendVariant4TitleBaseline {
     Variant0(LegendVariant4TitleBaselineVariant0),
     Variant1(BaselineValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant4TitleBaseline {
-    fn from(value: &LegendVariant4TitleBaseline) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LegendVariant4TitleBaselineVariant0> for LegendVariant4TitleBaseline {
     fn from(value: LegendVariant4TitleBaselineVariant0) -> Self {
         Self::Variant0(value)
@@ -63425,11 +59093,6 @@ pub enum LegendVariant4TitleBaselineVariant0 {
     LineTop,
     #[serde(rename = "line-bottom")]
     LineBottom,
-}
-impl ::std::convert::From<&Self> for LegendVariant4TitleBaselineVariant0 {
-    fn from(value: &LegendVariant4TitleBaselineVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant4TitleBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -63506,11 +59169,6 @@ pub enum LegendVariant4TitleColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant4TitleColor {
-    fn from(value: &LegendVariant4TitleColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant4TitleColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -63539,11 +59197,6 @@ pub enum LegendVariant4TitleFont {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant4TitleFont {
-    fn from(value: &LegendVariant4TitleFont) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for LegendVariant4TitleFont {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -63571,11 +59224,6 @@ impl ::std::convert::From<StringValue> for LegendVariant4TitleFont {
 pub enum LegendVariant4TitleFontSize {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant4TitleFontSize {
-    fn from(value: &LegendVariant4TitleFontSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant4TitleFontSize {
     fn from(value: f64) -> Self {
@@ -63609,11 +59257,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant4TitleFontSize {
 pub enum LegendVariant4TitleFontStyle {
     Variant0(::std::string::String),
     Variant1(StringValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant4TitleFontStyle {
-    fn from(value: &LegendVariant4TitleFontStyle) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<StringValue> for LegendVariant4TitleFontStyle {
     fn from(value: StringValue) -> Self {
@@ -63667,11 +59310,6 @@ pub enum LegendVariant4TitleFontWeight {
     Variant0(MyEnum),
     Variant1(FontWeightValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant4TitleFontWeight {
-    fn from(value: &LegendVariant4TitleFontWeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<MyEnum> for LegendVariant4TitleFontWeight {
     fn from(value: MyEnum) -> Self {
         Self::Variant0(value)
@@ -63704,11 +59342,6 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant4TitleFontWeight {
 pub enum LegendVariant4TitleLimit {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant4TitleLimit {
-    fn from(value: &LegendVariant4TitleLimit) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant4TitleLimit {
     fn from(value: f64) -> Self {
@@ -63743,11 +59376,6 @@ pub enum LegendVariant4TitleLineHeight {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant4TitleLineHeight {
-    fn from(value: &LegendVariant4TitleLineHeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant4TitleLineHeight {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -63780,11 +59408,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant4TitleLineHeight {
 pub enum LegendVariant4TitleOpacity {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant4TitleOpacity {
-    fn from(value: &LegendVariant4TitleOpacity) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant4TitleOpacity {
     fn from(value: f64) -> Self {
@@ -63823,11 +59446,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant4TitleOpacity {
 pub enum LegendVariant4TitleOrient {
     Variant0(LegendVariant4TitleOrientVariant0),
     Variant1(OrientValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant4TitleOrient {
-    fn from(value: &LegendVariant4TitleOrient) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant4TitleOrientVariant0> for LegendVariant4TitleOrient {
     fn from(value: LegendVariant4TitleOrientVariant0) -> Self {
@@ -63875,11 +59493,6 @@ pub enum LegendVariant4TitleOrientVariant0 {
     Top,
     #[serde(rename = "bottom")]
     Bottom,
-}
-impl ::std::convert::From<&Self> for LegendVariant4TitleOrientVariant0 {
-    fn from(value: &LegendVariant4TitleOrientVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant4TitleOrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -63948,11 +59561,6 @@ pub enum LegendVariant4TitlePadding {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant4TitlePadding {
-    fn from(value: &LegendVariant4TitlePadding) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant4TitlePadding {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -63993,11 +59601,6 @@ pub enum LegendVariant4Type {
     Gradient,
     #[serde(rename = "symbol")]
     Symbol,
-}
-impl ::std::convert::From<&Self> for LegendVariant4Type {
-    fn from(value: &LegendVariant4Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant4Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -64062,11 +59665,6 @@ pub enum LegendVariant5CornerRadius {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant5CornerRadius {
-    fn from(value: &LegendVariant5CornerRadius) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant5CornerRadius {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -64107,11 +59705,6 @@ pub enum LegendVariant5Direction {
     Vertical,
     #[serde(rename = "horizontal")]
     Horizontal,
-}
-impl ::std::convert::From<&Self> for LegendVariant5Direction {
-    fn from(value: &LegendVariant5Direction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant5Direction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -64200,11 +59793,6 @@ pub struct LegendVariant5Encode {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
 }
-impl ::std::convert::From<&LegendVariant5Encode> for LegendVariant5Encode {
-    fn from(value: &LegendVariant5Encode) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for LegendVariant5Encode {
     fn default() -> Self {
         Self {
@@ -64243,11 +59831,6 @@ pub enum LegendVariant5FillColor {
     Null,
     String(::std::string::String),
     ColorValue(ColorValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant5FillColor {
-    fn from(value: &LegendVariant5FillColor) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ColorValue> for LegendVariant5FillColor {
     fn from(value: ColorValue) -> Self {
@@ -64335,11 +59918,6 @@ pub enum LegendVariant5Format {
     },
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for LegendVariant5Format {
-    fn from(value: &LegendVariant5Format) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for LegendVariant5Format {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -64371,11 +59949,6 @@ impl ::std::convert::From<SignalRef> for LegendVariant5Format {
 pub enum LegendVariant5FormatType {
     Variant0(LegendVariant5FormatTypeVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for LegendVariant5FormatType {
-    fn from(value: &LegendVariant5FormatType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant5FormatTypeVariant0> for LegendVariant5FormatType {
     fn from(value: LegendVariant5FormatTypeVariant0) -> Self {
@@ -64420,11 +59993,6 @@ pub enum LegendVariant5FormatTypeVariant0 {
     Time,
     #[serde(rename = "utc")]
     Utc,
-}
-impl ::std::convert::From<&Self> for LegendVariant5FormatTypeVariant0 {
-    fn from(value: &LegendVariant5FormatTypeVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant5FormatTypeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -64491,11 +60059,6 @@ pub enum LegendVariant5GradientOpacity {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant5GradientOpacity {
-    fn from(value: &LegendVariant5GradientOpacity) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant5GradientOpacity {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -64533,11 +60096,6 @@ pub enum LegendVariant5GradientStrokeColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant5GradientStrokeColor {
-    fn from(value: &LegendVariant5GradientStrokeColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant5GradientStrokeColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -64565,11 +60123,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant5GradientStrokeColor {
 pub enum LegendVariant5GradientStrokeWidth {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant5GradientStrokeWidth {
-    fn from(value: &LegendVariant5GradientStrokeWidth) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant5GradientStrokeWidth {
     fn from(value: f64) -> Self {
@@ -64607,11 +60160,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant5GradientStrokeWidth {
 pub enum LegendVariant5GridAlign {
     Variant0(LegendVariant5GridAlignVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for LegendVariant5GridAlign {
-    fn from(value: &LegendVariant5GridAlign) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant5GridAlignVariant0> for LegendVariant5GridAlign {
     fn from(value: LegendVariant5GridAlignVariant0) -> Self {
@@ -64656,11 +60204,6 @@ pub enum LegendVariant5GridAlignVariant0 {
     Each,
     #[serde(rename = "none")]
     None,
-}
-impl ::std::convert::From<&Self> for LegendVariant5GridAlignVariant0 {
-    fn from(value: &LegendVariant5GridAlignVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant5GridAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -64731,11 +60274,6 @@ pub enum LegendVariant5LabelAlign {
     Variant0(LegendVariant5LabelAlignVariant0),
     Variant1(AlignValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant5LabelAlign {
-    fn from(value: &LegendVariant5LabelAlign) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LegendVariant5LabelAlignVariant0> for LegendVariant5LabelAlign {
     fn from(value: LegendVariant5LabelAlignVariant0) -> Self {
         Self::Variant0(value)
@@ -64779,11 +60317,6 @@ pub enum LegendVariant5LabelAlignVariant0 {
     Right,
     #[serde(rename = "center")]
     Center,
-}
-impl ::std::convert::From<&Self> for LegendVariant5LabelAlignVariant0 {
-    fn from(value: &LegendVariant5LabelAlignVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant5LabelAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -64857,11 +60390,6 @@ pub enum LegendVariant5LabelBaseline {
     Variant0(LegendVariant5LabelBaselineVariant0),
     Variant1(BaselineValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant5LabelBaseline {
-    fn from(value: &LegendVariant5LabelBaseline) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LegendVariant5LabelBaselineVariant0> for LegendVariant5LabelBaseline {
     fn from(value: LegendVariant5LabelBaselineVariant0) -> Self {
         Self::Variant0(value)
@@ -64914,11 +60442,6 @@ pub enum LegendVariant5LabelBaselineVariant0 {
     LineTop,
     #[serde(rename = "line-bottom")]
     LineBottom,
-}
-impl ::std::convert::From<&Self> for LegendVariant5LabelBaselineVariant0 {
-    fn from(value: &LegendVariant5LabelBaselineVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant5LabelBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -64995,11 +60518,6 @@ pub enum LegendVariant5LabelColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant5LabelColor {
-    fn from(value: &LegendVariant5LabelColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant5LabelColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -65028,11 +60546,6 @@ pub enum LegendVariant5LabelFont {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant5LabelFont {
-    fn from(value: &LegendVariant5LabelFont) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for LegendVariant5LabelFont {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -65060,11 +60573,6 @@ impl ::std::convert::From<StringValue> for LegendVariant5LabelFont {
 pub enum LegendVariant5LabelFontSize {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant5LabelFontSize {
-    fn from(value: &LegendVariant5LabelFontSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant5LabelFontSize {
     fn from(value: f64) -> Self {
@@ -65098,11 +60606,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant5LabelFontSize {
 pub enum LegendVariant5LabelFontStyle {
     Variant0(::std::string::String),
     Variant1(StringValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant5LabelFontStyle {
-    fn from(value: &LegendVariant5LabelFontStyle) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<StringValue> for LegendVariant5LabelFontStyle {
     fn from(value: StringValue) -> Self {
@@ -65156,11 +60659,6 @@ pub enum LegendVariant5LabelFontWeight {
     Variant0(MyEnum),
     Variant1(FontWeightValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant5LabelFontWeight {
-    fn from(value: &LegendVariant5LabelFontWeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<MyEnum> for LegendVariant5LabelFontWeight {
     fn from(value: MyEnum) -> Self {
         Self::Variant0(value)
@@ -65193,11 +60691,6 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant5LabelFontWeight {
 pub enum LegendVariant5LabelLimit {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant5LabelLimit {
-    fn from(value: &LegendVariant5LabelLimit) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant5LabelLimit {
     fn from(value: f64) -> Self {
@@ -65232,11 +60725,6 @@ pub enum LegendVariant5LabelOffset {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant5LabelOffset {
-    fn from(value: &LegendVariant5LabelOffset) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant5LabelOffset {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -65269,11 +60757,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant5LabelOffset {
 pub enum LegendVariant5LabelOpacity {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant5LabelOpacity {
-    fn from(value: &LegendVariant5LabelOpacity) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant5LabelOpacity {
     fn from(value: f64) -> Self {
@@ -65308,11 +60791,6 @@ pub enum LegendVariant5LegendX {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant5LegendX {
-    fn from(value: &LegendVariant5LegendX) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant5LegendX {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -65346,11 +60824,6 @@ pub enum LegendVariant5LegendY {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant5LegendY {
-    fn from(value: &LegendVariant5LegendY) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant5LegendY {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -65383,11 +60856,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant5LegendY {
 pub enum LegendVariant5Offset {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant5Offset {
-    fn from(value: &LegendVariant5Offset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant5Offset {
     fn from(value: f64) -> Self {
@@ -65432,11 +60900,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant5Offset {
 pub enum LegendVariant5Orient {
     Variant0(LegendVariant5OrientVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for LegendVariant5Orient {
-    fn from(value: &LegendVariant5Orient) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant5OrientVariant0> for LegendVariant5Orient {
     fn from(value: LegendVariant5OrientVariant0) -> Self {
@@ -65500,11 +60963,6 @@ pub enum LegendVariant5OrientVariant0 {
     BottomLeft,
     #[serde(rename = "bottom-right")]
     BottomRight,
-}
-impl ::std::convert::From<&Self> for LegendVariant5OrientVariant0 {
-    fn from(value: &LegendVariant5OrientVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant5OrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -65583,11 +61041,6 @@ pub enum LegendVariant5Padding {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant5Padding {
-    fn from(value: &LegendVariant5Padding) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant5Padding {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -65625,11 +61078,6 @@ pub enum LegendVariant5StrokeColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant5StrokeColor {
-    fn from(value: &LegendVariant5StrokeColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant5StrokeColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -65660,11 +61108,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant5StrokeColor {
 pub enum LegendVariant5SymbolDash {
     Variant0(::std::vec::Vec<f64>),
     Variant1(ArrayValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant5SymbolDash {
-    fn from(value: &LegendVariant5SymbolDash) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<f64>> for LegendVariant5SymbolDash {
     fn from(value: ::std::vec::Vec<f64>) -> Self {
@@ -65698,11 +61141,6 @@ impl ::std::convert::From<ArrayValue> for LegendVariant5SymbolDash {
 pub enum LegendVariant5SymbolDashOffset {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant5SymbolDashOffset {
-    fn from(value: &LegendVariant5SymbolDashOffset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant5SymbolDashOffset {
     fn from(value: f64) -> Self {
@@ -65741,11 +61179,6 @@ pub enum LegendVariant5SymbolFillColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant5SymbolFillColor {
-    fn from(value: &LegendVariant5SymbolFillColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant5SymbolFillColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -65773,11 +61206,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant5SymbolFillColor {
 pub enum LegendVariant5SymbolOffset {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant5SymbolOffset {
-    fn from(value: &LegendVariant5SymbolOffset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant5SymbolOffset {
     fn from(value: f64) -> Self {
@@ -65812,11 +61240,6 @@ pub enum LegendVariant5SymbolOpacity {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant5SymbolOpacity {
-    fn from(value: &LegendVariant5SymbolOpacity) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant5SymbolOpacity {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -65849,11 +61272,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant5SymbolOpacity {
 pub enum LegendVariant5SymbolSize {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant5SymbolSize {
-    fn from(value: &LegendVariant5SymbolSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant5SymbolSize {
     fn from(value: f64) -> Self {
@@ -65892,11 +61310,6 @@ pub enum LegendVariant5SymbolStrokeColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant5SymbolStrokeColor {
-    fn from(value: &LegendVariant5SymbolStrokeColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant5SymbolStrokeColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -65924,11 +61337,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant5SymbolStrokeColor {
 pub enum LegendVariant5SymbolStrokeWidth {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant5SymbolStrokeWidth {
-    fn from(value: &LegendVariant5SymbolStrokeWidth) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant5SymbolStrokeWidth {
     fn from(value: f64) -> Self {
@@ -65963,11 +61371,6 @@ pub enum LegendVariant5SymbolType {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant5SymbolType {
-    fn from(value: &LegendVariant5SymbolType) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for LegendVariant5SymbolType {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -65999,11 +61402,6 @@ impl ::std::convert::From<StringValue> for LegendVariant5SymbolType {
 pub enum LegendVariant5TitleAlign {
     Variant0(LegendVariant5TitleAlignVariant0),
     Variant1(AlignValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant5TitleAlign {
-    fn from(value: &LegendVariant5TitleAlign) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant5TitleAlignVariant0> for LegendVariant5TitleAlign {
     fn from(value: LegendVariant5TitleAlignVariant0) -> Self {
@@ -66048,11 +61446,6 @@ pub enum LegendVariant5TitleAlignVariant0 {
     Right,
     #[serde(rename = "center")]
     Center,
-}
-impl ::std::convert::From<&Self> for LegendVariant5TitleAlignVariant0 {
-    fn from(value: &LegendVariant5TitleAlignVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant5TitleAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -66124,11 +61517,6 @@ pub enum LegendVariant5TitleAnchor {
     Variant0(::std::option::Option<LegendVariant5TitleAnchorVariant0>),
     Variant1(AnchorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant5TitleAnchor {
-    fn from(value: &LegendVariant5TitleAnchor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::option::Option<LegendVariant5TitleAnchorVariant0>>
     for LegendVariant5TitleAnchor
 {
@@ -66175,11 +61563,6 @@ pub enum LegendVariant5TitleAnchorVariant0 {
     Middle,
     #[serde(rename = "end")]
     End,
-}
-impl ::std::convert::From<&Self> for LegendVariant5TitleAnchorVariant0 {
-    fn from(value: &LegendVariant5TitleAnchorVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant5TitleAnchorVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -66253,11 +61636,6 @@ pub enum LegendVariant5TitleBaseline {
     Variant0(LegendVariant5TitleBaselineVariant0),
     Variant1(BaselineValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant5TitleBaseline {
-    fn from(value: &LegendVariant5TitleBaseline) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LegendVariant5TitleBaselineVariant0> for LegendVariant5TitleBaseline {
     fn from(value: LegendVariant5TitleBaselineVariant0) -> Self {
         Self::Variant0(value)
@@ -66310,11 +61688,6 @@ pub enum LegendVariant5TitleBaselineVariant0 {
     LineTop,
     #[serde(rename = "line-bottom")]
     LineBottom,
-}
-impl ::std::convert::From<&Self> for LegendVariant5TitleBaselineVariant0 {
-    fn from(value: &LegendVariant5TitleBaselineVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant5TitleBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -66391,11 +61764,6 @@ pub enum LegendVariant5TitleColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant5TitleColor {
-    fn from(value: &LegendVariant5TitleColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant5TitleColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -66424,11 +61792,6 @@ pub enum LegendVariant5TitleFont {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant5TitleFont {
-    fn from(value: &LegendVariant5TitleFont) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for LegendVariant5TitleFont {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -66456,11 +61819,6 @@ impl ::std::convert::From<StringValue> for LegendVariant5TitleFont {
 pub enum LegendVariant5TitleFontSize {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant5TitleFontSize {
-    fn from(value: &LegendVariant5TitleFontSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant5TitleFontSize {
     fn from(value: f64) -> Self {
@@ -66494,11 +61852,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant5TitleFontSize {
 pub enum LegendVariant5TitleFontStyle {
     Variant0(::std::string::String),
     Variant1(StringValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant5TitleFontStyle {
-    fn from(value: &LegendVariant5TitleFontStyle) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<StringValue> for LegendVariant5TitleFontStyle {
     fn from(value: StringValue) -> Self {
@@ -66552,11 +61905,6 @@ pub enum LegendVariant5TitleFontWeight {
     Variant0(MyEnum),
     Variant1(FontWeightValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant5TitleFontWeight {
-    fn from(value: &LegendVariant5TitleFontWeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<MyEnum> for LegendVariant5TitleFontWeight {
     fn from(value: MyEnum) -> Self {
         Self::Variant0(value)
@@ -66589,11 +61937,6 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant5TitleFontWeight {
 pub enum LegendVariant5TitleLimit {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant5TitleLimit {
-    fn from(value: &LegendVariant5TitleLimit) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant5TitleLimit {
     fn from(value: f64) -> Self {
@@ -66628,11 +61971,6 @@ pub enum LegendVariant5TitleLineHeight {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant5TitleLineHeight {
-    fn from(value: &LegendVariant5TitleLineHeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant5TitleLineHeight {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -66665,11 +62003,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant5TitleLineHeight {
 pub enum LegendVariant5TitleOpacity {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant5TitleOpacity {
-    fn from(value: &LegendVariant5TitleOpacity) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant5TitleOpacity {
     fn from(value: f64) -> Self {
@@ -66708,11 +62041,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant5TitleOpacity {
 pub enum LegendVariant5TitleOrient {
     Variant0(LegendVariant5TitleOrientVariant0),
     Variant1(OrientValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant5TitleOrient {
-    fn from(value: &LegendVariant5TitleOrient) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant5TitleOrientVariant0> for LegendVariant5TitleOrient {
     fn from(value: LegendVariant5TitleOrientVariant0) -> Self {
@@ -66760,11 +62088,6 @@ pub enum LegendVariant5TitleOrientVariant0 {
     Top,
     #[serde(rename = "bottom")]
     Bottom,
-}
-impl ::std::convert::From<&Self> for LegendVariant5TitleOrientVariant0 {
-    fn from(value: &LegendVariant5TitleOrientVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant5TitleOrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -66833,11 +62156,6 @@ pub enum LegendVariant5TitlePadding {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant5TitlePadding {
-    fn from(value: &LegendVariant5TitlePadding) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant5TitlePadding {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -66878,11 +62196,6 @@ pub enum LegendVariant5Type {
     Gradient,
     #[serde(rename = "symbol")]
     Symbol,
-}
-impl ::std::convert::From<&Self> for LegendVariant5Type {
-    fn from(value: &LegendVariant5Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant5Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -66947,11 +62260,6 @@ pub enum LegendVariant6CornerRadius {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant6CornerRadius {
-    fn from(value: &LegendVariant6CornerRadius) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant6CornerRadius {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -66992,11 +62300,6 @@ pub enum LegendVariant6Direction {
     Vertical,
     #[serde(rename = "horizontal")]
     Horizontal,
-}
-impl ::std::convert::From<&Self> for LegendVariant6Direction {
-    fn from(value: &LegendVariant6Direction) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant6Direction {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -67085,11 +62388,6 @@ pub struct LegendVariant6Encode {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
 }
-impl ::std::convert::From<&LegendVariant6Encode> for LegendVariant6Encode {
-    fn from(value: &LegendVariant6Encode) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for LegendVariant6Encode {
     fn default() -> Self {
         Self {
@@ -67128,11 +62426,6 @@ pub enum LegendVariant6FillColor {
     Null,
     String(::std::string::String),
     ColorValue(ColorValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant6FillColor {
-    fn from(value: &LegendVariant6FillColor) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ColorValue> for LegendVariant6FillColor {
     fn from(value: ColorValue) -> Self {
@@ -67220,11 +62513,6 @@ pub enum LegendVariant6Format {
     },
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for LegendVariant6Format {
-    fn from(value: &LegendVariant6Format) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for LegendVariant6Format {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -67256,11 +62544,6 @@ impl ::std::convert::From<SignalRef> for LegendVariant6Format {
 pub enum LegendVariant6FormatType {
     Variant0(LegendVariant6FormatTypeVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for LegendVariant6FormatType {
-    fn from(value: &LegendVariant6FormatType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant6FormatTypeVariant0> for LegendVariant6FormatType {
     fn from(value: LegendVariant6FormatTypeVariant0) -> Self {
@@ -67305,11 +62588,6 @@ pub enum LegendVariant6FormatTypeVariant0 {
     Time,
     #[serde(rename = "utc")]
     Utc,
-}
-impl ::std::convert::From<&Self> for LegendVariant6FormatTypeVariant0 {
-    fn from(value: &LegendVariant6FormatTypeVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant6FormatTypeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -67376,11 +62654,6 @@ pub enum LegendVariant6GradientOpacity {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant6GradientOpacity {
-    fn from(value: &LegendVariant6GradientOpacity) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant6GradientOpacity {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -67418,11 +62691,6 @@ pub enum LegendVariant6GradientStrokeColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant6GradientStrokeColor {
-    fn from(value: &LegendVariant6GradientStrokeColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant6GradientStrokeColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -67450,11 +62718,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant6GradientStrokeColor {
 pub enum LegendVariant6GradientStrokeWidth {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant6GradientStrokeWidth {
-    fn from(value: &LegendVariant6GradientStrokeWidth) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant6GradientStrokeWidth {
     fn from(value: f64) -> Self {
@@ -67492,11 +62755,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant6GradientStrokeWidth {
 pub enum LegendVariant6GridAlign {
     Variant0(LegendVariant6GridAlignVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for LegendVariant6GridAlign {
-    fn from(value: &LegendVariant6GridAlign) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant6GridAlignVariant0> for LegendVariant6GridAlign {
     fn from(value: LegendVariant6GridAlignVariant0) -> Self {
@@ -67541,11 +62799,6 @@ pub enum LegendVariant6GridAlignVariant0 {
     Each,
     #[serde(rename = "none")]
     None,
-}
-impl ::std::convert::From<&Self> for LegendVariant6GridAlignVariant0 {
-    fn from(value: &LegendVariant6GridAlignVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant6GridAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -67616,11 +62869,6 @@ pub enum LegendVariant6LabelAlign {
     Variant0(LegendVariant6LabelAlignVariant0),
     Variant1(AlignValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant6LabelAlign {
-    fn from(value: &LegendVariant6LabelAlign) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LegendVariant6LabelAlignVariant0> for LegendVariant6LabelAlign {
     fn from(value: LegendVariant6LabelAlignVariant0) -> Self {
         Self::Variant0(value)
@@ -67664,11 +62912,6 @@ pub enum LegendVariant6LabelAlignVariant0 {
     Right,
     #[serde(rename = "center")]
     Center,
-}
-impl ::std::convert::From<&Self> for LegendVariant6LabelAlignVariant0 {
-    fn from(value: &LegendVariant6LabelAlignVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant6LabelAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -67742,11 +62985,6 @@ pub enum LegendVariant6LabelBaseline {
     Variant0(LegendVariant6LabelBaselineVariant0),
     Variant1(BaselineValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant6LabelBaseline {
-    fn from(value: &LegendVariant6LabelBaseline) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LegendVariant6LabelBaselineVariant0> for LegendVariant6LabelBaseline {
     fn from(value: LegendVariant6LabelBaselineVariant0) -> Self {
         Self::Variant0(value)
@@ -67799,11 +63037,6 @@ pub enum LegendVariant6LabelBaselineVariant0 {
     LineTop,
     #[serde(rename = "line-bottom")]
     LineBottom,
-}
-impl ::std::convert::From<&Self> for LegendVariant6LabelBaselineVariant0 {
-    fn from(value: &LegendVariant6LabelBaselineVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant6LabelBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -67880,11 +63113,6 @@ pub enum LegendVariant6LabelColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant6LabelColor {
-    fn from(value: &LegendVariant6LabelColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant6LabelColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -67913,11 +63141,6 @@ pub enum LegendVariant6LabelFont {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant6LabelFont {
-    fn from(value: &LegendVariant6LabelFont) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for LegendVariant6LabelFont {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -67945,11 +63168,6 @@ impl ::std::convert::From<StringValue> for LegendVariant6LabelFont {
 pub enum LegendVariant6LabelFontSize {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant6LabelFontSize {
-    fn from(value: &LegendVariant6LabelFontSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant6LabelFontSize {
     fn from(value: f64) -> Self {
@@ -67983,11 +63201,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant6LabelFontSize {
 pub enum LegendVariant6LabelFontStyle {
     Variant0(::std::string::String),
     Variant1(StringValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant6LabelFontStyle {
-    fn from(value: &LegendVariant6LabelFontStyle) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<StringValue> for LegendVariant6LabelFontStyle {
     fn from(value: StringValue) -> Self {
@@ -68041,11 +63254,6 @@ pub enum LegendVariant6LabelFontWeight {
     Variant0(MyEnum),
     Variant1(FontWeightValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant6LabelFontWeight {
-    fn from(value: &LegendVariant6LabelFontWeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<MyEnum> for LegendVariant6LabelFontWeight {
     fn from(value: MyEnum) -> Self {
         Self::Variant0(value)
@@ -68078,11 +63286,6 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant6LabelFontWeight {
 pub enum LegendVariant6LabelLimit {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant6LabelLimit {
-    fn from(value: &LegendVariant6LabelLimit) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant6LabelLimit {
     fn from(value: f64) -> Self {
@@ -68117,11 +63320,6 @@ pub enum LegendVariant6LabelOffset {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant6LabelOffset {
-    fn from(value: &LegendVariant6LabelOffset) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant6LabelOffset {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -68154,11 +63352,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant6LabelOffset {
 pub enum LegendVariant6LabelOpacity {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant6LabelOpacity {
-    fn from(value: &LegendVariant6LabelOpacity) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant6LabelOpacity {
     fn from(value: f64) -> Self {
@@ -68193,11 +63386,6 @@ pub enum LegendVariant6LegendX {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant6LegendX {
-    fn from(value: &LegendVariant6LegendX) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant6LegendX {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -68231,11 +63419,6 @@ pub enum LegendVariant6LegendY {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant6LegendY {
-    fn from(value: &LegendVariant6LegendY) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant6LegendY {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -68268,11 +63451,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant6LegendY {
 pub enum LegendVariant6Offset {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant6Offset {
-    fn from(value: &LegendVariant6Offset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant6Offset {
     fn from(value: f64) -> Self {
@@ -68317,11 +63495,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant6Offset {
 pub enum LegendVariant6Orient {
     Variant0(LegendVariant6OrientVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for LegendVariant6Orient {
-    fn from(value: &LegendVariant6Orient) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant6OrientVariant0> for LegendVariant6Orient {
     fn from(value: LegendVariant6OrientVariant0) -> Self {
@@ -68385,11 +63558,6 @@ pub enum LegendVariant6OrientVariant0 {
     BottomLeft,
     #[serde(rename = "bottom-right")]
     BottomRight,
-}
-impl ::std::convert::From<&Self> for LegendVariant6OrientVariant0 {
-    fn from(value: &LegendVariant6OrientVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant6OrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -68468,11 +63636,6 @@ pub enum LegendVariant6Padding {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant6Padding {
-    fn from(value: &LegendVariant6Padding) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant6Padding {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -68510,11 +63673,6 @@ pub enum LegendVariant6StrokeColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant6StrokeColor {
-    fn from(value: &LegendVariant6StrokeColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant6StrokeColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -68545,11 +63703,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant6StrokeColor {
 pub enum LegendVariant6SymbolDash {
     Variant0(::std::vec::Vec<f64>),
     Variant1(ArrayValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant6SymbolDash {
-    fn from(value: &LegendVariant6SymbolDash) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<f64>> for LegendVariant6SymbolDash {
     fn from(value: ::std::vec::Vec<f64>) -> Self {
@@ -68583,11 +63736,6 @@ impl ::std::convert::From<ArrayValue> for LegendVariant6SymbolDash {
 pub enum LegendVariant6SymbolDashOffset {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant6SymbolDashOffset {
-    fn from(value: &LegendVariant6SymbolDashOffset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant6SymbolDashOffset {
     fn from(value: f64) -> Self {
@@ -68626,11 +63774,6 @@ pub enum LegendVariant6SymbolFillColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant6SymbolFillColor {
-    fn from(value: &LegendVariant6SymbolFillColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant6SymbolFillColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -68658,11 +63801,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant6SymbolFillColor {
 pub enum LegendVariant6SymbolOffset {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant6SymbolOffset {
-    fn from(value: &LegendVariant6SymbolOffset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant6SymbolOffset {
     fn from(value: f64) -> Self {
@@ -68697,11 +63835,6 @@ pub enum LegendVariant6SymbolOpacity {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant6SymbolOpacity {
-    fn from(value: &LegendVariant6SymbolOpacity) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant6SymbolOpacity {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -68734,11 +63867,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant6SymbolOpacity {
 pub enum LegendVariant6SymbolSize {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant6SymbolSize {
-    fn from(value: &LegendVariant6SymbolSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant6SymbolSize {
     fn from(value: f64) -> Self {
@@ -68777,11 +63905,6 @@ pub enum LegendVariant6SymbolStrokeColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant6SymbolStrokeColor {
-    fn from(value: &LegendVariant6SymbolStrokeColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant6SymbolStrokeColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -68809,11 +63932,6 @@ impl ::std::convert::From<ColorValue> for LegendVariant6SymbolStrokeColor {
 pub enum LegendVariant6SymbolStrokeWidth {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant6SymbolStrokeWidth {
-    fn from(value: &LegendVariant6SymbolStrokeWidth) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant6SymbolStrokeWidth {
     fn from(value: f64) -> Self {
@@ -68848,11 +63966,6 @@ pub enum LegendVariant6SymbolType {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant6SymbolType {
-    fn from(value: &LegendVariant6SymbolType) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for LegendVariant6SymbolType {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -68884,11 +63997,6 @@ impl ::std::convert::From<StringValue> for LegendVariant6SymbolType {
 pub enum LegendVariant6TitleAlign {
     Variant0(LegendVariant6TitleAlignVariant0),
     Variant1(AlignValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant6TitleAlign {
-    fn from(value: &LegendVariant6TitleAlign) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant6TitleAlignVariant0> for LegendVariant6TitleAlign {
     fn from(value: LegendVariant6TitleAlignVariant0) -> Self {
@@ -68933,11 +64041,6 @@ pub enum LegendVariant6TitleAlignVariant0 {
     Right,
     #[serde(rename = "center")]
     Center,
-}
-impl ::std::convert::From<&Self> for LegendVariant6TitleAlignVariant0 {
-    fn from(value: &LegendVariant6TitleAlignVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant6TitleAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -69009,11 +64112,6 @@ pub enum LegendVariant6TitleAnchor {
     Variant0(::std::option::Option<LegendVariant6TitleAnchorVariant0>),
     Variant1(AnchorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant6TitleAnchor {
-    fn from(value: &LegendVariant6TitleAnchor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::option::Option<LegendVariant6TitleAnchorVariant0>>
     for LegendVariant6TitleAnchor
 {
@@ -69060,11 +64158,6 @@ pub enum LegendVariant6TitleAnchorVariant0 {
     Middle,
     #[serde(rename = "end")]
     End,
-}
-impl ::std::convert::From<&Self> for LegendVariant6TitleAnchorVariant0 {
-    fn from(value: &LegendVariant6TitleAnchorVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant6TitleAnchorVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -69138,11 +64231,6 @@ pub enum LegendVariant6TitleBaseline {
     Variant0(LegendVariant6TitleBaselineVariant0),
     Variant1(BaselineValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant6TitleBaseline {
-    fn from(value: &LegendVariant6TitleBaseline) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<LegendVariant6TitleBaselineVariant0> for LegendVariant6TitleBaseline {
     fn from(value: LegendVariant6TitleBaselineVariant0) -> Self {
         Self::Variant0(value)
@@ -69195,11 +64283,6 @@ pub enum LegendVariant6TitleBaselineVariant0 {
     LineTop,
     #[serde(rename = "line-bottom")]
     LineBottom,
-}
-impl ::std::convert::From<&Self> for LegendVariant6TitleBaselineVariant0 {
-    fn from(value: &LegendVariant6TitleBaselineVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant6TitleBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -69276,11 +64359,6 @@ pub enum LegendVariant6TitleColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant6TitleColor {
-    fn from(value: &LegendVariant6TitleColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for LegendVariant6TitleColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -69309,11 +64387,6 @@ pub enum LegendVariant6TitleFont {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant6TitleFont {
-    fn from(value: &LegendVariant6TitleFont) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for LegendVariant6TitleFont {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -69341,11 +64414,6 @@ impl ::std::convert::From<StringValue> for LegendVariant6TitleFont {
 pub enum LegendVariant6TitleFontSize {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant6TitleFontSize {
-    fn from(value: &LegendVariant6TitleFontSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant6TitleFontSize {
     fn from(value: f64) -> Self {
@@ -69379,11 +64447,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant6TitleFontSize {
 pub enum LegendVariant6TitleFontStyle {
     Variant0(::std::string::String),
     Variant1(StringValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant6TitleFontStyle {
-    fn from(value: &LegendVariant6TitleFontStyle) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<StringValue> for LegendVariant6TitleFontStyle {
     fn from(value: StringValue) -> Self {
@@ -69437,11 +64500,6 @@ pub enum LegendVariant6TitleFontWeight {
     Variant0(MyEnum),
     Variant1(FontWeightValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant6TitleFontWeight {
-    fn from(value: &LegendVariant6TitleFontWeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<MyEnum> for LegendVariant6TitleFontWeight {
     fn from(value: MyEnum) -> Self {
         Self::Variant0(value)
@@ -69474,11 +64532,6 @@ impl ::std::convert::From<FontWeightValue> for LegendVariant6TitleFontWeight {
 pub enum LegendVariant6TitleLimit {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant6TitleLimit {
-    fn from(value: &LegendVariant6TitleLimit) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant6TitleLimit {
     fn from(value: f64) -> Self {
@@ -69513,11 +64566,6 @@ pub enum LegendVariant6TitleLineHeight {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant6TitleLineHeight {
-    fn from(value: &LegendVariant6TitleLineHeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant6TitleLineHeight {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -69550,11 +64598,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant6TitleLineHeight {
 pub enum LegendVariant6TitleOpacity {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant6TitleOpacity {
-    fn from(value: &LegendVariant6TitleOpacity) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for LegendVariant6TitleOpacity {
     fn from(value: f64) -> Self {
@@ -69593,11 +64636,6 @@ impl ::std::convert::From<NumberValue> for LegendVariant6TitleOpacity {
 pub enum LegendVariant6TitleOrient {
     Variant0(LegendVariant6TitleOrientVariant0),
     Variant1(OrientValue),
-}
-impl ::std::convert::From<&Self> for LegendVariant6TitleOrient {
-    fn from(value: &LegendVariant6TitleOrient) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<LegendVariant6TitleOrientVariant0> for LegendVariant6TitleOrient {
     fn from(value: LegendVariant6TitleOrientVariant0) -> Self {
@@ -69645,11 +64683,6 @@ pub enum LegendVariant6TitleOrientVariant0 {
     Top,
     #[serde(rename = "bottom")]
     Bottom,
-}
-impl ::std::convert::From<&Self> for LegendVariant6TitleOrientVariant0 {
-    fn from(value: &LegendVariant6TitleOrientVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant6TitleOrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -69718,11 +64751,6 @@ pub enum LegendVariant6TitlePadding {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for LegendVariant6TitlePadding {
-    fn from(value: &LegendVariant6TitlePadding) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for LegendVariant6TitlePadding {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -69763,11 +64791,6 @@ pub enum LegendVariant6Type {
     Gradient,
     #[serde(rename = "symbol")]
     Symbol,
-}
-impl ::std::convert::From<&Self> for LegendVariant6Type {
-    fn from(value: &LegendVariant6Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LegendVariant6Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -69865,11 +64888,6 @@ pub struct LinearGradient {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub y2: ::std::option::Option<f64>,
 }
-impl ::std::convert::From<&LinearGradient> for LinearGradient {
-    fn from(value: &LinearGradient) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`LinearGradientGradient`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -69897,11 +64915,6 @@ impl ::std::convert::From<&LinearGradient> for LinearGradient {
 pub enum LinearGradientGradient {
     #[serde(rename = "linear")]
     Linear,
-}
-impl ::std::convert::From<&Self> for LinearGradientGradient {
-    fn from(value: &LinearGradientGradient) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LinearGradientGradient {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -70091,11 +65104,6 @@ pub struct LinkpathTransform {
     #[serde(rename = "type")]
     pub type_: LinkpathTransformType,
 }
-impl ::std::convert::From<&LinkpathTransform> for LinkpathTransform {
-    fn from(value: &LinkpathTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`LinkpathTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -70119,11 +65127,6 @@ impl ::std::convert::From<&LinkpathTransform> for LinkpathTransform {
 pub enum LinkpathTransformAs {
     String(::std::string::String),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for LinkpathTransformAs {
-    fn from(value: &LinkpathTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for LinkpathTransformAs {
     fn default() -> Self {
@@ -70162,11 +65165,6 @@ impl ::std::convert::From<SignalRef> for LinkpathTransformAs {
 pub enum LinkpathTransformOrient {
     Variant0(LinkpathTransformOrientVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for LinkpathTransformOrient {
-    fn from(value: &LinkpathTransformOrient) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for LinkpathTransformOrient {
     fn default() -> Self {
@@ -70216,11 +65214,6 @@ pub enum LinkpathTransformOrientVariant0 {
     Vertical,
     #[serde(rename = "radial")]
     Radial,
-}
-impl ::std::convert::From<&Self> for LinkpathTransformOrientVariant0 {
-    fn from(value: &LinkpathTransformOrientVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LinkpathTransformOrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -70294,11 +65287,6 @@ pub enum LinkpathTransformShape {
     Variant0(LinkpathTransformShapeVariant0),
     Variant1(SignalRef),
 }
-impl ::std::convert::From<&Self> for LinkpathTransformShape {
-    fn from(value: &LinkpathTransformShape) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for LinkpathTransformShape {
     fn default() -> Self {
         LinkpathTransformShape::Variant0(LinkpathTransformShapeVariant0::Line)
@@ -70353,11 +65341,6 @@ pub enum LinkpathTransformShapeVariant0 {
     Diagonal,
     #[serde(rename = "orthogonal")]
     Orthogonal,
-}
-impl ::std::convert::From<&Self> for LinkpathTransformShapeVariant0 {
-    fn from(value: &LinkpathTransformShapeVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LinkpathTransformShapeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -70433,11 +65416,6 @@ pub enum LinkpathTransformSourceX {
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for LinkpathTransformSourceX {
-    fn from(value: &LinkpathTransformSourceX) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for LinkpathTransformSourceX {
     fn default() -> Self {
         LinkpathTransformSourceX::ScaleField(ScaleField(StringOrSignal::String(
@@ -70487,11 +65465,6 @@ pub enum LinkpathTransformSourceY {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for LinkpathTransformSourceY {
-    fn from(value: &LinkpathTransformSourceY) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for LinkpathTransformSourceY {
     fn default() -> Self {
@@ -70543,11 +65516,6 @@ pub enum LinkpathTransformTargetX {
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for LinkpathTransformTargetX {
-    fn from(value: &LinkpathTransformTargetX) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for LinkpathTransformTargetX {
     fn default() -> Self {
         LinkpathTransformTargetX::ScaleField(ScaleField(StringOrSignal::String(
@@ -70598,11 +65566,6 @@ pub enum LinkpathTransformTargetY {
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for LinkpathTransformTargetY {
-    fn from(value: &LinkpathTransformTargetY) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for LinkpathTransformTargetY {
     fn default() -> Self {
         LinkpathTransformTargetY::ScaleField(ScaleField(StringOrSignal::String(
@@ -70652,11 +65615,6 @@ impl ::std::convert::From<Expr> for LinkpathTransformTargetY {
 pub enum LinkpathTransformType {
     #[serde(rename = "linkpath")]
     Linkpath,
-}
-impl ::std::convert::From<&Self> for LinkpathTransformType {
-    fn from(value: &LinkpathTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LinkpathTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -70730,11 +65688,6 @@ pub enum Listener {
     SignalRef(SignalRef),
     Object { scale: ::std::string::String },
     Stream(Stream),
-}
-impl ::std::convert::From<&Self> for Listener {
-    fn from(value: &Listener) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<SignalRef> for Listener {
     fn from(value: SignalRef) -> Self {
@@ -70872,11 +65825,6 @@ pub struct LoessTransform {
     pub x: LoessTransformX,
     pub y: LoessTransformY,
 }
-impl ::std::convert::From<&LoessTransform> for LoessTransform {
-    fn from(value: &LoessTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`LoessTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -70909,11 +65857,6 @@ impl ::std::convert::From<&LoessTransform> for LoessTransform {
 pub enum LoessTransformAs {
     Array(::std::vec::Vec<LoessTransformAsArrayItem>),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for LoessTransformAs {
-    fn from(value: &LoessTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<LoessTransformAsArrayItem>> for LoessTransformAs {
     fn from(value: ::std::vec::Vec<LoessTransformAsArrayItem>) -> Self {
@@ -70948,11 +65891,6 @@ pub enum LoessTransformAsArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for LoessTransformAsArrayItem {
-    fn from(value: &LoessTransformAsArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for LoessTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -70981,11 +65919,6 @@ impl ::std::convert::From<SignalRef> for LoessTransformAsArrayItem {
 pub enum LoessTransformBandwidth {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for LoessTransformBandwidth {
-    fn from(value: &LoessTransformBandwidth) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for LoessTransformBandwidth {
     fn default() -> Self {
@@ -71038,11 +65971,6 @@ pub enum LoessTransformGroupby {
     Array(::std::vec::Vec<LoessTransformGroupbyArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for LoessTransformGroupby {
-    fn from(value: &LoessTransformGroupby) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<LoessTransformGroupbyArrayItem>>
     for LoessTransformGroupby
 {
@@ -71081,11 +66009,6 @@ pub enum LoessTransformGroupbyArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for LoessTransformGroupbyArrayItem {
-    fn from(value: &LoessTransformGroupbyArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for LoessTransformGroupbyArrayItem {
     fn from(value: ScaleField) -> Self {
@@ -71129,11 +66052,6 @@ impl ::std::convert::From<Expr> for LoessTransformGroupbyArrayItem {
 pub enum LoessTransformType {
     #[serde(rename = "loess")]
     Loess,
-}
-impl ::std::convert::From<&Self> for LoessTransformType {
-    fn from(value: &LoessTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LoessTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -71200,11 +66118,6 @@ pub enum LoessTransformX {
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for LoessTransformX {
-    fn from(value: &LoessTransformX) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleField> for LoessTransformX {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
@@ -71246,11 +66159,6 @@ pub enum LoessTransformY {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for LoessTransformY {
-    fn from(value: &LoessTransformY) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for LoessTransformY {
     fn from(value: ScaleField) -> Self {
@@ -71398,11 +66306,6 @@ pub struct LookupTransform {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub values: ::std::option::Option<LookupTransformValues>,
 }
-impl ::std::convert::From<&LookupTransform> for LookupTransform {
-    fn from(value: &LookupTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`LookupTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -71436,11 +66339,6 @@ pub enum LookupTransformAs {
     Array(::std::vec::Vec<LookupTransformAsArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for LookupTransformAs {
-    fn from(value: &LookupTransformAs) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<LookupTransformAsArrayItem>> for LookupTransformAs {
     fn from(value: ::std::vec::Vec<LookupTransformAsArrayItem>) -> Self {
         Self::Array(value)
@@ -71473,11 +66371,6 @@ impl ::std::convert::From<SignalRef> for LookupTransformAs {
 pub enum LookupTransformAsArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for LookupTransformAsArrayItem {
-    fn from(value: &LookupTransformAsArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<SignalRef> for LookupTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
@@ -71520,11 +66413,6 @@ pub enum LookupTransformFields {
     Array(::std::vec::Vec<LookupTransformFieldsArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for LookupTransformFields {
-    fn from(value: &LookupTransformFields) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<LookupTransformFieldsArrayItem>>
     for LookupTransformFields
 {
@@ -71563,11 +66451,6 @@ pub enum LookupTransformFieldsArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for LookupTransformFieldsArrayItem {
-    fn from(value: &LookupTransformFieldsArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for LookupTransformFieldsArrayItem {
     fn from(value: ScaleField) -> Self {
@@ -71611,11 +66494,6 @@ pub enum LookupTransformKey {
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for LookupTransformKey {
-    fn from(value: &LookupTransformKey) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleField> for LookupTransformKey {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
@@ -71658,11 +66536,6 @@ impl ::std::convert::From<Expr> for LookupTransformKey {
 pub enum LookupTransformType {
     #[serde(rename = "lookup")]
     Lookup,
-}
-impl ::std::convert::From<&Self> for LookupTransformType {
-    fn from(value: &LookupTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LookupTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -71738,11 +66611,6 @@ pub enum LookupTransformValues {
     Array(::std::vec::Vec<LookupTransformValuesArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for LookupTransformValues {
-    fn from(value: &LookupTransformValues) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<LookupTransformValuesArrayItem>>
     for LookupTransformValues
 {
@@ -71781,11 +66649,6 @@ pub enum LookupTransformValuesArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for LookupTransformValuesArrayItem {
-    fn from(value: &LookupTransformValuesArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for LookupTransformValuesArrayItem {
     fn from(value: ScaleField) -> Self {
@@ -71888,11 +66751,6 @@ pub struct Mark {
     #[serde(rename = "type")]
     pub type_: Marktype,
 }
-impl ::std::convert::From<&Mark> for Mark {
-    fn from(value: &Mark) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MarkGroup`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -71984,11 +66842,6 @@ pub struct MarkGroup {
     #[serde(default, skip_serializing_if = "::serde_json::Map::is_empty")]
     pub usermeta: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
 }
-impl ::std::convert::From<&MarkGroup> for MarkGroup {
-    fn from(value: &MarkGroup) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`MarkGroupFrom`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -72011,11 +66864,6 @@ impl ::std::convert::From<&MarkGroup> for MarkGroup {
 pub enum MarkGroupFrom {
     From(From),
     Facet(Facet),
-}
-impl ::std::convert::From<&Self> for MarkGroupFrom {
-    fn from(value: &MarkGroupFrom) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<From> for MarkGroupFrom {
     fn from(value: From) -> Self {
@@ -72049,11 +66897,6 @@ impl ::std::convert::From<Facet> for MarkGroupFrom {
 pub enum MarkGroupMarksItem {
     Group(MarkGroup),
     Visual(MarkVisual),
-}
-impl ::std::convert::From<&Self> for MarkGroupMarksItem {
-    fn from(value: &MarkGroupMarksItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<MarkGroup> for MarkGroupMarksItem {
     fn from(value: MarkGroup) -> Self {
@@ -72093,11 +66936,6 @@ impl ::std::convert::From<MarkVisual> for MarkGroupMarksItem {
 pub enum MarkGroupType {
     #[serde(rename = "group")]
     Group,
-}
-impl ::std::convert::From<&Self> for MarkGroupType {
-    fn from(value: &MarkGroupType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for MarkGroupType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -72197,11 +67035,6 @@ pub struct MarkVisual {
     #[serde(rename = "type")]
     pub type_: Marktype,
 }
-impl ::std::convert::From<&MarkVisual> for MarkVisual {
-    fn from(value: &MarkVisual) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`Markclip`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -72247,11 +67080,6 @@ pub enum Markclip {
     Variant1 { path: StringOrSignal },
     Variant2 { sphere: StringOrSignal },
 }
-impl ::std::convert::From<&Self> for Markclip {
-    fn from(value: &Markclip) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<BooleanOrSignal> for Markclip {
     fn from(value: BooleanOrSignal) -> Self {
         Self::Variant0(value)
@@ -72289,11 +67117,6 @@ impl ::std::ops::Deref for Marktype {
 impl ::std::convert::From<Marktype> for ::std::string::String {
     fn from(value: Marktype) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&Marktype> for Marktype {
-    fn from(value: &Marktype) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<::std::string::String> for Marktype {
@@ -72381,11 +67204,6 @@ pub struct NestTransform {
     #[serde(rename = "type")]
     pub type_: NestTransformType,
 }
-impl ::std::convert::From<&NestTransform> for NestTransform {
-    fn from(value: &NestTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`NestTransformGenerate`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -72408,11 +67226,6 @@ impl ::std::convert::From<&NestTransform> for NestTransform {
 pub enum NestTransformGenerate {
     Boolean(bool),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for NestTransformGenerate {
-    fn from(value: &NestTransformGenerate) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<bool> for NestTransformGenerate {
     fn from(value: bool) -> Self {
@@ -72460,11 +67273,6 @@ pub enum NestTransformKeys {
     Array(::std::vec::Vec<NestTransformKeysArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for NestTransformKeys {
-    fn from(value: &NestTransformKeys) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<NestTransformKeysArrayItem>> for NestTransformKeys {
     fn from(value: ::std::vec::Vec<NestTransformKeysArrayItem>) -> Self {
         Self::Array(value)
@@ -72501,11 +67309,6 @@ pub enum NestTransformKeysArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for NestTransformKeysArrayItem {
-    fn from(value: &NestTransformKeysArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for NestTransformKeysArrayItem {
     fn from(value: ScaleField) -> Self {
@@ -72549,11 +67352,6 @@ impl ::std::convert::From<Expr> for NestTransformKeysArrayItem {
 pub enum NestTransformType {
     #[serde(rename = "nest")]
     Nest,
-}
-impl ::std::convert::From<&Self> for NestTransformType {
-    fn from(value: &NestTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for NestTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -72672,11 +67470,6 @@ pub struct NumberModifiers {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub scale: ::std::option::Option<Field>,
 }
-impl ::std::convert::From<&NumberModifiers> for NumberModifiers {
-    fn from(value: &NumberModifiers) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for NumberModifiers {
     fn default() -> Self {
         Self {
@@ -72712,11 +67505,6 @@ impl ::std::default::Default for NumberModifiers {
 pub enum NumberModifiersBand {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for NumberModifiersBand {
-    fn from(value: &NumberModifiersBand) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for NumberModifiersBand {
     type Err = self::error::ConversionError;
@@ -72793,11 +67581,6 @@ pub enum NumberModifiersExponent {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for NumberModifiersExponent {
-    fn from(value: &NumberModifiersExponent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for NumberModifiersExponent {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -72830,11 +67613,6 @@ impl ::std::convert::From<NumberValue> for NumberModifiersExponent {
 pub enum NumberModifiersMult {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for NumberModifiersMult {
-    fn from(value: &NumberModifiersMult) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for NumberModifiersMult {
     fn from(value: f64) -> Self {
@@ -72869,11 +67647,6 @@ pub enum NumberModifiersOffset {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for NumberModifiersOffset {
-    fn from(value: &NumberModifiersOffset) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for NumberModifiersOffset {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -72906,11 +67679,6 @@ impl ::std::convert::From<NumberValue> for NumberModifiersOffset {
 pub enum NumberOrSignal {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for NumberOrSignal {
-    fn from(value: &NumberOrSignal) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for NumberOrSignal {
     fn from(value: f64) -> Self {
@@ -73105,11 +67873,6 @@ pub enum NumberValue {
     Variant0(::std::vec::Vec<NumberValueVariant0Item>),
     Variant1(NumberValueVariant1),
 }
-impl ::std::convert::From<&Self> for NumberValue {
-    fn from(value: &NumberValue) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<NumberValueVariant0Item>> for NumberValue {
     fn from(value: ::std::vec::Vec<NumberValueVariant0Item>) -> Self {
         Self::Variant0(value)
@@ -73231,11 +67994,6 @@ pub enum NumberValueVariant0Item {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
-}
-impl ::std::convert::From<&Self> for NumberValueVariant0Item {
-    fn from(value: &NumberValueVariant0Item) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<NumberValueVariant0ItemVariant0> for NumberValueVariant0Item {
     fn from(value: NumberValueVariant0ItemVariant0) -> Self {
@@ -73474,11 +68232,6 @@ pub enum NumberValueVariant0ItemVariant0 {
         test: ::std::option::Option<::std::string::String>,
     },
 }
-impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant0 {
-    fn from(value: &NumberValueVariant0ItemVariant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`NumberValueVariant0ItemVariant0Variant0Band`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -73501,11 +68254,6 @@ impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant0 {
 pub enum NumberValueVariant0ItemVariant0Variant0Band {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant0Variant0Band {
-    fn from(value: &NumberValueVariant0ItemVariant0Variant0Band) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for NumberValueVariant0ItemVariant0Variant0Band {
     type Err = self::error::ConversionError;
@@ -73586,11 +68334,6 @@ pub enum NumberValueVariant0ItemVariant0Variant0Exponent {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant0Variant0Exponent {
-    fn from(value: &NumberValueVariant0ItemVariant0Variant0Exponent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for NumberValueVariant0ItemVariant0Variant0Exponent {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -73623,11 +68366,6 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant0Varian
 pub enum NumberValueVariant0ItemVariant0Variant0Mult {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant0Variant0Mult {
-    fn from(value: &NumberValueVariant0ItemVariant0Variant0Mult) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for NumberValueVariant0ItemVariant0Variant0Mult {
     fn from(value: f64) -> Self {
@@ -73662,11 +68400,6 @@ pub enum NumberValueVariant0ItemVariant0Variant0Offset {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant0Variant0Offset {
-    fn from(value: &NumberValueVariant0ItemVariant0Variant0Offset) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for NumberValueVariant0ItemVariant0Variant0Offset {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -73699,11 +68432,6 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant0Varian
 pub enum NumberValueVariant0ItemVariant0Variant1Band {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant0Variant1Band {
-    fn from(value: &NumberValueVariant0ItemVariant0Variant1Band) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for NumberValueVariant0ItemVariant0Variant1Band {
     type Err = self::error::ConversionError;
@@ -73784,11 +68512,6 @@ pub enum NumberValueVariant0ItemVariant0Variant1Exponent {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant0Variant1Exponent {
-    fn from(value: &NumberValueVariant0ItemVariant0Variant1Exponent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for NumberValueVariant0ItemVariant0Variant1Exponent {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -73821,11 +68544,6 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant0Varian
 pub enum NumberValueVariant0ItemVariant0Variant1Mult {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant0Variant1Mult {
-    fn from(value: &NumberValueVariant0ItemVariant0Variant1Mult) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for NumberValueVariant0ItemVariant0Variant1Mult {
     fn from(value: f64) -> Self {
@@ -73860,11 +68578,6 @@ pub enum NumberValueVariant0ItemVariant0Variant1Offset {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant0Variant1Offset {
-    fn from(value: &NumberValueVariant0ItemVariant0Variant1Offset) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for NumberValueVariant0ItemVariant0Variant1Offset {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -73897,11 +68610,6 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant0Varian
 pub enum NumberValueVariant0ItemVariant0Variant2Band {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant0Variant2Band {
-    fn from(value: &NumberValueVariant0ItemVariant0Variant2Band) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for NumberValueVariant0ItemVariant0Variant2Band {
     type Err = self::error::ConversionError;
@@ -73982,11 +68690,6 @@ pub enum NumberValueVariant0ItemVariant0Variant2Exponent {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant0Variant2Exponent {
-    fn from(value: &NumberValueVariant0ItemVariant0Variant2Exponent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for NumberValueVariant0ItemVariant0Variant2Exponent {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -74019,11 +68722,6 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant0Varian
 pub enum NumberValueVariant0ItemVariant0Variant2Mult {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant0Variant2Mult {
-    fn from(value: &NumberValueVariant0ItemVariant0Variant2Mult) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for NumberValueVariant0ItemVariant0Variant2Mult {
     fn from(value: f64) -> Self {
@@ -74058,11 +68756,6 @@ pub enum NumberValueVariant0ItemVariant0Variant2Offset {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant0Variant2Offset {
-    fn from(value: &NumberValueVariant0ItemVariant0Variant2Offset) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for NumberValueVariant0ItemVariant0Variant2Offset {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -74095,11 +68788,6 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant0Varian
 pub enum NumberValueVariant0ItemVariant0Variant3Band {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant0Variant3Band {
-    fn from(value: &NumberValueVariant0ItemVariant0Variant3Band) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for NumberValueVariant0ItemVariant0Variant3Band {
     type Err = self::error::ConversionError;
@@ -74180,11 +68868,6 @@ pub enum NumberValueVariant0ItemVariant0Variant3Exponent {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant0Variant3Exponent {
-    fn from(value: &NumberValueVariant0ItemVariant0Variant3Exponent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for NumberValueVariant0ItemVariant0Variant3Exponent {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -74217,11 +68900,6 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant0Varian
 pub enum NumberValueVariant0ItemVariant0Variant3Mult {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant0Variant3Mult {
-    fn from(value: &NumberValueVariant0ItemVariant0Variant3Mult) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for NumberValueVariant0ItemVariant0Variant3Mult {
     fn from(value: f64) -> Self {
@@ -74256,11 +68934,6 @@ pub enum NumberValueVariant0ItemVariant0Variant3Offset {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant0Variant3Offset {
-    fn from(value: &NumberValueVariant0ItemVariant0Variant3Offset) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for NumberValueVariant0ItemVariant0Variant3Offset {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -74293,11 +68966,6 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant0Varian
 pub enum NumberValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant0Variant3Range {
-    fn from(value: &NumberValueVariant0ItemVariant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for NumberValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -74511,11 +69179,6 @@ impl ::std::convert::From<bool> for NumberValueVariant0ItemVariant0Variant3Range
 )]
 #[serde(deny_unknown_fields)]
 pub enum NumberValueVariant0ItemVariant1 {}
-impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant1 {
-    fn from(value: &NumberValueVariant0ItemVariant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`NumberValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -74672,11 +69335,6 @@ impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum NumberValueVariant0ItemVariant2 {}
-impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant2 {
-    fn from(value: &NumberValueVariant0ItemVariant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`NumberValueVariant0ItemVariant3Exponent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -74699,11 +69357,6 @@ impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant2 {
 pub enum NumberValueVariant0ItemVariant3Exponent {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant3Exponent {
-    fn from(value: &NumberValueVariant0ItemVariant3Exponent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for NumberValueVariant0ItemVariant3Exponent {
     fn from(value: f64) -> Self {
@@ -74738,11 +69391,6 @@ pub enum NumberValueVariant0ItemVariant3Mult {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant3Mult {
-    fn from(value: &NumberValueVariant0ItemVariant3Mult) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for NumberValueVariant0ItemVariant3Mult {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -74775,11 +69423,6 @@ impl ::std::convert::From<NumberValue> for NumberValueVariant0ItemVariant3Mult {
 pub enum NumberValueVariant0ItemVariant3Offset {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for NumberValueVariant0ItemVariant3Offset {
-    fn from(value: &NumberValueVariant0ItemVariant3Offset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for NumberValueVariant0ItemVariant3Offset {
     fn from(value: f64) -> Self {
@@ -74893,11 +69536,6 @@ pub enum NumberValueVariant1 {
         #[serde(default)]
         round: bool,
     },
-}
-impl ::std::convert::From<&Self> for NumberValueVariant1 {
-    fn from(value: &NumberValueVariant1) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<NumberValueVariant1Variant0> for NumberValueVariant1 {
     fn from(value: NumberValueVariant1Variant0) -> Self {
@@ -75125,11 +69763,6 @@ pub enum NumberValueVariant1Variant0 {
         scale: ::std::option::Option<Field>,
     },
 }
-impl ::std::convert::From<&Self> for NumberValueVariant1Variant0 {
-    fn from(value: &NumberValueVariant1Variant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`NumberValueVariant1Variant0Variant0Band`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -75152,11 +69785,6 @@ impl ::std::convert::From<&Self> for NumberValueVariant1Variant0 {
 pub enum NumberValueVariant1Variant0Variant0Band {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for NumberValueVariant1Variant0Variant0Band {
-    fn from(value: &NumberValueVariant1Variant0Variant0Band) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for NumberValueVariant1Variant0Variant0Band {
     type Err = self::error::ConversionError;
@@ -75233,11 +69861,6 @@ pub enum NumberValueVariant1Variant0Variant0Exponent {
     Variant0(f64),
     Variant1(::std::boxed::Box<NumberValue>),
 }
-impl ::std::convert::From<&Self> for NumberValueVariant1Variant0Variant0Exponent {
-    fn from(value: &NumberValueVariant1Variant0Variant0Exponent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for NumberValueVariant1Variant0Variant0Exponent {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -75272,11 +69895,6 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>>
 pub enum NumberValueVariant1Variant0Variant0Mult {
     Variant0(f64),
     Variant1(::std::boxed::Box<NumberValue>),
-}
-impl ::std::convert::From<&Self> for NumberValueVariant1Variant0Variant0Mult {
-    fn from(value: &NumberValueVariant1Variant0Variant0Mult) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for NumberValueVariant1Variant0Variant0Mult {
     fn from(value: f64) -> Self {
@@ -75313,11 +69931,6 @@ pub enum NumberValueVariant1Variant0Variant0Offset {
     Variant0(f64),
     Variant1(::std::boxed::Box<NumberValue>),
 }
-impl ::std::convert::From<&Self> for NumberValueVariant1Variant0Variant0Offset {
-    fn from(value: &NumberValueVariant1Variant0Variant0Offset) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for NumberValueVariant1Variant0Variant0Offset {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -75352,11 +69965,6 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>>
 pub enum NumberValueVariant1Variant0Variant1Band {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for NumberValueVariant1Variant0Variant1Band {
-    fn from(value: &NumberValueVariant1Variant0Variant1Band) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for NumberValueVariant1Variant0Variant1Band {
     type Err = self::error::ConversionError;
@@ -75433,11 +70041,6 @@ pub enum NumberValueVariant1Variant0Variant1Exponent {
     Variant0(f64),
     Variant1(::std::boxed::Box<NumberValue>),
 }
-impl ::std::convert::From<&Self> for NumberValueVariant1Variant0Variant1Exponent {
-    fn from(value: &NumberValueVariant1Variant0Variant1Exponent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for NumberValueVariant1Variant0Variant1Exponent {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -75472,11 +70075,6 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>>
 pub enum NumberValueVariant1Variant0Variant1Mult {
     Variant0(f64),
     Variant1(::std::boxed::Box<NumberValue>),
-}
-impl ::std::convert::From<&Self> for NumberValueVariant1Variant0Variant1Mult {
-    fn from(value: &NumberValueVariant1Variant0Variant1Mult) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for NumberValueVariant1Variant0Variant1Mult {
     fn from(value: f64) -> Self {
@@ -75513,11 +70111,6 @@ pub enum NumberValueVariant1Variant0Variant1Offset {
     Variant0(f64),
     Variant1(::std::boxed::Box<NumberValue>),
 }
-impl ::std::convert::From<&Self> for NumberValueVariant1Variant0Variant1Offset {
-    fn from(value: &NumberValueVariant1Variant0Variant1Offset) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for NumberValueVariant1Variant0Variant1Offset {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -75552,11 +70145,6 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>>
 pub enum NumberValueVariant1Variant0Variant2Band {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for NumberValueVariant1Variant0Variant2Band {
-    fn from(value: &NumberValueVariant1Variant0Variant2Band) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for NumberValueVariant1Variant0Variant2Band {
     type Err = self::error::ConversionError;
@@ -75633,11 +70221,6 @@ pub enum NumberValueVariant1Variant0Variant2Exponent {
     Variant0(f64),
     Variant1(::std::boxed::Box<NumberValue>),
 }
-impl ::std::convert::From<&Self> for NumberValueVariant1Variant0Variant2Exponent {
-    fn from(value: &NumberValueVariant1Variant0Variant2Exponent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for NumberValueVariant1Variant0Variant2Exponent {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -75672,11 +70255,6 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>>
 pub enum NumberValueVariant1Variant0Variant2Mult {
     Variant0(f64),
     Variant1(::std::boxed::Box<NumberValue>),
-}
-impl ::std::convert::From<&Self> for NumberValueVariant1Variant0Variant2Mult {
-    fn from(value: &NumberValueVariant1Variant0Variant2Mult) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for NumberValueVariant1Variant0Variant2Mult {
     fn from(value: f64) -> Self {
@@ -75713,11 +70291,6 @@ pub enum NumberValueVariant1Variant0Variant2Offset {
     Variant0(f64),
     Variant1(::std::boxed::Box<NumberValue>),
 }
-impl ::std::convert::From<&Self> for NumberValueVariant1Variant0Variant2Offset {
-    fn from(value: &NumberValueVariant1Variant0Variant2Offset) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for NumberValueVariant1Variant0Variant2Offset {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -75752,11 +70325,6 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>>
 pub enum NumberValueVariant1Variant0Variant3Band {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for NumberValueVariant1Variant0Variant3Band {
-    fn from(value: &NumberValueVariant1Variant0Variant3Band) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for NumberValueVariant1Variant0Variant3Band {
     type Err = self::error::ConversionError;
@@ -75833,11 +70401,6 @@ pub enum NumberValueVariant1Variant0Variant3Exponent {
     Variant0(f64),
     Variant1(::std::boxed::Box<NumberValue>),
 }
-impl ::std::convert::From<&Self> for NumberValueVariant1Variant0Variant3Exponent {
-    fn from(value: &NumberValueVariant1Variant0Variant3Exponent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for NumberValueVariant1Variant0Variant3Exponent {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -75872,11 +70435,6 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>>
 pub enum NumberValueVariant1Variant0Variant3Mult {
     Variant0(f64),
     Variant1(::std::boxed::Box<NumberValue>),
-}
-impl ::std::convert::From<&Self> for NumberValueVariant1Variant0Variant3Mult {
-    fn from(value: &NumberValueVariant1Variant0Variant3Mult) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for NumberValueVariant1Variant0Variant3Mult {
     fn from(value: f64) -> Self {
@@ -75913,11 +70471,6 @@ pub enum NumberValueVariant1Variant0Variant3Offset {
     Variant0(f64),
     Variant1(::std::boxed::Box<NumberValue>),
 }
-impl ::std::convert::From<&Self> for NumberValueVariant1Variant0Variant3Offset {
-    fn from(value: &NumberValueVariant1Variant0Variant3Offset) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for NumberValueVariant1Variant0Variant3Offset {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -75952,11 +70505,6 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>>
 pub enum NumberValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for NumberValueVariant1Variant0Variant3Range {
-    fn from(value: &NumberValueVariant1Variant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for NumberValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -76163,11 +70711,6 @@ impl ::std::convert::From<bool> for NumberValueVariant1Variant0Variant3Range {
 )]
 #[serde(deny_unknown_fields)]
 pub enum NumberValueVariant1Variant1 {}
-impl ::std::convert::From<&Self> for NumberValueVariant1Variant1 {
-    fn from(value: &NumberValueVariant1Variant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`NumberValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -76321,11 +70864,6 @@ impl ::std::convert::From<&Self> for NumberValueVariant1Variant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum NumberValueVariant1Variant2 {}
-impl ::std::convert::From<&Self> for NumberValueVariant1Variant2 {
-    fn from(value: &NumberValueVariant1Variant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`NumberValueVariant1Variant3Exponent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -76348,11 +70886,6 @@ impl ::std::convert::From<&Self> for NumberValueVariant1Variant2 {
 pub enum NumberValueVariant1Variant3Exponent {
     Variant0(f64),
     Variant1(::std::boxed::Box<NumberValue>),
-}
-impl ::std::convert::From<&Self> for NumberValueVariant1Variant3Exponent {
-    fn from(value: &NumberValueVariant1Variant3Exponent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for NumberValueVariant1Variant3Exponent {
     fn from(value: f64) -> Self {
@@ -76387,11 +70920,6 @@ pub enum NumberValueVariant1Variant3Mult {
     Variant0(f64),
     Variant1(::std::boxed::Box<NumberValue>),
 }
-impl ::std::convert::From<&Self> for NumberValueVariant1Variant3Mult {
-    fn from(value: &NumberValueVariant1Variant3Mult) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for NumberValueVariant1Variant3Mult {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -76424,11 +70952,6 @@ impl ::std::convert::From<::std::boxed::Box<NumberValue>> for NumberValueVariant
 pub enum NumberValueVariant1Variant3Offset {
     Variant0(f64),
     Variant1(::std::boxed::Box<NumberValue>),
-}
-impl ::std::convert::From<&Self> for NumberValueVariant1Variant3Offset {
-    fn from(value: &NumberValueVariant1Variant3Offset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for NumberValueVariant1Variant3Offset {
     fn from(value: f64) -> Self {
@@ -76541,11 +71064,6 @@ impl ::std::convert::From<OnEvents> for ::std::vec::Vec<OnEventsItem> {
         value.0
     }
 }
-impl ::std::convert::From<&OnEvents> for OnEvents {
-    fn from(value: &OnEvents) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<OnEventsItem>> for OnEvents {
     fn from(value: ::std::vec::Vec<OnEventsItem>) -> Self {
         Self(value)
@@ -76651,11 +71169,6 @@ pub enum OnEventsItem {
         update: OnEventsItemVariant1Update,
     },
 }
-impl ::std::convert::From<&Self> for OnEventsItem {
-    fn from(value: &OnEventsItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`OnEventsItemVariant0Events`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -76686,11 +71199,6 @@ pub enum OnEventsItemVariant0Events {
     Selector(Selector),
     Listener(Listener),
     Array(::std::vec::Vec<Listener>),
-}
-impl ::std::convert::From<&Self> for OnEventsItemVariant0Events {
-    fn from(value: &OnEventsItemVariant0Events) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<Selector> for OnEventsItemVariant0Events {
     fn from(value: Selector) -> Self {
@@ -76737,11 +71245,6 @@ pub enum OnEventsItemVariant1Events {
     Selector(Selector),
     Listener(Listener),
     Array(::std::vec::Vec<Listener>),
-}
-impl ::std::convert::From<&Self> for OnEventsItemVariant1Events {
-    fn from(value: &OnEventsItemVariant1Events) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<Selector> for OnEventsItemVariant1Events {
     fn from(value: Selector) -> Self {
@@ -76794,11 +71297,6 @@ pub enum OnEventsItemVariant1Update {
     Expr(Expr),
     SignalRef(SignalRef),
     Object { value: ::serde_json::Value },
-}
-impl ::std::convert::From<&Self> for OnEventsItemVariant1Update {
-    fn from(value: &OnEventsItemVariant1Update) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ExprString> for OnEventsItemVariant1Update {
     fn from(value: ExprString) -> Self {
@@ -76857,11 +71355,6 @@ impl ::std::convert::From<OnMarkTrigger> for ::std::vec::Vec<OnMarkTriggerItem> 
         value.0
     }
 }
-impl ::std::convert::From<&OnMarkTrigger> for OnMarkTrigger {
-    fn from(value: &OnMarkTrigger) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<OnMarkTriggerItem>> for OnMarkTrigger {
     fn from(value: ::std::vec::Vec<OnMarkTriggerItem>) -> Self {
         Self(value)
@@ -76900,11 +71393,6 @@ pub struct OnMarkTriggerItem {
     pub trigger: ExprString,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub values: ::std::option::Option<ExprString>,
-}
-impl ::std::convert::From<&OnMarkTriggerItem> for OnMarkTriggerItem {
-    fn from(value: &OnMarkTriggerItem) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`OnTrigger`"]
 #[doc = r""]
@@ -76962,11 +71450,6 @@ impl ::std::ops::Deref for OnTrigger {
 impl ::std::convert::From<OnTrigger> for ::std::vec::Vec<OnTriggerItem> {
     fn from(value: OnTrigger) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&OnTrigger> for OnTrigger {
-    fn from(value: &OnTrigger) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<::std::vec::Vec<OnTriggerItem>> for OnTrigger {
@@ -77030,11 +71513,6 @@ pub struct OnTriggerItem {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub values: ::std::option::Option<ExprString>,
 }
-impl ::std::convert::From<&OnTriggerItem> for OnTriggerItem {
-    fn from(value: &OnTriggerItem) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`OnTriggerItemRemove`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -77057,11 +71535,6 @@ impl ::std::convert::From<&OnTriggerItem> for OnTriggerItem {
 pub enum OnTriggerItemRemove {
     Boolean(bool),
     ExprString(ExprString),
-}
-impl ::std::convert::From<&Self> for OnTriggerItemRemove {
-    fn from(value: &OnTriggerItemRemove) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for OnTriggerItemRemove {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -77274,11 +71747,6 @@ pub enum OrientValue {
     Variant0(::std::vec::Vec<OrientValueVariant0Item>),
     Variant1(OrientValueVariant1),
 }
-impl ::std::convert::From<&Self> for OrientValue {
-    fn from(value: &OrientValue) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<OrientValueVariant0Item>> for OrientValue {
     fn from(value: ::std::vec::Vec<OrientValueVariant0Item>) -> Self {
         Self::Variant0(value)
@@ -77397,11 +71865,6 @@ pub enum OrientValueVariant0Item {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
-}
-impl ::std::convert::From<&Self> for OrientValueVariant0Item {
-    fn from(value: &OrientValueVariant0Item) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<OrientValueVariant0ItemVariant0> for OrientValueVariant0Item {
     fn from(value: OrientValueVariant0ItemVariant0) -> Self {
@@ -77550,11 +72013,6 @@ pub enum OrientValueVariant0ItemVariant0 {
         test: ::std::option::Option<::std::string::String>,
     },
 }
-impl ::std::convert::From<&Self> for OrientValueVariant0ItemVariant0 {
-    fn from(value: &OrientValueVariant0ItemVariant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`OrientValueVariant0ItemVariant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -77591,11 +72049,6 @@ pub enum OrientValueVariant0ItemVariant0Variant1Value {
     Top,
     #[serde(rename = "bottom")]
     Bottom,
-}
-impl ::std::convert::From<&Self> for OrientValueVariant0ItemVariant0Variant1Value {
-    fn from(value: &OrientValueVariant0ItemVariant0Variant1Value) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for OrientValueVariant0ItemVariant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -77667,11 +72120,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum OrientValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for OrientValueVariant0ItemVariant0Variant3Range {
-    fn from(value: &OrientValueVariant0ItemVariant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for OrientValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -77843,11 +72291,6 @@ impl ::std::convert::From<bool> for OrientValueVariant0ItemVariant0Variant3Range
 )]
 #[serde(deny_unknown_fields)]
 pub enum OrientValueVariant0ItemVariant1 {}
-impl ::std::convert::From<&Self> for OrientValueVariant0ItemVariant1 {
-    fn from(value: &OrientValueVariant0ItemVariant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`OrientValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -77962,11 +72405,6 @@ impl ::std::convert::From<&Self> for OrientValueVariant0ItemVariant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum OrientValueVariant0ItemVariant2 {}
-impl ::std::convert::From<&Self> for OrientValueVariant0ItemVariant2 {
-    fn from(value: &OrientValueVariant0ItemVariant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`OrientValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -78064,11 +72502,6 @@ pub enum OrientValueVariant1 {
     Variant1(OrientValueVariant1Variant1),
     Variant2(OrientValueVariant1Variant2),
     Variant3 { offset: ::serde_json::Value },
-}
-impl ::std::convert::From<&Self> for OrientValueVariant1 {
-    fn from(value: &OrientValueVariant1) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<OrientValueVariant1Variant0> for OrientValueVariant1 {
     fn from(value: OrientValueVariant1Variant0) -> Self {
@@ -78206,11 +72639,6 @@ pub enum OrientValueVariant1Variant0 {
         scale: ::std::option::Option<Field>,
     },
 }
-impl ::std::convert::From<&Self> for OrientValueVariant1Variant0 {
-    fn from(value: &OrientValueVariant1Variant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`OrientValueVariant1Variant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -78247,11 +72675,6 @@ pub enum OrientValueVariant1Variant0Variant1Value {
     Top,
     #[serde(rename = "bottom")]
     Bottom,
-}
-impl ::std::convert::From<&Self> for OrientValueVariant1Variant0Variant1Value {
-    fn from(value: &OrientValueVariant1Variant0Variant1Value) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for OrientValueVariant1Variant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -78319,11 +72742,6 @@ impl ::std::convert::TryFrom<::std::string::String> for OrientValueVariant1Varia
 pub enum OrientValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for OrientValueVariant1Variant0Variant3Range {
-    fn from(value: &OrientValueVariant1Variant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for OrientValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -78488,11 +72906,6 @@ impl ::std::convert::From<bool> for OrientValueVariant1Variant0Variant3Range {
 )]
 #[serde(deny_unknown_fields)]
 pub enum OrientValueVariant1Variant1 {}
-impl ::std::convert::From<&Self> for OrientValueVariant1Variant1 {
-    fn from(value: &OrientValueVariant1Variant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`OrientValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -78604,11 +73017,6 @@ impl ::std::convert::From<&Self> for OrientValueVariant1Variant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum OrientValueVariant1Variant2 {}
-impl ::std::convert::From<&Self> for OrientValueVariant1Variant2 {
-    fn from(value: &OrientValueVariant1Variant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PackTransform`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -78743,11 +73151,6 @@ pub struct PackTransform {
     #[serde(rename = "type")]
     pub type_: PackTransformType,
 }
-impl ::std::convert::From<&PackTransform> for PackTransform {
-    fn from(value: &PackTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PackTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -78789,11 +73192,6 @@ impl ::std::convert::From<&PackTransform> for PackTransform {
 pub enum PackTransformAs {
     Array([PackTransformAsArrayItem; 5usize]),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for PackTransformAs {
-    fn from(value: &PackTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for PackTransformAs {
     fn default() -> Self {
@@ -78839,11 +73237,6 @@ pub enum PackTransformAsArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for PackTransformAsArrayItem {
-    fn from(value: &PackTransformAsArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for PackTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -78875,11 +73268,6 @@ pub enum PackTransformField {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for PackTransformField {
-    fn from(value: &PackTransformField) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for PackTransformField {
     fn from(value: ScaleField) -> Self {
@@ -78919,11 +73307,6 @@ pub enum PackTransformPadding {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for PackTransformPadding {
-    fn from(value: &PackTransformPadding) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for PackTransformPadding {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -78960,11 +73343,6 @@ pub enum PackTransformRadius {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for PackTransformRadius {
-    fn from(value: &PackTransformRadius) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for PackTransformRadius {
     fn from(value: ScaleField) -> Self {
@@ -79016,11 +73394,6 @@ pub enum PackTransformSize {
     Array([PackTransformSizeArrayItem; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for PackTransformSize {
-    fn from(value: &PackTransformSize) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[PackTransformSizeArrayItem; 2usize]> for PackTransformSize {
     fn from(value: [PackTransformSizeArrayItem; 2usize]) -> Self {
         Self::Array(value)
@@ -79053,11 +73426,6 @@ impl ::std::convert::From<SignalRef> for PackTransformSize {
 pub enum PackTransformSizeArrayItem {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for PackTransformSizeArrayItem {
-    fn from(value: &PackTransformSizeArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for PackTransformSizeArrayItem {
     fn from(value: f64) -> Self {
@@ -79096,11 +73464,6 @@ impl ::std::convert::From<SignalRef> for PackTransformSizeArrayItem {
 pub enum PackTransformType {
     #[serde(rename = "pack")]
     Pack,
-}
-impl ::std::convert::From<&Self> for PackTransformType {
-    fn from(value: &PackTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PackTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -79191,11 +73554,6 @@ pub enum Padding {
     },
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for Padding {
-    fn from(value: &Padding) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for Padding {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -79238,11 +73596,6 @@ pub struct ParamField {
     )]
     pub as_: ::std::option::Option<::std::string::String>,
     pub field: ::std::string::String,
-}
-impl ::std::convert::From<&ParamField> for ParamField {
-    fn from(value: &ParamField) -> Self {
-        value.clone()
-    }
 }
 #[doc = "`PartitionTransform`"]
 #[doc = r""]
@@ -79376,11 +73729,6 @@ pub struct PartitionTransform {
     #[serde(rename = "type")]
     pub type_: PartitionTransformType,
 }
-impl ::std::convert::From<&PartitionTransform> for PartitionTransform {
-    fn from(value: &PartitionTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PartitionTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -79423,11 +73771,6 @@ impl ::std::convert::From<&PartitionTransform> for PartitionTransform {
 pub enum PartitionTransformAs {
     Array([PartitionTransformAsArrayItem; 6usize]),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for PartitionTransformAs {
-    fn from(value: &PartitionTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for PartitionTransformAs {
     fn default() -> Self {
@@ -79474,11 +73817,6 @@ pub enum PartitionTransformAsArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for PartitionTransformAsArrayItem {
-    fn from(value: &PartitionTransformAsArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for PartitionTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -79510,11 +73848,6 @@ pub enum PartitionTransformField {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for PartitionTransformField {
-    fn from(value: &PartitionTransformField) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for PartitionTransformField {
     fn from(value: ScaleField) -> Self {
@@ -79554,11 +73887,6 @@ pub enum PartitionTransformPadding {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for PartitionTransformPadding {
-    fn from(value: &PartitionTransformPadding) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for PartitionTransformPadding {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -79591,11 +73919,6 @@ impl ::std::convert::From<SignalRef> for PartitionTransformPadding {
 pub enum PartitionTransformRound {
     Boolean(bool),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for PartitionTransformRound {
-    fn from(value: &PartitionTransformRound) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<bool> for PartitionTransformRound {
     fn from(value: bool) -> Self {
@@ -79642,11 +73965,6 @@ pub enum PartitionTransformSize {
     Array([PartitionTransformSizeArrayItem; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for PartitionTransformSize {
-    fn from(value: &PartitionTransformSize) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[PartitionTransformSizeArrayItem; 2usize]> for PartitionTransformSize {
     fn from(value: [PartitionTransformSizeArrayItem; 2usize]) -> Self {
         Self::Array(value)
@@ -79679,11 +73997,6 @@ impl ::std::convert::From<SignalRef> for PartitionTransformSize {
 pub enum PartitionTransformSizeArrayItem {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for PartitionTransformSizeArrayItem {
-    fn from(value: &PartitionTransformSizeArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for PartitionTransformSizeArrayItem {
     fn from(value: f64) -> Self {
@@ -79722,11 +74035,6 @@ impl ::std::convert::From<SignalRef> for PartitionTransformSizeArrayItem {
 pub enum PartitionTransformType {
     #[serde(rename = "partition")]
     Partition,
-}
-impl ::std::convert::From<&Self> for PartitionTransformType {
-    fn from(value: &PartitionTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PartitionTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -79882,11 +74190,6 @@ pub struct PieTransform {
     #[serde(rename = "type")]
     pub type_: PieTransformType,
 }
-impl ::std::convert::From<&PieTransform> for PieTransform {
-    fn from(value: &PieTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PieTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -79925,11 +74228,6 @@ impl ::std::convert::From<&PieTransform> for PieTransform {
 pub enum PieTransformAs {
     Array([PieTransformAsArrayItem; 2usize]),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for PieTransformAs {
-    fn from(value: &PieTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for PieTransformAs {
     fn default() -> Self {
@@ -79972,11 +74270,6 @@ pub enum PieTransformAsArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for PieTransformAsArrayItem {
-    fn from(value: &PieTransformAsArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for PieTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -80005,11 +74298,6 @@ impl ::std::convert::From<SignalRef> for PieTransformAsArrayItem {
 pub enum PieTransformEndAngle {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for PieTransformEndAngle {
-    fn from(value: &PieTransformEndAngle) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for PieTransformEndAngle {
     fn default() -> Self {
@@ -80053,11 +74341,6 @@ pub enum PieTransformField {
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for PieTransformField {
-    fn from(value: &PieTransformField) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleField> for PieTransformField {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
@@ -80096,11 +74379,6 @@ pub enum PieTransformSort {
     Boolean(bool),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for PieTransformSort {
-    fn from(value: &PieTransformSort) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for PieTransformSort {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -80133,11 +74411,6 @@ impl ::std::convert::From<SignalRef> for PieTransformSort {
 pub enum PieTransformStartAngle {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for PieTransformStartAngle {
-    fn from(value: &PieTransformStartAngle) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for PieTransformStartAngle {
     fn from(value: f64) -> Self {
@@ -80176,11 +74449,6 @@ impl ::std::convert::From<SignalRef> for PieTransformStartAngle {
 pub enum PieTransformType {
     #[serde(rename = "pie")]
     Pie,
-}
-impl ::std::convert::From<&Self> for PieTransformType {
-    fn from(value: &PieTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for PieTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -80372,11 +74640,6 @@ pub struct PivotTransform {
     pub type_: PivotTransformType,
     pub value: PivotTransformValue,
 }
-impl ::std::convert::From<&PivotTransform> for PivotTransform {
-    fn from(value: &PivotTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`PivotTransformField`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -80403,11 +74666,6 @@ pub enum PivotTransformField {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for PivotTransformField {
-    fn from(value: &PivotTransformField) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for PivotTransformField {
     fn from(value: ScaleField) -> Self {
@@ -80460,11 +74718,6 @@ pub enum PivotTransformGroupby {
     Array(::std::vec::Vec<PivotTransformGroupbyArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for PivotTransformGroupby {
-    fn from(value: &PivotTransformGroupby) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<PivotTransformGroupbyArrayItem>>
     for PivotTransformGroupby
 {
@@ -80503,11 +74756,6 @@ pub enum PivotTransformGroupbyArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for PivotTransformGroupbyArrayItem {
-    fn from(value: &PivotTransformGroupbyArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for PivotTransformGroupbyArrayItem {
     fn from(value: ScaleField) -> Self {
@@ -80551,11 +74799,6 @@ pub enum PivotTransformKey {
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for PivotTransformKey {
-    fn from(value: &PivotTransformKey) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleField> for PivotTransformKey {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
@@ -80593,11 +74836,6 @@ impl ::std::convert::From<Expr> for PivotTransformKey {
 pub enum PivotTransformLimit {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for PivotTransformLimit {
-    fn from(value: &PivotTransformLimit) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for PivotTransformLimit {
     fn from(value: f64) -> Self {
@@ -80657,11 +74895,6 @@ impl ::std::convert::From<SignalRef> for PivotTransformLimit {
 pub enum PivotTransformOp {
     Variant0(PivotTransformOpVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for PivotTransformOp {
-    fn from(value: &PivotTransformOp) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for PivotTransformOp {
     fn default() -> Self {
@@ -80775,11 +75008,6 @@ pub enum PivotTransformOpVariant0 {
     #[serde(rename = "argmax")]
     Argmax,
 }
-impl ::std::convert::From<&Self> for PivotTransformOpVariant0 {
-    fn from(value: &PivotTransformOpVariant0) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for PivotTransformOpVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -80892,11 +75120,6 @@ pub enum PivotTransformType {
     #[serde(rename = "pivot")]
     Pivot,
 }
-impl ::std::convert::From<&Self> for PivotTransformType {
-    fn from(value: &PivotTransformType) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for PivotTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -80961,11 +75184,6 @@ pub enum PivotTransformValue {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for PivotTransformValue {
-    fn from(value: &PivotTransformValue) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for PivotTransformValue {
     fn from(value: ScaleField) -> Self {
@@ -81068,11 +75286,6 @@ pub struct ProjectTransform {
     #[serde(rename = "type")]
     pub type_: ProjectTransformType,
 }
-impl ::std::convert::From<&ProjectTransform> for ProjectTransform {
-    fn from(value: &ProjectTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ProjectTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -81108,11 +75321,6 @@ impl ::std::convert::From<&ProjectTransform> for ProjectTransform {
 pub enum ProjectTransformAs {
     Array(::std::vec::Vec<ProjectTransformAsArrayItem>),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ProjectTransformAs {
-    fn from(value: &ProjectTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<ProjectTransformAsArrayItem>> for ProjectTransformAs {
     fn from(value: ::std::vec::Vec<ProjectTransformAsArrayItem>) -> Self {
@@ -81150,11 +75358,6 @@ pub enum ProjectTransformAsArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
     Null,
-}
-impl ::std::convert::From<&Self> for ProjectTransformAsArrayItem {
-    fn from(value: &ProjectTransformAsArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<SignalRef> for ProjectTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
@@ -81197,11 +75400,6 @@ pub enum ProjectTransformFields {
     Array(::std::vec::Vec<ProjectTransformFieldsArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ProjectTransformFields {
-    fn from(value: &ProjectTransformFields) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ProjectTransformFieldsArrayItem>>
     for ProjectTransformFields
 {
@@ -81240,11 +75438,6 @@ pub enum ProjectTransformFieldsArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for ProjectTransformFieldsArrayItem {
-    fn from(value: &ProjectTransformFieldsArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for ProjectTransformFieldsArrayItem {
     fn from(value: ScaleField) -> Self {
@@ -81288,11 +75481,6 @@ impl ::std::convert::From<Expr> for ProjectTransformFieldsArrayItem {
 pub enum ProjectTransformType {
     #[serde(rename = "project")]
     Project,
-}
-impl ::std::convert::From<&Self> for ProjectTransformType {
-    fn from(value: &ProjectTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ProjectTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -81551,11 +75739,6 @@ pub struct Projection {
     )]
     pub type_: ::std::option::Option<StringOrSignal>,
 }
-impl ::std::convert::From<&Projection> for Projection {
-    fn from(value: &Projection) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ProjectionCenter`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -81583,11 +75766,6 @@ impl ::std::convert::From<&Projection> for Projection {
 pub enum ProjectionCenter {
     Array([NumberOrSignal; 2usize]),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ProjectionCenter {
-    fn from(value: &ProjectionCenter) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ProjectionCenter {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
@@ -81639,11 +75817,6 @@ pub enum ProjectionClipExtent {
     Array([ProjectionClipExtentArrayItem; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ProjectionClipExtent {
-    fn from(value: &ProjectionClipExtent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[ProjectionClipExtentArrayItem; 2usize]> for ProjectionClipExtent {
     fn from(value: [ProjectionClipExtentArrayItem; 2usize]) -> Self {
         Self::Array(value)
@@ -81681,11 +75854,6 @@ impl ::std::convert::From<SignalRef> for ProjectionClipExtent {
 pub enum ProjectionClipExtentArrayItem {
     Array([NumberOrSignal; 2usize]),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ProjectionClipExtentArrayItem {
-    fn from(value: &ProjectionClipExtentArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ProjectionClipExtentArrayItem {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
@@ -81737,11 +75905,6 @@ pub enum ProjectionExtent {
     Array([ProjectionExtentArrayItem; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ProjectionExtent {
-    fn from(value: &ProjectionExtent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[ProjectionExtentArrayItem; 2usize]> for ProjectionExtent {
     fn from(value: [ProjectionExtentArrayItem; 2usize]) -> Self {
         Self::Array(value)
@@ -81780,11 +75943,6 @@ pub enum ProjectionExtentArrayItem {
     Array([NumberOrSignal; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ProjectionExtentArrayItem {
-    fn from(value: &ProjectionExtentArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ProjectionExtentArrayItem {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
         Self::Array(value)
@@ -81817,11 +75975,6 @@ impl ::std::convert::From<SignalRef> for ProjectionExtentArrayItem {
 pub enum ProjectionFit {
     Object(::serde_json::Map<::std::string::String, ::serde_json::Value>),
     Array(::std::vec::Vec<::serde_json::Value>),
-}
-impl ::std::convert::From<&Self> for ProjectionFit {
-    fn from(value: &ProjectionFit) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::serde_json::Map<::std::string::String, ::serde_json::Value>>
     for ProjectionFit
@@ -81863,11 +76016,6 @@ pub enum ProjectionParallels {
     Array([NumberOrSignal; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ProjectionParallels {
-    fn from(value: &ProjectionParallels) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ProjectionParallels {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
         Self::Array(value)
@@ -81905,11 +76053,6 @@ impl ::std::convert::From<SignalRef> for ProjectionParallels {
 pub enum ProjectionRotate {
     Array(::std::vec::Vec<NumberOrSignal>),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ProjectionRotate {
-    fn from(value: &ProjectionRotate) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ProjectionRotate {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
@@ -81949,11 +76092,6 @@ pub enum ProjectionSize {
     Array([NumberOrSignal; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ProjectionSize {
-    fn from(value: &ProjectionSize) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ProjectionSize {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
         Self::Array(value)
@@ -81991,11 +76129,6 @@ impl ::std::convert::From<SignalRef> for ProjectionSize {
 pub enum ProjectionTranslate {
     Array([NumberOrSignal; 2usize]),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ProjectionTranslate {
-    fn from(value: &ProjectionTranslate) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ProjectionTranslate {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
@@ -82140,11 +76273,6 @@ pub struct QuantileTransform {
     #[serde(rename = "type")]
     pub type_: QuantileTransformType,
 }
-impl ::std::convert::From<&QuantileTransform> for QuantileTransform {
-    fn from(value: &QuantileTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`QuantileTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -82181,11 +76309,6 @@ impl ::std::convert::From<&QuantileTransform> for QuantileTransform {
 pub enum QuantileTransformAs {
     Array(::std::vec::Vec<QuantileTransformAsArrayItem>),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for QuantileTransformAs {
-    fn from(value: &QuantileTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for QuantileTransformAs {
     fn default() -> Self {
@@ -82228,11 +76351,6 @@ pub enum QuantileTransformAsArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for QuantileTransformAsArrayItem {
-    fn from(value: &QuantileTransformAsArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for QuantileTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -82264,11 +76382,6 @@ pub enum QuantileTransformField {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for QuantileTransformField {
-    fn from(value: &QuantileTransformField) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for QuantileTransformField {
     fn from(value: ScaleField) -> Self {
@@ -82321,11 +76434,6 @@ pub enum QuantileTransformGroupby {
     Array(::std::vec::Vec<QuantileTransformGroupbyArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for QuantileTransformGroupby {
-    fn from(value: &QuantileTransformGroupby) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<QuantileTransformGroupbyArrayItem>>
     for QuantileTransformGroupby
 {
@@ -82364,11 +76472,6 @@ pub enum QuantileTransformGroupbyArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for QuantileTransformGroupbyArrayItem {
-    fn from(value: &QuantileTransformGroupbyArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for QuantileTransformGroupbyArrayItem {
     fn from(value: ScaleField) -> Self {
@@ -82418,11 +76521,6 @@ pub enum QuantileTransformProbs {
     Array(::std::vec::Vec<QuantileTransformProbsArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for QuantileTransformProbs {
-    fn from(value: &QuantileTransformProbs) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<QuantileTransformProbsArrayItem>>
     for QuantileTransformProbs
 {
@@ -82458,11 +76556,6 @@ pub enum QuantileTransformProbsArrayItem {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for QuantileTransformProbsArrayItem {
-    fn from(value: &QuantileTransformProbsArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for QuantileTransformProbsArrayItem {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -82496,11 +76589,6 @@ impl ::std::convert::From<SignalRef> for QuantileTransformProbsArrayItem {
 pub enum QuantileTransformStep {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for QuantileTransformStep {
-    fn from(value: &QuantileTransformStep) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for QuantileTransformStep {
     fn default() -> Self {
@@ -82544,11 +76632,6 @@ impl ::std::convert::From<SignalRef> for QuantileTransformStep {
 pub enum QuantileTransformType {
     #[serde(rename = "quantile")]
     Quantile,
-}
-impl ::std::convert::From<&Self> for QuantileTransformType {
-    fn from(value: &QuantileTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for QuantileTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -82654,11 +76737,6 @@ pub struct RadialGradient {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub y2: ::std::option::Option<f64>,
 }
-impl ::std::convert::From<&RadialGradient> for RadialGradient {
-    fn from(value: &RadialGradient) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RadialGradientGradient`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -82686,11 +76764,6 @@ impl ::std::convert::From<&RadialGradient> for RadialGradient {
 pub enum RadialGradientGradient {
     #[serde(rename = "radial")]
     Radial,
-}
-impl ::std::convert::From<&Self> for RadialGradientGradient {
-    fn from(value: &RadialGradientGradient) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for RadialGradientGradient {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -82905,11 +76978,6 @@ pub struct RegressionTransform {
     pub x: RegressionTransformX,
     pub y: RegressionTransformY,
 }
-impl ::std::convert::From<&RegressionTransform> for RegressionTransform {
-    fn from(value: &RegressionTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`RegressionTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -82942,11 +77010,6 @@ impl ::std::convert::From<&RegressionTransform> for RegressionTransform {
 pub enum RegressionTransformAs {
     Array(::std::vec::Vec<RegressionTransformAsArrayItem>),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for RegressionTransformAs {
-    fn from(value: &RegressionTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<RegressionTransformAsArrayItem>>
     for RegressionTransformAs
@@ -82982,11 +77045,6 @@ impl ::std::convert::From<SignalRef> for RegressionTransformAs {
 pub enum RegressionTransformAsArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for RegressionTransformAsArrayItem {
-    fn from(value: &RegressionTransformAsArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<SignalRef> for RegressionTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
@@ -83028,11 +77086,6 @@ pub enum RegressionTransformExtent {
     Array([RegressionTransformExtentArrayItem; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for RegressionTransformExtent {
-    fn from(value: &RegressionTransformExtent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[RegressionTransformExtentArrayItem; 2usize]>
     for RegressionTransformExtent
 {
@@ -83067,11 +77120,6 @@ impl ::std::convert::From<SignalRef> for RegressionTransformExtent {
 pub enum RegressionTransformExtentArrayItem {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for RegressionTransformExtentArrayItem {
-    fn from(value: &RegressionTransformExtentArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for RegressionTransformExtentArrayItem {
     fn from(value: f64) -> Self {
@@ -83119,11 +77167,6 @@ pub enum RegressionTransformGroupby {
     Array(::std::vec::Vec<RegressionTransformGroupbyArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for RegressionTransformGroupby {
-    fn from(value: &RegressionTransformGroupby) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<RegressionTransformGroupbyArrayItem>>
     for RegressionTransformGroupby
 {
@@ -83162,11 +77205,6 @@ pub enum RegressionTransformGroupbyArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for RegressionTransformGroupbyArrayItem {
-    fn from(value: &RegressionTransformGroupbyArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for RegressionTransformGroupbyArrayItem {
     fn from(value: ScaleField) -> Self {
@@ -83207,11 +77245,6 @@ pub enum RegressionTransformMethod {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for RegressionTransformMethod {
-    fn from(value: &RegressionTransformMethod) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for RegressionTransformMethod {
     fn default() -> Self {
         RegressionTransformMethod::String("linear".to_string())
@@ -83245,11 +77278,6 @@ impl ::std::convert::From<SignalRef> for RegressionTransformMethod {
 pub enum RegressionTransformOrder {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for RegressionTransformOrder {
-    fn from(value: &RegressionTransformOrder) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for RegressionTransformOrder {
     fn default() -> Self {
@@ -83289,11 +77317,6 @@ pub enum RegressionTransformParams {
     Boolean(bool),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for RegressionTransformParams {
-    fn from(value: &RegressionTransformParams) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for RegressionTransformParams {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -83331,11 +77354,6 @@ impl ::std::convert::From<SignalRef> for RegressionTransformParams {
 pub enum RegressionTransformType {
     #[serde(rename = "regression")]
     Regression,
-}
-impl ::std::convert::From<&Self> for RegressionTransformType {
-    fn from(value: &RegressionTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for RegressionTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -83402,11 +77420,6 @@ pub enum RegressionTransformX {
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for RegressionTransformX {
-    fn from(value: &RegressionTransformX) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleField> for RegressionTransformX {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
@@ -83448,11 +77461,6 @@ pub enum RegressionTransformY {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for RegressionTransformY {
-    fn from(value: &RegressionTransformY) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for RegressionTransformY {
     fn from(value: ScaleField) -> Self {
@@ -83516,11 +77524,6 @@ pub struct ResolvefilterTransform {
     #[serde(rename = "type")]
     pub type_: ResolvefilterTransformType,
 }
-impl ::std::convert::From<&ResolvefilterTransform> for ResolvefilterTransform {
-    fn from(value: &ResolvefilterTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ResolvefilterTransformIgnore`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -83543,11 +77546,6 @@ impl ::std::convert::From<&ResolvefilterTransform> for ResolvefilterTransform {
 pub enum ResolvefilterTransformIgnore {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ResolvefilterTransformIgnore {
-    fn from(value: &ResolvefilterTransformIgnore) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for ResolvefilterTransformIgnore {
     fn from(value: f64) -> Self {
@@ -83586,11 +77584,6 @@ impl ::std::convert::From<SignalRef> for ResolvefilterTransformIgnore {
 pub enum ResolvefilterTransformType {
     #[serde(rename = "resolvefilter")]
     Resolvefilter,
-}
-impl ::std::convert::From<&Self> for ResolvefilterTransformType {
-    fn from(value: &ResolvefilterTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ResolvefilterTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -83650,11 +77643,6 @@ pub struct Rule {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub test: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&Rule> for Rule {
-    fn from(value: &Rule) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for Rule {
     fn default() -> Self {
         Self {
@@ -83707,11 +77695,6 @@ pub struct SampleTransform {
     #[serde(rename = "type")]
     pub type_: SampleTransformType,
 }
-impl ::std::convert::From<&SampleTransform> for SampleTransform {
-    fn from(value: &SampleTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SampleTransformSize`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -83735,11 +77718,6 @@ impl ::std::convert::From<&SampleTransform> for SampleTransform {
 pub enum SampleTransformSize {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for SampleTransformSize {
-    fn from(value: &SampleTransformSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for SampleTransformSize {
     fn default() -> Self {
@@ -83783,11 +77761,6 @@ impl ::std::convert::From<SignalRef> for SampleTransformSize {
 pub enum SampleTransformType {
     #[serde(rename = "sample")]
     Sample,
-}
-impl ::std::convert::From<&Self> for SampleTransformType {
-    fn from(value: &SampleTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for SampleTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -86845,11 +80818,6 @@ pub enum Scale {
         zero: ::std::option::Option<BooleanOrSignal>,
     },
 }
-impl ::std::convert::From<&Self> for Scale {
-    fn from(value: &Scale) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ScaleBins`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -86900,11 +80868,6 @@ pub enum ScaleBins {
         stop: ::std::option::Option<NumberOrSignal>,
     },
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleBins {
-    fn from(value: &ScaleBins) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleBins {
     fn from(value: ::std::vec::Vec<NumberOrSignal>) -> Self {
@@ -87146,11 +81109,6 @@ pub enum ScaleData {
         sort: ::std::option::Option<ScaleDataVariant2Sort>,
     },
 }
-impl ::std::convert::From<&Self> for ScaleData {
-    fn from(value: &ScaleData) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ScaleDataVariant0Sort`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -87192,11 +81150,6 @@ pub enum ScaleDataVariant0Sort {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         order: ::std::option::Option<SortOrder>,
     },
-}
-impl ::std::convert::From<&Self> for ScaleDataVariant0Sort {
-    fn from(value: &ScaleDataVariant0Sort) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<bool> for ScaleDataVariant0Sort {
     fn from(value: bool) -> Self {
@@ -87271,11 +81224,6 @@ pub enum ScaleDataVariant1Sort {
         order: ::std::option::Option<SortOrder>,
     },
 }
-impl ::std::convert::From<&Self> for ScaleDataVariant1Sort {
-    fn from(value: &ScaleDataVariant1Sort) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleDataVariant1Sort {
     fn from(value: bool) -> Self {
         Self::Variant0(value)
@@ -87308,11 +81256,6 @@ impl ::std::convert::From<bool> for ScaleDataVariant1Sort {
 pub enum ScaleDataVariant1SortVariant1Op {
     #[serde(rename = "count")]
     Count,
-}
-impl ::std::convert::From<&Self> for ScaleDataVariant1SortVariant1Op {
-    fn from(value: &ScaleDataVariant1SortVariant1Op) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleDataVariant1SortVariant1Op {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -87385,11 +81328,6 @@ pub enum ScaleDataVariant1SortVariant2Op {
     Min,
     #[serde(rename = "max")]
     Max,
-}
-impl ::std::convert::From<&Self> for ScaleDataVariant1SortVariant2Op {
-    fn from(value: &ScaleDataVariant1SortVariant2Op) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleDataVariant1SortVariant2Op {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -87489,11 +81427,6 @@ pub enum ScaleDataVariant2FieldsItem {
     Array(::std::vec::Vec<ScaleDataVariant2FieldsItemArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleDataVariant2FieldsItem {
-    fn from(value: &ScaleDataVariant2FieldsItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ScaleDataVariant2FieldsItemArrayItem>>
     for ScaleDataVariant2FieldsItem
 {
@@ -87532,11 +81465,6 @@ pub enum ScaleDataVariant2FieldsItemArrayItem {
     String(::std::string::String),
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for ScaleDataVariant2FieldsItemArrayItem {
-    fn from(value: &ScaleDataVariant2FieldsItemArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleDataVariant2FieldsItemArrayItem {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -87625,11 +81553,6 @@ pub enum ScaleDataVariant2Sort {
         order: ::std::option::Option<SortOrder>,
     },
 }
-impl ::std::convert::From<&Self> for ScaleDataVariant2Sort {
-    fn from(value: &ScaleDataVariant2Sort) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleDataVariant2Sort {
     fn from(value: bool) -> Self {
         Self::Variant0(value)
@@ -87662,11 +81585,6 @@ impl ::std::convert::From<bool> for ScaleDataVariant2Sort {
 pub enum ScaleDataVariant2SortVariant1Op {
     #[serde(rename = "count")]
     Count,
-}
-impl ::std::convert::From<&Self> for ScaleDataVariant2SortVariant1Op {
-    fn from(value: &ScaleDataVariant2SortVariant1Op) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleDataVariant2SortVariant1Op {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -87740,11 +81658,6 @@ pub enum ScaleDataVariant2SortVariant2Op {
     #[serde(rename = "max")]
     Max,
 }
-impl ::std::convert::From<&Self> for ScaleDataVariant2SortVariant2Op {
-    fn from(value: &ScaleDataVariant2SortVariant2Op) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for ScaleDataVariant2SortVariant2Op {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -87811,11 +81724,6 @@ impl ::std::convert::From<ScaleField> for StringOrSignal {
         value.0
     }
 }
-impl ::std::convert::From<&ScaleField> for ScaleField {
-    fn from(value: &ScaleField) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringOrSignal> for ScaleField {
     fn from(value: StringOrSignal) -> Self {
         Self(value)
@@ -87864,11 +81772,6 @@ pub enum ScaleInterpolate {
         #[serde(rename = "type")]
         type_: StringOrSignal,
     },
-}
-impl ::std::convert::From<&Self> for ScaleInterpolate {
-    fn from(value: &ScaleInterpolate) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<SignalRef> for ScaleInterpolate {
     fn from(value: SignalRef) -> Self {
@@ -87927,11 +81830,6 @@ pub enum ScaleVariant0Domain {
     ScaleData(ScaleData),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant0Domain {
-    fn from(value: &ScaleVariant0Domain) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ScaleVariant0DomainArrayItem>> for ScaleVariant0Domain {
     fn from(value: ::std::vec::Vec<ScaleVariant0DomainArrayItem>) -> Self {
         Self::Array(value)
@@ -87989,11 +81887,6 @@ pub enum ScaleVariant0DomainArrayItem {
     SignalRef(SignalRef),
     Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant0DomainArrayItem {
-    fn from(value: &ScaleVariant0DomainArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleVariant0DomainArrayItem {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -88041,11 +81934,6 @@ pub enum ScaleVariant0DomainRaw {
     Array(::std::vec::Vec<::serde_json::Value>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant0DomainRaw {
-    fn from(value: &ScaleVariant0DomainRaw) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant0DomainRaw {
     fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
         Self::Array(value)
@@ -88083,11 +81971,6 @@ impl ::std::convert::From<SignalRef> for ScaleVariant0DomainRaw {
 pub enum ScaleVariant0Type {
     #[serde(rename = "identity")]
     Identity,
-}
-impl ::std::convert::From<&Self> for ScaleVariant0Type {
-    fn from(value: &ScaleVariant0Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant0Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -88179,11 +82062,6 @@ pub enum ScaleVariant10Domain {
     ScaleData(ScaleData),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant10Domain {
-    fn from(value: &ScaleVariant10Domain) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ScaleVariant10DomainArrayItem>> for ScaleVariant10Domain {
     fn from(value: ::std::vec::Vec<ScaleVariant10DomainArrayItem>) -> Self {
         Self::Array(value)
@@ -88241,11 +82119,6 @@ pub enum ScaleVariant10DomainArrayItem {
     SignalRef(SignalRef),
     Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant10DomainArrayItem {
-    fn from(value: &ScaleVariant10DomainArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleVariant10DomainArrayItem {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -88293,11 +82166,6 @@ pub enum ScaleVariant10DomainRaw {
     Array(::std::vec::Vec<::serde_json::Value>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant10DomainRaw {
-    fn from(value: &ScaleVariant10DomainRaw) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant10DomainRaw {
     fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
         Self::Array(value)
@@ -88334,11 +82202,6 @@ pub enum ScaleVariant10Nice {
     Boolean(bool),
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant10Nice {
-    fn from(value: &ScaleVariant10Nice) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<bool> for ScaleVariant10Nice {
     fn from(value: bool) -> Self {
@@ -88473,11 +82336,6 @@ pub enum ScaleVariant10Range {
     },
     Variant3(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant10Range {
-    fn from(value: &ScaleVariant10Range) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleVariant10RangeVariant0> for ScaleVariant10Range {
     fn from(value: ScaleVariant10RangeVariant0) -> Self {
         Self::Variant0(value)
@@ -88543,11 +82401,6 @@ pub enum ScaleVariant10RangeVariant0 {
     Diverging,
     #[serde(rename = "heatmap")]
     Heatmap,
-}
-impl ::std::convert::From<&Self> for ScaleVariant10RangeVariant0 {
-    fn from(value: &ScaleVariant10RangeVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant10RangeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -88643,11 +82496,6 @@ pub enum ScaleVariant10RangeVariant1Item {
     SignalRef(SignalRef),
     Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant10RangeVariant1Item {
-    fn from(value: &ScaleVariant10RangeVariant1Item) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleVariant10RangeVariant1Item {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -88696,11 +82544,6 @@ pub enum ScaleVariant10RangeVariant2Extent {
     Array([NumberOrSignal; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant10RangeVariant2Extent {
-    fn from(value: &ScaleVariant10RangeVariant2Extent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ScaleVariant10RangeVariant2Extent {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
         Self::Array(value)
@@ -88748,11 +82591,6 @@ pub enum ScaleVariant10RangeVariant2Scheme {
     Array(::std::vec::Vec<ScaleVariant10RangeVariant2SchemeArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant10RangeVariant2Scheme {
-    fn from(value: &ScaleVariant10RangeVariant2Scheme) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ScaleVariant10RangeVariant2SchemeArrayItem>>
     for ScaleVariant10RangeVariant2Scheme
 {
@@ -88788,11 +82626,6 @@ pub enum ScaleVariant10RangeVariant2SchemeArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant10RangeVariant2SchemeArrayItem {
-    fn from(value: &ScaleVariant10RangeVariant2SchemeArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for ScaleVariant10RangeVariant2SchemeArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -88825,11 +82658,6 @@ impl ::std::convert::From<SignalRef> for ScaleVariant10RangeVariant2SchemeArrayI
 pub enum ScaleVariant10Type {
     #[serde(rename = "pow")]
     Pow,
-}
-impl ::std::convert::From<&Self> for ScaleVariant10Type {
-    fn from(value: &ScaleVariant10Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant10Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -88921,11 +82749,6 @@ pub enum ScaleVariant11Domain {
     ScaleData(ScaleData),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant11Domain {
-    fn from(value: &ScaleVariant11Domain) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ScaleVariant11DomainArrayItem>> for ScaleVariant11Domain {
     fn from(value: ::std::vec::Vec<ScaleVariant11DomainArrayItem>) -> Self {
         Self::Array(value)
@@ -88983,11 +82806,6 @@ pub enum ScaleVariant11DomainArrayItem {
     SignalRef(SignalRef),
     Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant11DomainArrayItem {
-    fn from(value: &ScaleVariant11DomainArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleVariant11DomainArrayItem {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -89035,11 +82853,6 @@ pub enum ScaleVariant11DomainRaw {
     Array(::std::vec::Vec<::serde_json::Value>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant11DomainRaw {
-    fn from(value: &ScaleVariant11DomainRaw) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant11DomainRaw {
     fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
         Self::Array(value)
@@ -89076,11 +82889,6 @@ pub enum ScaleVariant11Nice {
     Boolean(bool),
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant11Nice {
-    fn from(value: &ScaleVariant11Nice) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<bool> for ScaleVariant11Nice {
     fn from(value: bool) -> Self {
@@ -89215,11 +83023,6 @@ pub enum ScaleVariant11Range {
     },
     Variant3(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant11Range {
-    fn from(value: &ScaleVariant11Range) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleVariant11RangeVariant0> for ScaleVariant11Range {
     fn from(value: ScaleVariant11RangeVariant0) -> Self {
         Self::Variant0(value)
@@ -89285,11 +83088,6 @@ pub enum ScaleVariant11RangeVariant0 {
     Diverging,
     #[serde(rename = "heatmap")]
     Heatmap,
-}
-impl ::std::convert::From<&Self> for ScaleVariant11RangeVariant0 {
-    fn from(value: &ScaleVariant11RangeVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant11RangeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -89385,11 +83183,6 @@ pub enum ScaleVariant11RangeVariant1Item {
     SignalRef(SignalRef),
     Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant11RangeVariant1Item {
-    fn from(value: &ScaleVariant11RangeVariant1Item) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleVariant11RangeVariant1Item {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -89438,11 +83231,6 @@ pub enum ScaleVariant11RangeVariant2Extent {
     Array([NumberOrSignal; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant11RangeVariant2Extent {
-    fn from(value: &ScaleVariant11RangeVariant2Extent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ScaleVariant11RangeVariant2Extent {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
         Self::Array(value)
@@ -89490,11 +83278,6 @@ pub enum ScaleVariant11RangeVariant2Scheme {
     Array(::std::vec::Vec<ScaleVariant11RangeVariant2SchemeArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant11RangeVariant2Scheme {
-    fn from(value: &ScaleVariant11RangeVariant2Scheme) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ScaleVariant11RangeVariant2SchemeArrayItem>>
     for ScaleVariant11RangeVariant2Scheme
 {
@@ -89530,11 +83313,6 @@ pub enum ScaleVariant11RangeVariant2SchemeArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant11RangeVariant2SchemeArrayItem {
-    fn from(value: &ScaleVariant11RangeVariant2SchemeArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for ScaleVariant11RangeVariant2SchemeArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -89567,11 +83345,6 @@ impl ::std::convert::From<SignalRef> for ScaleVariant11RangeVariant2SchemeArrayI
 pub enum ScaleVariant11Type {
     #[serde(rename = "symlog")]
     Symlog,
-}
-impl ::std::convert::From<&Self> for ScaleVariant11Type {
-    fn from(value: &ScaleVariant11Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant11Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -89663,11 +83436,6 @@ pub enum ScaleVariant1Domain {
     ScaleData(ScaleData),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant1Domain {
-    fn from(value: &ScaleVariant1Domain) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ScaleVariant1DomainArrayItem>> for ScaleVariant1Domain {
     fn from(value: ::std::vec::Vec<ScaleVariant1DomainArrayItem>) -> Self {
         Self::Array(value)
@@ -89725,11 +83493,6 @@ pub enum ScaleVariant1DomainArrayItem {
     SignalRef(SignalRef),
     Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant1DomainArrayItem {
-    fn from(value: &ScaleVariant1DomainArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleVariant1DomainArrayItem {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -89776,11 +83539,6 @@ pub enum ScaleVariant1DomainRaw {
     Null,
     Array(::std::vec::Vec<::serde_json::Value>),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant1DomainRaw {
-    fn from(value: &ScaleVariant1DomainRaw) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant1DomainRaw {
     fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
@@ -90113,11 +83871,6 @@ pub enum ScaleVariant1Range {
     Variant3(ScaleVariant1RangeVariant3),
     Variant4(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant1Range {
-    fn from(value: &ScaleVariant1Range) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleVariant1RangeVariant0> for ScaleVariant1Range {
     fn from(value: ScaleVariant1RangeVariant0) -> Self {
         Self::Variant0(value)
@@ -90186,11 +83939,6 @@ pub enum ScaleVariant1RangeVariant0 {
     Diverging,
     #[serde(rename = "heatmap")]
     Heatmap,
-}
-impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant0 {
-    fn from(value: &ScaleVariant1RangeVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant1RangeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -90286,11 +84034,6 @@ pub enum ScaleVariant1RangeVariant1Item {
     SignalRef(SignalRef),
     Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant1Item {
-    fn from(value: &ScaleVariant1RangeVariant1Item) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleVariant1RangeVariant1Item {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -90339,11 +84082,6 @@ pub enum ScaleVariant1RangeVariant2Extent {
     Array([NumberOrSignal; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant2Extent {
-    fn from(value: &ScaleVariant1RangeVariant2Extent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ScaleVariant1RangeVariant2Extent {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
         Self::Array(value)
@@ -90391,11 +84129,6 @@ pub enum ScaleVariant1RangeVariant2Scheme {
     Array(::std::vec::Vec<ScaleVariant1RangeVariant2SchemeArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant2Scheme {
-    fn from(value: &ScaleVariant1RangeVariant2Scheme) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ScaleVariant1RangeVariant2SchemeArrayItem>>
     for ScaleVariant1RangeVariant2Scheme
 {
@@ -90430,11 +84163,6 @@ impl ::std::convert::From<SignalRef> for ScaleVariant1RangeVariant2Scheme {
 pub enum ScaleVariant1RangeVariant2SchemeArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant2SchemeArrayItem {
-    fn from(value: &ScaleVariant1RangeVariant2SchemeArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant1RangeVariant2SchemeArrayItem {
     fn from(value: SignalRef) -> Self {
@@ -90671,11 +84399,6 @@ pub enum ScaleVariant1RangeVariant3 {
         sort: ::std::option::Option<ScaleVariant1RangeVariant3Variant2Sort>,
     },
 }
-impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant3 {
-    fn from(value: &ScaleVariant1RangeVariant3) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`ScaleVariant1RangeVariant3Variant0Sort`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -90717,11 +84440,6 @@ pub enum ScaleVariant1RangeVariant3Variant0Sort {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         order: ::std::option::Option<SortOrder>,
     },
-}
-impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant3Variant0Sort {
-    fn from(value: &ScaleVariant1RangeVariant3Variant0Sort) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<bool> for ScaleVariant1RangeVariant3Variant0Sort {
     fn from(value: bool) -> Self {
@@ -90796,11 +84514,6 @@ pub enum ScaleVariant1RangeVariant3Variant1Sort {
         order: ::std::option::Option<SortOrder>,
     },
 }
-impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant3Variant1Sort {
-    fn from(value: &ScaleVariant1RangeVariant3Variant1Sort) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleVariant1RangeVariant3Variant1Sort {
     fn from(value: bool) -> Self {
         Self::Variant0(value)
@@ -90833,11 +84546,6 @@ impl ::std::convert::From<bool> for ScaleVariant1RangeVariant3Variant1Sort {
 pub enum ScaleVariant1RangeVariant3Variant1SortVariant1Op {
     #[serde(rename = "count")]
     Count,
-}
-impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant3Variant1SortVariant1Op {
-    fn from(value: &ScaleVariant1RangeVariant3Variant1SortVariant1Op) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant1RangeVariant3Variant1SortVariant1Op {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -90914,11 +84622,6 @@ pub enum ScaleVariant1RangeVariant3Variant1SortVariant2Op {
     Min,
     #[serde(rename = "max")]
     Max,
-}
-impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant3Variant1SortVariant2Op {
-    fn from(value: &ScaleVariant1RangeVariant3Variant1SortVariant2Op) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant1RangeVariant3Variant1SortVariant2Op {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -91022,11 +84725,6 @@ pub enum ScaleVariant1RangeVariant3Variant2FieldsItem {
     Array(::std::vec::Vec<ScaleVariant1RangeVariant3Variant2FieldsItemArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant3Variant2FieldsItem {
-    fn from(value: &ScaleVariant1RangeVariant3Variant2FieldsItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ScaleVariant1RangeVariant3Variant2FieldsItemArrayItem>>
     for ScaleVariant1RangeVariant3Variant2FieldsItem
 {
@@ -91065,11 +84763,6 @@ pub enum ScaleVariant1RangeVariant3Variant2FieldsItemArrayItem {
     String(::std::string::String),
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant3Variant2FieldsItemArrayItem {
-    fn from(value: &ScaleVariant1RangeVariant3Variant2FieldsItemArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant1RangeVariant3Variant2FieldsItemArrayItem {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -91158,11 +84851,6 @@ pub enum ScaleVariant1RangeVariant3Variant2Sort {
         order: ::std::option::Option<SortOrder>,
     },
 }
-impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant3Variant2Sort {
-    fn from(value: &ScaleVariant1RangeVariant3Variant2Sort) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleVariant1RangeVariant3Variant2Sort {
     fn from(value: bool) -> Self {
         Self::Variant0(value)
@@ -91195,11 +84883,6 @@ impl ::std::convert::From<bool> for ScaleVariant1RangeVariant3Variant2Sort {
 pub enum ScaleVariant1RangeVariant3Variant2SortVariant1Op {
     #[serde(rename = "count")]
     Count,
-}
-impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant3Variant2SortVariant1Op {
-    fn from(value: &ScaleVariant1RangeVariant3Variant2SortVariant1Op) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant1RangeVariant3Variant2SortVariant1Op {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -91277,11 +84960,6 @@ pub enum ScaleVariant1RangeVariant3Variant2SortVariant2Op {
     #[serde(rename = "max")]
     Max,
 }
-impl ::std::convert::From<&Self> for ScaleVariant1RangeVariant3Variant2SortVariant2Op {
-    fn from(value: &ScaleVariant1RangeVariant3Variant2SortVariant2Op) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for ScaleVariant1RangeVariant3Variant2SortVariant2Op {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -91355,11 +85033,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum ScaleVariant1Type {
     #[serde(rename = "ordinal")]
     Ordinal,
-}
-impl ::std::convert::From<&Self> for ScaleVariant1Type {
-    fn from(value: &ScaleVariant1Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant1Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -91451,11 +85124,6 @@ pub enum ScaleVariant2Domain {
     ScaleData(ScaleData),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant2Domain {
-    fn from(value: &ScaleVariant2Domain) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ScaleVariant2DomainArrayItem>> for ScaleVariant2Domain {
     fn from(value: ::std::vec::Vec<ScaleVariant2DomainArrayItem>) -> Self {
         Self::Array(value)
@@ -91513,11 +85181,6 @@ pub enum ScaleVariant2DomainArrayItem {
     SignalRef(SignalRef),
     Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant2DomainArrayItem {
-    fn from(value: &ScaleVariant2DomainArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleVariant2DomainArrayItem {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -91564,11 +85227,6 @@ pub enum ScaleVariant2DomainRaw {
     Null,
     Array(::std::vec::Vec<::serde_json::Value>),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant2DomainRaw {
-    fn from(value: &ScaleVariant2DomainRaw) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant2DomainRaw {
     fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
@@ -91654,11 +85312,6 @@ pub enum ScaleVariant2Range {
     Variant2 { step: NumberOrSignal },
     Variant3(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant2Range {
-    fn from(value: &ScaleVariant2Range) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleVariant2RangeVariant0> for ScaleVariant2Range {
     fn from(value: ScaleVariant2RangeVariant0) -> Self {
         Self::Variant0(value)
@@ -91722,11 +85375,6 @@ pub enum ScaleVariant2RangeVariant0 {
     Diverging,
     #[serde(rename = "heatmap")]
     Heatmap,
-}
-impl ::std::convert::From<&Self> for ScaleVariant2RangeVariant0 {
-    fn from(value: &ScaleVariant2RangeVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant2RangeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -91822,11 +85470,6 @@ pub enum ScaleVariant2RangeVariant1Item {
     SignalRef(SignalRef),
     Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant2RangeVariant1Item {
-    fn from(value: &ScaleVariant2RangeVariant1Item) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleVariant2RangeVariant1Item {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -91874,11 +85517,6 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant2Rang
 pub enum ScaleVariant2Type {
     #[serde(rename = "band")]
     Band,
-}
-impl ::std::convert::From<&Self> for ScaleVariant2Type {
-    fn from(value: &ScaleVariant2Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant2Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -91970,11 +85608,6 @@ pub enum ScaleVariant3Domain {
     ScaleData(ScaleData),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant3Domain {
-    fn from(value: &ScaleVariant3Domain) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ScaleVariant3DomainArrayItem>> for ScaleVariant3Domain {
     fn from(value: ::std::vec::Vec<ScaleVariant3DomainArrayItem>) -> Self {
         Self::Array(value)
@@ -92032,11 +85665,6 @@ pub enum ScaleVariant3DomainArrayItem {
     SignalRef(SignalRef),
     Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant3DomainArrayItem {
-    fn from(value: &ScaleVariant3DomainArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleVariant3DomainArrayItem {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -92083,11 +85711,6 @@ pub enum ScaleVariant3DomainRaw {
     Null,
     Array(::std::vec::Vec<::serde_json::Value>),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant3DomainRaw {
-    fn from(value: &ScaleVariant3DomainRaw) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant3DomainRaw {
     fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
@@ -92173,11 +85796,6 @@ pub enum ScaleVariant3Range {
     Variant2 { step: NumberOrSignal },
     Variant3(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant3Range {
-    fn from(value: &ScaleVariant3Range) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleVariant3RangeVariant0> for ScaleVariant3Range {
     fn from(value: ScaleVariant3RangeVariant0) -> Self {
         Self::Variant0(value)
@@ -92241,11 +85859,6 @@ pub enum ScaleVariant3RangeVariant0 {
     Diverging,
     #[serde(rename = "heatmap")]
     Heatmap,
-}
-impl ::std::convert::From<&Self> for ScaleVariant3RangeVariant0 {
-    fn from(value: &ScaleVariant3RangeVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant3RangeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -92341,11 +85954,6 @@ pub enum ScaleVariant3RangeVariant1Item {
     SignalRef(SignalRef),
     Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant3RangeVariant1Item {
-    fn from(value: &ScaleVariant3RangeVariant1Item) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleVariant3RangeVariant1Item {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -92393,11 +86001,6 @@ impl ::std::convert::From<::std::vec::Vec<NumberOrSignal>> for ScaleVariant3Rang
 pub enum ScaleVariant3Type {
     #[serde(rename = "point")]
     Point,
-}
-impl ::std::convert::From<&Self> for ScaleVariant3Type {
-    fn from(value: &ScaleVariant3Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant3Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -92489,11 +86092,6 @@ pub enum ScaleVariant4Domain {
     ScaleData(ScaleData),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant4Domain {
-    fn from(value: &ScaleVariant4Domain) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ScaleVariant4DomainArrayItem>> for ScaleVariant4Domain {
     fn from(value: ::std::vec::Vec<ScaleVariant4DomainArrayItem>) -> Self {
         Self::Array(value)
@@ -92551,11 +86149,6 @@ pub enum ScaleVariant4DomainArrayItem {
     SignalRef(SignalRef),
     Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant4DomainArrayItem {
-    fn from(value: &ScaleVariant4DomainArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleVariant4DomainArrayItem {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -92603,11 +86196,6 @@ pub enum ScaleVariant4DomainRaw {
     Array(::std::vec::Vec<::serde_json::Value>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant4DomainRaw {
-    fn from(value: &ScaleVariant4DomainRaw) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant4DomainRaw {
     fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
         Self::Array(value)
@@ -92644,11 +86232,6 @@ pub enum ScaleVariant4Nice {
     Boolean(bool),
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant4Nice {
-    fn from(value: &ScaleVariant4Nice) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<bool> for ScaleVariant4Nice {
     fn from(value: bool) -> Self {
@@ -92783,11 +86366,6 @@ pub enum ScaleVariant4Range {
     },
     Variant3(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant4Range {
-    fn from(value: &ScaleVariant4Range) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleVariant4RangeVariant0> for ScaleVariant4Range {
     fn from(value: ScaleVariant4RangeVariant0) -> Self {
         Self::Variant0(value)
@@ -92851,11 +86429,6 @@ pub enum ScaleVariant4RangeVariant0 {
     Diverging,
     #[serde(rename = "heatmap")]
     Heatmap,
-}
-impl ::std::convert::From<&Self> for ScaleVariant4RangeVariant0 {
-    fn from(value: &ScaleVariant4RangeVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant4RangeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -92951,11 +86524,6 @@ pub enum ScaleVariant4RangeVariant1Item {
     SignalRef(SignalRef),
     Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant4RangeVariant1Item {
-    fn from(value: &ScaleVariant4RangeVariant1Item) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleVariant4RangeVariant1Item {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -93004,11 +86572,6 @@ pub enum ScaleVariant4RangeVariant2Extent {
     Array([NumberOrSignal; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant4RangeVariant2Extent {
-    fn from(value: &ScaleVariant4RangeVariant2Extent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ScaleVariant4RangeVariant2Extent {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
         Self::Array(value)
@@ -93056,11 +86619,6 @@ pub enum ScaleVariant4RangeVariant2Scheme {
     Array(::std::vec::Vec<ScaleVariant4RangeVariant2SchemeArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant4RangeVariant2Scheme {
-    fn from(value: &ScaleVariant4RangeVariant2Scheme) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ScaleVariant4RangeVariant2SchemeArrayItem>>
     for ScaleVariant4RangeVariant2Scheme
 {
@@ -93095,11 +86653,6 @@ impl ::std::convert::From<SignalRef> for ScaleVariant4RangeVariant2Scheme {
 pub enum ScaleVariant4RangeVariant2SchemeArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant4RangeVariant2SchemeArrayItem {
-    fn from(value: &ScaleVariant4RangeVariant2SchemeArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant4RangeVariant2SchemeArrayItem {
     fn from(value: SignalRef) -> Self {
@@ -93136,11 +86689,6 @@ pub enum ScaleVariant4Type {
     Quantize,
     #[serde(rename = "threshold")]
     Threshold,
-}
-impl ::std::convert::From<&Self> for ScaleVariant4Type {
-    fn from(value: &ScaleVariant4Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant4Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -93234,11 +86782,6 @@ pub enum ScaleVariant5Domain {
     ScaleData(ScaleData),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant5Domain {
-    fn from(value: &ScaleVariant5Domain) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ScaleVariant5DomainArrayItem>> for ScaleVariant5Domain {
     fn from(value: ::std::vec::Vec<ScaleVariant5DomainArrayItem>) -> Self {
         Self::Array(value)
@@ -93296,11 +86839,6 @@ pub enum ScaleVariant5DomainArrayItem {
     SignalRef(SignalRef),
     Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant5DomainArrayItem {
-    fn from(value: &ScaleVariant5DomainArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleVariant5DomainArrayItem {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -93347,11 +86885,6 @@ pub enum ScaleVariant5DomainRaw {
     Null,
     Array(::std::vec::Vec<::serde_json::Value>),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant5DomainRaw {
-    fn from(value: &ScaleVariant5DomainRaw) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant5DomainRaw {
     fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
@@ -93481,11 +87014,6 @@ pub enum ScaleVariant5Range {
     },
     Variant3(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant5Range {
-    fn from(value: &ScaleVariant5Range) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleVariant5RangeVariant0> for ScaleVariant5Range {
     fn from(value: ScaleVariant5RangeVariant0) -> Self {
         Self::Variant0(value)
@@ -93549,11 +87077,6 @@ pub enum ScaleVariant5RangeVariant0 {
     Diverging,
     #[serde(rename = "heatmap")]
     Heatmap,
-}
-impl ::std::convert::From<&Self> for ScaleVariant5RangeVariant0 {
-    fn from(value: &ScaleVariant5RangeVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant5RangeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -93649,11 +87172,6 @@ pub enum ScaleVariant5RangeVariant1Item {
     SignalRef(SignalRef),
     Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant5RangeVariant1Item {
-    fn from(value: &ScaleVariant5RangeVariant1Item) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleVariant5RangeVariant1Item {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -93702,11 +87220,6 @@ pub enum ScaleVariant5RangeVariant2Extent {
     Array([NumberOrSignal; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant5RangeVariant2Extent {
-    fn from(value: &ScaleVariant5RangeVariant2Extent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ScaleVariant5RangeVariant2Extent {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
         Self::Array(value)
@@ -93754,11 +87267,6 @@ pub enum ScaleVariant5RangeVariant2Scheme {
     Array(::std::vec::Vec<ScaleVariant5RangeVariant2SchemeArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant5RangeVariant2Scheme {
-    fn from(value: &ScaleVariant5RangeVariant2Scheme) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ScaleVariant5RangeVariant2SchemeArrayItem>>
     for ScaleVariant5RangeVariant2Scheme
 {
@@ -93794,11 +87302,6 @@ pub enum ScaleVariant5RangeVariant2SchemeArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant5RangeVariant2SchemeArrayItem {
-    fn from(value: &ScaleVariant5RangeVariant2SchemeArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for ScaleVariant5RangeVariant2SchemeArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -93831,11 +87334,6 @@ impl ::std::convert::From<SignalRef> for ScaleVariant5RangeVariant2SchemeArrayIt
 pub enum ScaleVariant5Type {
     #[serde(rename = "quantile")]
     Quantile,
-}
-impl ::std::convert::From<&Self> for ScaleVariant5Type {
-    fn from(value: &ScaleVariant5Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant5Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -93927,11 +87425,6 @@ pub enum ScaleVariant6Domain {
     ScaleData(ScaleData),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant6Domain {
-    fn from(value: &ScaleVariant6Domain) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ScaleVariant6DomainArrayItem>> for ScaleVariant6Domain {
     fn from(value: ::std::vec::Vec<ScaleVariant6DomainArrayItem>) -> Self {
         Self::Array(value)
@@ -93989,11 +87482,6 @@ pub enum ScaleVariant6DomainArrayItem {
     SignalRef(SignalRef),
     Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant6DomainArrayItem {
-    fn from(value: &ScaleVariant6DomainArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleVariant6DomainArrayItem {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -94040,11 +87528,6 @@ pub enum ScaleVariant6DomainRaw {
     Null,
     Array(::std::vec::Vec<::serde_json::Value>),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant6DomainRaw {
-    fn from(value: &ScaleVariant6DomainRaw) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant6DomainRaw {
     fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
@@ -94174,11 +87657,6 @@ pub enum ScaleVariant6Range {
     },
     Variant3(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant6Range {
-    fn from(value: &ScaleVariant6Range) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleVariant6RangeVariant0> for ScaleVariant6Range {
     fn from(value: ScaleVariant6RangeVariant0) -> Self {
         Self::Variant0(value)
@@ -94242,11 +87720,6 @@ pub enum ScaleVariant6RangeVariant0 {
     Diverging,
     #[serde(rename = "heatmap")]
     Heatmap,
-}
-impl ::std::convert::From<&Self> for ScaleVariant6RangeVariant0 {
-    fn from(value: &ScaleVariant6RangeVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant6RangeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -94342,11 +87815,6 @@ pub enum ScaleVariant6RangeVariant1Item {
     SignalRef(SignalRef),
     Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant6RangeVariant1Item {
-    fn from(value: &ScaleVariant6RangeVariant1Item) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleVariant6RangeVariant1Item {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -94395,11 +87863,6 @@ pub enum ScaleVariant6RangeVariant2Extent {
     Array([NumberOrSignal; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant6RangeVariant2Extent {
-    fn from(value: &ScaleVariant6RangeVariant2Extent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ScaleVariant6RangeVariant2Extent {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
         Self::Array(value)
@@ -94447,11 +87910,6 @@ pub enum ScaleVariant6RangeVariant2Scheme {
     Array(::std::vec::Vec<ScaleVariant6RangeVariant2SchemeArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant6RangeVariant2Scheme {
-    fn from(value: &ScaleVariant6RangeVariant2Scheme) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ScaleVariant6RangeVariant2SchemeArrayItem>>
     for ScaleVariant6RangeVariant2Scheme
 {
@@ -94487,11 +87945,6 @@ pub enum ScaleVariant6RangeVariant2SchemeArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant6RangeVariant2SchemeArrayItem {
-    fn from(value: &ScaleVariant6RangeVariant2SchemeArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for ScaleVariant6RangeVariant2SchemeArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -94524,11 +87977,6 @@ impl ::std::convert::From<SignalRef> for ScaleVariant6RangeVariant2SchemeArrayIt
 pub enum ScaleVariant6Type {
     #[serde(rename = "bin-ordinal")]
     BinOrdinal,
-}
-impl ::std::convert::From<&Self> for ScaleVariant6Type {
-    fn from(value: &ScaleVariant6Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant6Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -94620,11 +88068,6 @@ pub enum ScaleVariant7Domain {
     ScaleData(ScaleData),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant7Domain {
-    fn from(value: &ScaleVariant7Domain) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ScaleVariant7DomainArrayItem>> for ScaleVariant7Domain {
     fn from(value: ::std::vec::Vec<ScaleVariant7DomainArrayItem>) -> Self {
         Self::Array(value)
@@ -94682,11 +88125,6 @@ pub enum ScaleVariant7DomainArrayItem {
     SignalRef(SignalRef),
     Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant7DomainArrayItem {
-    fn from(value: &ScaleVariant7DomainArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleVariant7DomainArrayItem {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -94733,11 +88171,6 @@ pub enum ScaleVariant7DomainRaw {
     Null,
     Array(::std::vec::Vec<::serde_json::Value>),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant7DomainRaw {
-    fn from(value: &ScaleVariant7DomainRaw) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant7DomainRaw {
     fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
@@ -94817,11 +88250,6 @@ pub enum ScaleVariant7Nice {
         step: ::std::option::Option<NumberOrSignal>,
     },
 }
-impl ::std::convert::From<&Self> for ScaleVariant7Nice {
-    fn from(value: &ScaleVariant7Nice) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleVariant7Nice {
     fn from(value: bool) -> Self {
         Self::Variant0(value)
@@ -94880,11 +88308,6 @@ pub enum ScaleVariant7NiceVariant1 {
     Month,
     #[serde(rename = "year")]
     Year,
-}
-impl ::std::convert::From<&Self> for ScaleVariant7NiceVariant1 {
-    fn from(value: &ScaleVariant7NiceVariant1) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant7NiceVariant1 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -94970,11 +88393,6 @@ pub enum ScaleVariant7NiceVariant2Interval {
     Variant0(ScaleVariant7NiceVariant2IntervalVariant0),
     Variant1(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant7NiceVariant2Interval {
-    fn from(value: &ScaleVariant7NiceVariant2Interval) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleVariant7NiceVariant2IntervalVariant0>
     for ScaleVariant7NiceVariant2Interval
 {
@@ -95035,11 +88453,6 @@ pub enum ScaleVariant7NiceVariant2IntervalVariant0 {
     Month,
     #[serde(rename = "year")]
     Year,
-}
-impl ::std::convert::From<&Self> for ScaleVariant7NiceVariant2IntervalVariant0 {
-    fn from(value: &ScaleVariant7NiceVariant2IntervalVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant7NiceVariant2IntervalVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -95211,11 +88624,6 @@ pub enum ScaleVariant7Range {
     },
     Variant3(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant7Range {
-    fn from(value: &ScaleVariant7Range) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleVariant7RangeVariant0> for ScaleVariant7Range {
     fn from(value: ScaleVariant7RangeVariant0) -> Self {
         Self::Variant0(value)
@@ -95279,11 +88687,6 @@ pub enum ScaleVariant7RangeVariant0 {
     Diverging,
     #[serde(rename = "heatmap")]
     Heatmap,
-}
-impl ::std::convert::From<&Self> for ScaleVariant7RangeVariant0 {
-    fn from(value: &ScaleVariant7RangeVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant7RangeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -95379,11 +88782,6 @@ pub enum ScaleVariant7RangeVariant1Item {
     SignalRef(SignalRef),
     Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant7RangeVariant1Item {
-    fn from(value: &ScaleVariant7RangeVariant1Item) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleVariant7RangeVariant1Item {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -95432,11 +88830,6 @@ pub enum ScaleVariant7RangeVariant2Extent {
     Array([NumberOrSignal; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant7RangeVariant2Extent {
-    fn from(value: &ScaleVariant7RangeVariant2Extent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ScaleVariant7RangeVariant2Extent {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
         Self::Array(value)
@@ -95484,11 +88877,6 @@ pub enum ScaleVariant7RangeVariant2Scheme {
     Array(::std::vec::Vec<ScaleVariant7RangeVariant2SchemeArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant7RangeVariant2Scheme {
-    fn from(value: &ScaleVariant7RangeVariant2Scheme) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ScaleVariant7RangeVariant2SchemeArrayItem>>
     for ScaleVariant7RangeVariant2Scheme
 {
@@ -95523,11 +88911,6 @@ impl ::std::convert::From<SignalRef> for ScaleVariant7RangeVariant2Scheme {
 pub enum ScaleVariant7RangeVariant2SchemeArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant7RangeVariant2SchemeArrayItem {
-    fn from(value: &ScaleVariant7RangeVariant2SchemeArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant7RangeVariant2SchemeArrayItem {
     fn from(value: SignalRef) -> Self {
@@ -95564,11 +88947,6 @@ pub enum ScaleVariant7Type {
     Time,
     #[serde(rename = "utc")]
     Utc,
-}
-impl ::std::convert::From<&Self> for ScaleVariant7Type {
-    fn from(value: &ScaleVariant7Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant7Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -95662,11 +89040,6 @@ pub enum ScaleVariant8Domain {
     ScaleData(ScaleData),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant8Domain {
-    fn from(value: &ScaleVariant8Domain) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ScaleVariant8DomainArrayItem>> for ScaleVariant8Domain {
     fn from(value: ::std::vec::Vec<ScaleVariant8DomainArrayItem>) -> Self {
         Self::Array(value)
@@ -95724,11 +89097,6 @@ pub enum ScaleVariant8DomainArrayItem {
     SignalRef(SignalRef),
     Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant8DomainArrayItem {
-    fn from(value: &ScaleVariant8DomainArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleVariant8DomainArrayItem {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -95776,11 +89144,6 @@ pub enum ScaleVariant8DomainRaw {
     Array(::std::vec::Vec<::serde_json::Value>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant8DomainRaw {
-    fn from(value: &ScaleVariant8DomainRaw) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant8DomainRaw {
     fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
         Self::Array(value)
@@ -95817,11 +89180,6 @@ pub enum ScaleVariant8Nice {
     Boolean(bool),
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant8Nice {
-    fn from(value: &ScaleVariant8Nice) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<bool> for ScaleVariant8Nice {
     fn from(value: bool) -> Self {
@@ -95956,11 +89314,6 @@ pub enum ScaleVariant8Range {
     },
     Variant3(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant8Range {
-    fn from(value: &ScaleVariant8Range) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleVariant8RangeVariant0> for ScaleVariant8Range {
     fn from(value: ScaleVariant8RangeVariant0) -> Self {
         Self::Variant0(value)
@@ -96024,11 +89377,6 @@ pub enum ScaleVariant8RangeVariant0 {
     Diverging,
     #[serde(rename = "heatmap")]
     Heatmap,
-}
-impl ::std::convert::From<&Self> for ScaleVariant8RangeVariant0 {
-    fn from(value: &ScaleVariant8RangeVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant8RangeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -96124,11 +89472,6 @@ pub enum ScaleVariant8RangeVariant1Item {
     SignalRef(SignalRef),
     Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant8RangeVariant1Item {
-    fn from(value: &ScaleVariant8RangeVariant1Item) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleVariant8RangeVariant1Item {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -96177,11 +89520,6 @@ pub enum ScaleVariant8RangeVariant2Extent {
     Array([NumberOrSignal; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant8RangeVariant2Extent {
-    fn from(value: &ScaleVariant8RangeVariant2Extent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ScaleVariant8RangeVariant2Extent {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
         Self::Array(value)
@@ -96229,11 +89567,6 @@ pub enum ScaleVariant8RangeVariant2Scheme {
     Array(::std::vec::Vec<ScaleVariant8RangeVariant2SchemeArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant8RangeVariant2Scheme {
-    fn from(value: &ScaleVariant8RangeVariant2Scheme) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ScaleVariant8RangeVariant2SchemeArrayItem>>
     for ScaleVariant8RangeVariant2Scheme
 {
@@ -96268,11 +89601,6 @@ impl ::std::convert::From<SignalRef> for ScaleVariant8RangeVariant2Scheme {
 pub enum ScaleVariant8RangeVariant2SchemeArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant8RangeVariant2SchemeArrayItem {
-    fn from(value: &ScaleVariant8RangeVariant2SchemeArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<SignalRef> for ScaleVariant8RangeVariant2SchemeArrayItem {
     fn from(value: SignalRef) -> Self {
@@ -96312,11 +89640,6 @@ pub enum ScaleVariant8Type {
     Sqrt,
     #[serde(rename = "sequential")]
     Sequential,
-}
-impl ::std::convert::From<&Self> for ScaleVariant8Type {
-    fn from(value: &ScaleVariant8Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant8Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -96412,11 +89735,6 @@ pub enum ScaleVariant9Domain {
     ScaleData(ScaleData),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant9Domain {
-    fn from(value: &ScaleVariant9Domain) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ScaleVariant9DomainArrayItem>> for ScaleVariant9Domain {
     fn from(value: ::std::vec::Vec<ScaleVariant9DomainArrayItem>) -> Self {
         Self::Array(value)
@@ -96474,11 +89792,6 @@ pub enum ScaleVariant9DomainArrayItem {
     SignalRef(SignalRef),
     Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant9DomainArrayItem {
-    fn from(value: &ScaleVariant9DomainArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleVariant9DomainArrayItem {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -96526,11 +89839,6 @@ pub enum ScaleVariant9DomainRaw {
     Array(::std::vec::Vec<::serde_json::Value>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant9DomainRaw {
-    fn from(value: &ScaleVariant9DomainRaw) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ScaleVariant9DomainRaw {
     fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
         Self::Array(value)
@@ -96567,11 +89875,6 @@ pub enum ScaleVariant9Nice {
     Boolean(bool),
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for ScaleVariant9Nice {
-    fn from(value: &ScaleVariant9Nice) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<bool> for ScaleVariant9Nice {
     fn from(value: bool) -> Self {
@@ -96706,11 +90009,6 @@ pub enum ScaleVariant9Range {
     },
     Variant3(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant9Range {
-    fn from(value: &ScaleVariant9Range) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleVariant9RangeVariant0> for ScaleVariant9Range {
     fn from(value: ScaleVariant9RangeVariant0) -> Self {
         Self::Variant0(value)
@@ -96774,11 +90072,6 @@ pub enum ScaleVariant9RangeVariant0 {
     Diverging,
     #[serde(rename = "heatmap")]
     Heatmap,
-}
-impl ::std::convert::From<&Self> for ScaleVariant9RangeVariant0 {
-    fn from(value: &ScaleVariant9RangeVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant9RangeVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -96874,11 +90167,6 @@ pub enum ScaleVariant9RangeVariant1Item {
     SignalRef(SignalRef),
     Array(::std::vec::Vec<NumberOrSignal>),
 }
-impl ::std::convert::From<&Self> for ScaleVariant9RangeVariant1Item {
-    fn from(value: &ScaleVariant9RangeVariant1Item) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<bool> for ScaleVariant9RangeVariant1Item {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
@@ -96927,11 +90215,6 @@ pub enum ScaleVariant9RangeVariant2Extent {
     Array([NumberOrSignal; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant9RangeVariant2Extent {
-    fn from(value: &ScaleVariant9RangeVariant2Extent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[NumberOrSignal; 2usize]> for ScaleVariant9RangeVariant2Extent {
     fn from(value: [NumberOrSignal; 2usize]) -> Self {
         Self::Array(value)
@@ -96979,11 +90262,6 @@ pub enum ScaleVariant9RangeVariant2Scheme {
     Array(::std::vec::Vec<ScaleVariant9RangeVariant2SchemeArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant9RangeVariant2Scheme {
-    fn from(value: &ScaleVariant9RangeVariant2Scheme) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<ScaleVariant9RangeVariant2SchemeArrayItem>>
     for ScaleVariant9RangeVariant2Scheme
 {
@@ -97019,11 +90297,6 @@ pub enum ScaleVariant9RangeVariant2SchemeArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for ScaleVariant9RangeVariant2SchemeArrayItem {
-    fn from(value: &ScaleVariant9RangeVariant2SchemeArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for ScaleVariant9RangeVariant2SchemeArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -97056,11 +90329,6 @@ impl ::std::convert::From<SignalRef> for ScaleVariant9RangeVariant2SchemeArrayIt
 pub enum ScaleVariant9Type {
     #[serde(rename = "log")]
     Log,
-}
-impl ::std::convert::From<&Self> for ScaleVariant9Type {
-    fn from(value: &ScaleVariant9Type) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ScaleVariant9Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -97198,11 +90466,6 @@ pub struct Scope {
     #[serde(default, skip_serializing_if = "::serde_json::Map::is_empty")]
     pub usermeta: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
 }
-impl ::std::convert::From<&Scope> for Scope {
-    fn from(value: &Scope) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for Scope {
     fn default() -> Self {
         Self {
@@ -97242,11 +90505,6 @@ impl ::std::default::Default for Scope {
 pub enum ScopeMarksItem {
     Group(MarkGroup),
     Visual(MarkVisual),
-}
-impl ::std::convert::From<&Self> for ScopeMarksItem {
-    fn from(value: &ScopeMarksItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<MarkGroup> for ScopeMarksItem {
     fn from(value: MarkGroup) -> Self {
@@ -97290,11 +90548,6 @@ impl ::std::ops::Deref for Selector {
 impl ::std::convert::From<Selector> for ::std::string::String {
     fn from(value: Selector) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&Selector> for Selector {
-    fn from(value: &Selector) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<::std::string::String> for Selector {
@@ -97395,11 +90648,6 @@ pub struct SequenceTransform {
     #[serde(rename = "type")]
     pub type_: SequenceTransformType,
 }
-impl ::std::convert::From<&SequenceTransform> for SequenceTransform {
-    fn from(value: &SequenceTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SequenceTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -97423,11 +90671,6 @@ impl ::std::convert::From<&SequenceTransform> for SequenceTransform {
 pub enum SequenceTransformAs {
     String(::std::string::String),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for SequenceTransformAs {
-    fn from(value: &SequenceTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for SequenceTransformAs {
     fn default() -> Self {
@@ -97462,11 +90705,6 @@ pub enum SequenceTransformStart {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for SequenceTransformStart {
-    fn from(value: &SequenceTransformStart) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for SequenceTransformStart {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -97500,11 +90738,6 @@ impl ::std::convert::From<SignalRef> for SequenceTransformStart {
 pub enum SequenceTransformStep {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for SequenceTransformStep {
-    fn from(value: &SequenceTransformStep) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for SequenceTransformStep {
     fn default() -> Self {
@@ -97544,11 +90777,6 @@ pub enum SequenceTransformStop {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for SequenceTransformStop {
-    fn from(value: &SequenceTransformStop) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for SequenceTransformStop {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -97586,11 +90814,6 @@ impl ::std::convert::From<SignalRef> for SequenceTransformStop {
 pub enum SequenceTransformType {
     #[serde(rename = "sequence")]
     Sequence,
-}
-impl ::std::convert::From<&Self> for SequenceTransformType {
-    fn from(value: &SequenceTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for SequenceTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -97759,11 +90982,6 @@ pub enum Signal {
         value: ::std::option::Option<::serde_json::Value>,
     },
 }
-impl ::std::convert::From<&Self> for Signal {
-    fn from(value: &Signal) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SignalName`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -97794,11 +91012,6 @@ impl ::std::ops::Deref for SignalName {
 impl ::std::convert::From<SignalName> for ::std::string::String {
     fn from(value: SignalName) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&SignalName> for SignalName {
-    fn from(value: &SignalName) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::TryFrom<::std::string::String> for SignalName {
@@ -97851,11 +91064,6 @@ impl<'de> ::serde::Deserialize<'de> for SignalName {
 pub struct SignalRef {
     pub signal: ::std::string::String,
 }
-impl ::std::convert::From<&SignalRef> for SignalRef {
-    fn from(value: &SignalRef) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`SignalVariant0Push`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -97883,11 +91091,6 @@ impl ::std::convert::From<&SignalRef> for SignalRef {
 pub enum SignalVariant0Push {
     #[serde(rename = "outer")]
     Outer,
-}
-impl ::std::convert::From<&Self> for SignalVariant0Push {
-    fn from(value: &SignalVariant0Push) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for SignalVariant0Push {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -97953,11 +91156,6 @@ pub enum SortOrder {
     Variant0(SortOrderVariant0),
     Variant1(SignalRef),
 }
-impl ::std::convert::From<&Self> for SortOrder {
-    fn from(value: &SortOrder) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SortOrderVariant0> for SortOrder {
     fn from(value: SortOrderVariant0) -> Self {
         Self::Variant0(value)
@@ -97998,11 +91196,6 @@ pub enum SortOrderVariant0 {
     Ascending,
     #[serde(rename = "descending")]
     Descending,
-}
-impl ::std::convert::From<&Self> for SortOrderVariant0 {
-    fn from(value: &SortOrderVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for SortOrderVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -98166,11 +91359,6 @@ pub struct StackTransform {
     #[serde(rename = "type")]
     pub type_: StackTransformType,
 }
-impl ::std::convert::From<&StackTransform> for StackTransform {
-    fn from(value: &StackTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StackTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -98209,11 +91397,6 @@ impl ::std::convert::From<&StackTransform> for StackTransform {
 pub enum StackTransformAs {
     Array([StackTransformAsArrayItem; 2usize]),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for StackTransformAs {
-    fn from(value: &StackTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for StackTransformAs {
     fn default() -> Self {
@@ -98256,11 +91439,6 @@ pub enum StackTransformAsArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for StackTransformAsArrayItem {
-    fn from(value: &StackTransformAsArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for StackTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -98292,11 +91470,6 @@ pub enum StackTransformField {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for StackTransformField {
-    fn from(value: &StackTransformField) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for StackTransformField {
     fn from(value: ScaleField) -> Self {
@@ -98349,11 +91522,6 @@ pub enum StackTransformGroupby {
     Array(::std::vec::Vec<StackTransformGroupbyArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for StackTransformGroupby {
-    fn from(value: &StackTransformGroupby) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<StackTransformGroupbyArrayItem>>
     for StackTransformGroupby
 {
@@ -98392,11 +91560,6 @@ pub enum StackTransformGroupbyArrayItem {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for StackTransformGroupbyArrayItem {
-    fn from(value: &StackTransformGroupbyArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for StackTransformGroupbyArrayItem {
     fn from(value: ScaleField) -> Self {
@@ -98440,11 +91603,6 @@ impl ::std::convert::From<Expr> for StackTransformGroupbyArrayItem {
 pub enum StackTransformOffset {
     Variant0(StackTransformOffsetVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for StackTransformOffset {
-    fn from(value: &StackTransformOffset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for StackTransformOffset {
     fn default() -> Self {
@@ -98494,11 +91652,6 @@ pub enum StackTransformOffsetVariant0 {
     Center,
     #[serde(rename = "normalize")]
     Normalize,
-}
-impl ::std::convert::From<&Self> for StackTransformOffsetVariant0 {
-    fn from(value: &StackTransformOffsetVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for StackTransformOffsetVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -98569,11 +91722,6 @@ impl ::std::convert::TryFrom<::std::string::String> for StackTransformOffsetVari
 pub enum StackTransformType {
     #[serde(rename = "stack")]
     Stack,
-}
-impl ::std::convert::From<&Self> for StackTransformType {
-    fn from(value: &StackTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for StackTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -98676,11 +91824,6 @@ pub struct StratifyTransform {
     #[serde(rename = "type")]
     pub type_: StratifyTransformType,
 }
-impl ::std::convert::From<&StratifyTransform> for StratifyTransform {
-    fn from(value: &StratifyTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StratifyTransformKey`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -98707,11 +91850,6 @@ pub enum StratifyTransformKey {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for StratifyTransformKey {
-    fn from(value: &StratifyTransformKey) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for StratifyTransformKey {
     fn from(value: ScaleField) -> Self {
@@ -98755,11 +91893,6 @@ pub enum StratifyTransformParentKey {
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for StratifyTransformParentKey {
-    fn from(value: &StratifyTransformParentKey) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleField> for StratifyTransformParentKey {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
@@ -98802,11 +91935,6 @@ impl ::std::convert::From<Expr> for StratifyTransformParentKey {
 pub enum StratifyTransformType {
     #[serde(rename = "stratify")]
     Stratify,
-}
-impl ::std::convert::From<&Self> for StratifyTransformType {
-    fn from(value: &StratifyTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for StratifyTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -99001,11 +92129,6 @@ pub enum Stream {
         throttle: ::std::option::Option<f64>,
     },
 }
-impl ::std::convert::From<&Self> for Stream {
-    fn from(value: &Stream) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StreamVariant0Filter`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -99032,11 +92155,6 @@ impl ::std::convert::From<&Self> for Stream {
 pub enum StreamVariant0Filter {
     ExprString(ExprString),
     Array(::std::vec::Vec<ExprString>),
-}
-impl ::std::convert::From<&Self> for StreamVariant0Filter {
-    fn from(value: &StreamVariant0Filter) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ExprString> for StreamVariant0Filter {
     fn from(value: ExprString) -> Self {
@@ -99075,11 +92193,6 @@ pub enum StreamVariant1Filter {
     ExprString(ExprString),
     Array(::std::vec::Vec<ExprString>),
 }
-impl ::std::convert::From<&Self> for StreamVariant1Filter {
-    fn from(value: &StreamVariant1Filter) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ExprString> for StreamVariant1Filter {
     fn from(value: ExprString) -> Self {
         Self::ExprString(value)
@@ -99117,11 +92230,6 @@ pub enum StreamVariant2Filter {
     ExprString(ExprString),
     Array(::std::vec::Vec<ExprString>),
 }
-impl ::std::convert::From<&Self> for StreamVariant2Filter {
-    fn from(value: &StreamVariant2Filter) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ExprString> for StreamVariant2Filter {
     fn from(value: ExprString) -> Self {
         Self::ExprString(value)
@@ -99152,11 +92260,6 @@ pub struct StringModifiers {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub scale: ::std::option::Option<Field>,
 }
-impl ::std::convert::From<&StringModifiers> for StringModifiers {
-    fn from(value: &StringModifiers) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for StringModifiers {
     fn default() -> Self {
         Self {
@@ -99186,11 +92289,6 @@ impl ::std::default::Default for StringModifiers {
 pub enum StringOrSignal {
     String(::std::string::String),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for StringOrSignal {
-    fn from(value: &StringOrSignal) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<SignalRef> for StringOrSignal {
     fn from(value: SignalRef) -> Self {
@@ -99380,11 +92478,6 @@ pub enum StringValue {
     Variant0(::std::vec::Vec<StringValueVariant0Item>),
     Variant1(StringValueVariant1),
 }
-impl ::std::convert::From<&Self> for StringValue {
-    fn from(value: &StringValue) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<StringValueVariant0Item>> for StringValue {
     fn from(value: ::std::vec::Vec<StringValueVariant0Item>) -> Self {
         Self::Variant0(value)
@@ -99498,11 +92591,6 @@ pub enum StringValueVariant0Item {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
-}
-impl ::std::convert::From<&Self> for StringValueVariant0Item {
-    fn from(value: &StringValueVariant0Item) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<StringValueVariant0ItemVariant0> for StringValueVariant0Item {
     fn from(value: StringValueVariant0ItemVariant0) -> Self {
@@ -99646,11 +92734,6 @@ pub enum StringValueVariant0ItemVariant0 {
         test: ::std::option::Option<::std::string::String>,
     },
 }
-impl ::std::convert::From<&Self> for StringValueVariant0ItemVariant0 {
-    fn from(value: &StringValueVariant0ItemVariant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StringValueVariant0ItemVariant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -99673,11 +92756,6 @@ impl ::std::convert::From<&Self> for StringValueVariant0ItemVariant0 {
 pub enum StringValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for StringValueVariant0ItemVariant0Variant3Range {
-    fn from(value: &StringValueVariant0ItemVariant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for StringValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -99844,11 +92922,6 @@ impl ::std::convert::From<bool> for StringValueVariant0ItemVariant0Variant3Range
 )]
 #[serde(deny_unknown_fields)]
 pub enum StringValueVariant0ItemVariant1 {}
-impl ::std::convert::From<&Self> for StringValueVariant0ItemVariant1 {
-    fn from(value: &StringValueVariant0ItemVariant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StringValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -99958,11 +93031,6 @@ impl ::std::convert::From<&Self> for StringValueVariant0ItemVariant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum StringValueVariant0ItemVariant2 {}
-impl ::std::convert::From<&Self> for StringValueVariant0ItemVariant2 {
-    fn from(value: &StringValueVariant0ItemVariant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StringValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -100055,11 +93123,6 @@ pub enum StringValueVariant1 {
     Variant1(StringValueVariant1Variant1),
     Variant2(StringValueVariant1Variant2),
     Variant3 { offset: ::serde_json::Value },
-}
-impl ::std::convert::From<&Self> for StringValueVariant1 {
-    fn from(value: &StringValueVariant1) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<StringValueVariant1Variant0> for StringValueVariant1 {
     fn from(value: StringValueVariant1Variant0) -> Self {
@@ -100192,11 +93255,6 @@ pub enum StringValueVariant1Variant0 {
         scale: ::std::option::Option<Field>,
     },
 }
-impl ::std::convert::From<&Self> for StringValueVariant1Variant0 {
-    fn from(value: &StringValueVariant1Variant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StringValueVariant1Variant0Variant3Range`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -100219,11 +93277,6 @@ impl ::std::convert::From<&Self> for StringValueVariant1Variant0 {
 pub enum StringValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for StringValueVariant1Variant0Variant3Range {
-    fn from(value: &StringValueVariant1Variant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for StringValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -100383,11 +93436,6 @@ impl ::std::convert::From<bool> for StringValueVariant1Variant0Variant3Range {
 )]
 #[serde(deny_unknown_fields)]
 pub enum StringValueVariant1Variant1 {}
-impl ::std::convert::From<&Self> for StringValueVariant1Variant1 {
-    fn from(value: &StringValueVariant1Variant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StringValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -100494,11 +93542,6 @@ impl ::std::convert::From<&Self> for StringValueVariant1Variant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum StringValueVariant1Variant2 {}
-impl ::std::convert::From<&Self> for StringValueVariant1Variant2 {
-    fn from(value: &StringValueVariant1Variant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StrokeCapValue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -100690,11 +93733,6 @@ pub enum StrokeCapValue {
     Variant0(::std::vec::Vec<StrokeCapValueVariant0Item>),
     Variant1(StrokeCapValueVariant1),
 }
-impl ::std::convert::From<&Self> for StrokeCapValue {
-    fn from(value: &StrokeCapValue) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<StrokeCapValueVariant0Item>> for StrokeCapValue {
     fn from(value: ::std::vec::Vec<StrokeCapValueVariant0Item>) -> Self {
         Self::Variant0(value)
@@ -100812,11 +93850,6 @@ pub enum StrokeCapValueVariant0Item {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
-}
-impl ::std::convert::From<&Self> for StrokeCapValueVariant0Item {
-    fn from(value: &StrokeCapValueVariant0Item) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<StrokeCapValueVariant0ItemVariant0> for StrokeCapValueVariant0Item {
     fn from(value: StrokeCapValueVariant0ItemVariant0) -> Self {
@@ -100964,11 +93997,6 @@ pub enum StrokeCapValueVariant0ItemVariant0 {
         test: ::std::option::Option<::std::string::String>,
     },
 }
-impl ::std::convert::From<&Self> for StrokeCapValueVariant0ItemVariant0 {
-    fn from(value: &StrokeCapValueVariant0ItemVariant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StrokeCapValueVariant0ItemVariant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -101002,11 +94030,6 @@ pub enum StrokeCapValueVariant0ItemVariant0Variant1Value {
     Round,
     #[serde(rename = "square")]
     Square,
-}
-impl ::std::convert::From<&Self> for StrokeCapValueVariant0ItemVariant0Variant1Value {
-    fn from(value: &StrokeCapValueVariant0ItemVariant0Variant1Value) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for StrokeCapValueVariant0ItemVariant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -101076,11 +94099,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum StrokeCapValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for StrokeCapValueVariant0ItemVariant0Variant3Range {
-    fn from(value: &StrokeCapValueVariant0ItemVariant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for StrokeCapValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -101251,11 +94269,6 @@ impl ::std::convert::From<bool> for StrokeCapValueVariant0ItemVariant0Variant3Ra
 )]
 #[serde(deny_unknown_fields)]
 pub enum StrokeCapValueVariant0ItemVariant1 {}
-impl ::std::convert::From<&Self> for StrokeCapValueVariant0ItemVariant1 {
-    fn from(value: &StrokeCapValueVariant0ItemVariant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StrokeCapValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -101369,11 +94382,6 @@ impl ::std::convert::From<&Self> for StrokeCapValueVariant0ItemVariant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum StrokeCapValueVariant0ItemVariant2 {}
-impl ::std::convert::From<&Self> for StrokeCapValueVariant0ItemVariant2 {
-    fn from(value: &StrokeCapValueVariant0ItemVariant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StrokeCapValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -101470,11 +94478,6 @@ pub enum StrokeCapValueVariant1 {
     Variant1(StrokeCapValueVariant1Variant1),
     Variant2(StrokeCapValueVariant1Variant2),
     Variant3 { offset: ::serde_json::Value },
-}
-impl ::std::convert::From<&Self> for StrokeCapValueVariant1 {
-    fn from(value: &StrokeCapValueVariant1) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<StrokeCapValueVariant1Variant0> for StrokeCapValueVariant1 {
     fn from(value: StrokeCapValueVariant1Variant0) -> Self {
@@ -101611,11 +94614,6 @@ pub enum StrokeCapValueVariant1Variant0 {
         scale: ::std::option::Option<Field>,
     },
 }
-impl ::std::convert::From<&Self> for StrokeCapValueVariant1Variant0 {
-    fn from(value: &StrokeCapValueVariant1Variant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StrokeCapValueVariant1Variant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -101649,11 +94647,6 @@ pub enum StrokeCapValueVariant1Variant0Variant1Value {
     Round,
     #[serde(rename = "square")]
     Square,
-}
-impl ::std::convert::From<&Self> for StrokeCapValueVariant1Variant0Variant1Value {
-    fn from(value: &StrokeCapValueVariant1Variant0Variant1Value) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for StrokeCapValueVariant1Variant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -101723,11 +94716,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum StrokeCapValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for StrokeCapValueVariant1Variant0Variant3Range {
-    fn from(value: &StrokeCapValueVariant1Variant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for StrokeCapValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -101895,11 +94883,6 @@ impl ::std::convert::From<bool> for StrokeCapValueVariant1Variant0Variant3Range 
 )]
 #[serde(deny_unknown_fields)]
 pub enum StrokeCapValueVariant1Variant1 {}
-impl ::std::convert::From<&Self> for StrokeCapValueVariant1Variant1 {
-    fn from(value: &StrokeCapValueVariant1Variant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StrokeCapValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -102010,11 +94993,6 @@ impl ::std::convert::From<&Self> for StrokeCapValueVariant1Variant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum StrokeCapValueVariant1Variant2 {}
-impl ::std::convert::From<&Self> for StrokeCapValueVariant1Variant2 {
-    fn from(value: &StrokeCapValueVariant1Variant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StrokeJoinValue`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -102206,11 +95184,6 @@ pub enum StrokeJoinValue {
     Variant0(::std::vec::Vec<StrokeJoinValueVariant0Item>),
     Variant1(StrokeJoinValueVariant1),
 }
-impl ::std::convert::From<&Self> for StrokeJoinValue {
-    fn from(value: &StrokeJoinValue) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<StrokeJoinValueVariant0Item>> for StrokeJoinValue {
     fn from(value: ::std::vec::Vec<StrokeJoinValueVariant0Item>) -> Self {
         Self::Variant0(value)
@@ -102328,11 +95301,6 @@ pub enum StrokeJoinValueVariant0Item {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
-}
-impl ::std::convert::From<&Self> for StrokeJoinValueVariant0Item {
-    fn from(value: &StrokeJoinValueVariant0Item) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<StrokeJoinValueVariant0ItemVariant0> for StrokeJoinValueVariant0Item {
     fn from(value: StrokeJoinValueVariant0ItemVariant0) -> Self {
@@ -102480,11 +95448,6 @@ pub enum StrokeJoinValueVariant0ItemVariant0 {
         test: ::std::option::Option<::std::string::String>,
     },
 }
-impl ::std::convert::From<&Self> for StrokeJoinValueVariant0ItemVariant0 {
-    fn from(value: &StrokeJoinValueVariant0ItemVariant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StrokeJoinValueVariant0ItemVariant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -102518,11 +95481,6 @@ pub enum StrokeJoinValueVariant0ItemVariant0Variant1Value {
     Round,
     #[serde(rename = "bevel")]
     Bevel,
-}
-impl ::std::convert::From<&Self> for StrokeJoinValueVariant0ItemVariant0Variant1Value {
-    fn from(value: &StrokeJoinValueVariant0ItemVariant0Variant1Value) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for StrokeJoinValueVariant0ItemVariant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -102592,11 +95550,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum StrokeJoinValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for StrokeJoinValueVariant0ItemVariant0Variant3Range {
-    fn from(value: &StrokeJoinValueVariant0ItemVariant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for StrokeJoinValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -102767,11 +95720,6 @@ impl ::std::convert::From<bool> for StrokeJoinValueVariant0ItemVariant0Variant3R
 )]
 #[serde(deny_unknown_fields)]
 pub enum StrokeJoinValueVariant0ItemVariant1 {}
-impl ::std::convert::From<&Self> for StrokeJoinValueVariant0ItemVariant1 {
-    fn from(value: &StrokeJoinValueVariant0ItemVariant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StrokeJoinValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -102885,11 +95833,6 @@ impl ::std::convert::From<&Self> for StrokeJoinValueVariant0ItemVariant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum StrokeJoinValueVariant0ItemVariant2 {}
-impl ::std::convert::From<&Self> for StrokeJoinValueVariant0ItemVariant2 {
-    fn from(value: &StrokeJoinValueVariant0ItemVariant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StrokeJoinValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -102986,11 +95929,6 @@ pub enum StrokeJoinValueVariant1 {
     Variant1(StrokeJoinValueVariant1Variant1),
     Variant2(StrokeJoinValueVariant1Variant2),
     Variant3 { offset: ::serde_json::Value },
-}
-impl ::std::convert::From<&Self> for StrokeJoinValueVariant1 {
-    fn from(value: &StrokeJoinValueVariant1) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<StrokeJoinValueVariant1Variant0> for StrokeJoinValueVariant1 {
     fn from(value: StrokeJoinValueVariant1Variant0) -> Self {
@@ -103127,11 +96065,6 @@ pub enum StrokeJoinValueVariant1Variant0 {
         scale: ::std::option::Option<Field>,
     },
 }
-impl ::std::convert::From<&Self> for StrokeJoinValueVariant1Variant0 {
-    fn from(value: &StrokeJoinValueVariant1Variant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StrokeJoinValueVariant1Variant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -103165,11 +96098,6 @@ pub enum StrokeJoinValueVariant1Variant0Variant1Value {
     Round,
     #[serde(rename = "bevel")]
     Bevel,
-}
-impl ::std::convert::From<&Self> for StrokeJoinValueVariant1Variant0Variant1Value {
-    fn from(value: &StrokeJoinValueVariant1Variant0Variant1Value) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for StrokeJoinValueVariant1Variant0Variant1Value {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -103239,11 +96167,6 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum StrokeJoinValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for StrokeJoinValueVariant1Variant0Variant3Range {
-    fn from(value: &StrokeJoinValueVariant1Variant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for StrokeJoinValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -103411,11 +96334,6 @@ impl ::std::convert::From<bool> for StrokeJoinValueVariant1Variant0Variant3Range
 )]
 #[serde(deny_unknown_fields)]
 pub enum StrokeJoinValueVariant1Variant1 {}
-impl ::std::convert::From<&Self> for StrokeJoinValueVariant1Variant1 {
-    fn from(value: &StrokeJoinValueVariant1Variant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StrokeJoinValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -103526,11 +96444,6 @@ impl ::std::convert::From<&Self> for StrokeJoinValueVariant1Variant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum StrokeJoinValueVariant1Variant2 {}
-impl ::std::convert::From<&Self> for StrokeJoinValueVariant1Variant2 {
-    fn from(value: &StrokeJoinValueVariant1Variant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`Style`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -103556,11 +96469,6 @@ impl ::std::convert::From<&Self> for StrokeJoinValueVariant1Variant2 {
 pub enum Style {
     String(::std::string::String),
     Array(::std::vec::Vec<::std::string::String>),
-}
-impl ::std::convert::From<&Self> for Style {
-    fn from(value: &Style) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<::std::string::String>> for Style {
     fn from(value: ::std::vec::Vec<::std::string::String>) -> Self {
@@ -103600,11 +96508,6 @@ pub enum TextOrSignal {
     Variant0(TextOrSignalVariant0),
     Variant1(SignalRef),
 }
-impl ::std::convert::From<&Self> for TextOrSignal {
-    fn from(value: &TextOrSignal) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<TextOrSignalVariant0> for TextOrSignal {
     fn from(value: TextOrSignalVariant0) -> Self {
         Self::Variant0(value)
@@ -103640,11 +96543,6 @@ impl ::std::convert::From<SignalRef> for TextOrSignal {
 pub enum TextOrSignalVariant0 {
     String(::std::string::String),
     Array(::std::vec::Vec<::std::string::String>),
-}
-impl ::std::convert::From<&Self> for TextOrSignalVariant0 {
-    fn from(value: &TextOrSignalVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<::std::string::String>> for TextOrSignalVariant0 {
     fn from(value: ::std::vec::Vec<::std::string::String>) -> Self {
@@ -103854,11 +96752,6 @@ pub enum TextValue {
     Variant0(::std::vec::Vec<TextValueVariant0Item>),
     Variant1(TextValueVariant1),
 }
-impl ::std::convert::From<&Self> for TextValue {
-    fn from(value: &TextValue) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<TextValueVariant0Item>> for TextValue {
     fn from(value: ::std::vec::Vec<TextValueVariant0Item>) -> Self {
         Self::Variant0(value)
@@ -103982,11 +96875,6 @@ pub enum TextValueVariant0Item {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
-}
-impl ::std::convert::From<&Self> for TextValueVariant0Item {
-    fn from(value: &TextValueVariant0Item) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<TextValueVariant0ItemVariant0> for TextValueVariant0Item {
     fn from(value: TextValueVariant0ItemVariant0) -> Self {
@@ -104140,11 +97028,6 @@ pub enum TextValueVariant0ItemVariant0 {
         test: ::std::option::Option<::std::string::String>,
     },
 }
-impl ::std::convert::From<&Self> for TextValueVariant0ItemVariant0 {
-    fn from(value: &TextValueVariant0ItemVariant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`TextValueVariant0ItemVariant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -104170,11 +97053,6 @@ impl ::std::convert::From<&Self> for TextValueVariant0ItemVariant0 {
 pub enum TextValueVariant0ItemVariant0Variant1Value {
     String(::std::string::String),
     Array(::std::vec::Vec<::std::string::String>),
-}
-impl ::std::convert::From<&Self> for TextValueVariant0ItemVariant0Variant1Value {
-    fn from(value: &TextValueVariant0ItemVariant0Variant1Value) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<::std::string::String>>
     for TextValueVariant0ItemVariant0Variant1Value
@@ -104205,11 +97083,6 @@ impl ::std::convert::From<::std::vec::Vec<::std::string::String>>
 pub enum TextValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for TextValueVariant0ItemVariant0Variant3Range {
-    fn from(value: &TextValueVariant0ItemVariant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for TextValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -104384,11 +97257,6 @@ impl ::std::convert::From<bool> for TextValueVariant0ItemVariant0Variant3Range {
 )]
 #[serde(deny_unknown_fields)]
 pub enum TextValueVariant0ItemVariant1 {}
-impl ::std::convert::From<&Self> for TextValueVariant0ItemVariant1 {
-    fn from(value: &TextValueVariant0ItemVariant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`TextValueVariant0ItemVariant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -104508,11 +97376,6 @@ impl ::std::convert::From<&Self> for TextValueVariant0ItemVariant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum TextValueVariant0ItemVariant2 {}
-impl ::std::convert::From<&Self> for TextValueVariant0ItemVariant2 {
-    fn from(value: &TextValueVariant0ItemVariant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`TextValueVariant1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -104615,11 +97478,6 @@ pub enum TextValueVariant1 {
     Variant1(TextValueVariant1Variant1),
     Variant2(TextValueVariant1Variant2),
     Variant3 { offset: ::serde_json::Value },
-}
-impl ::std::convert::From<&Self> for TextValueVariant1 {
-    fn from(value: &TextValueVariant1) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<TextValueVariant1Variant0> for TextValueVariant1 {
     fn from(value: TextValueVariant1Variant0) -> Self {
@@ -104762,11 +97620,6 @@ pub enum TextValueVariant1Variant0 {
         scale: ::std::option::Option<Field>,
     },
 }
-impl ::std::convert::From<&Self> for TextValueVariant1Variant0 {
-    fn from(value: &TextValueVariant1Variant0) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`TextValueVariant1Variant0Variant1Value`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -104792,11 +97645,6 @@ impl ::std::convert::From<&Self> for TextValueVariant1Variant0 {
 pub enum TextValueVariant1Variant0Variant1Value {
     String(::std::string::String),
     Array(::std::vec::Vec<::std::string::String>),
-}
-impl ::std::convert::From<&Self> for TextValueVariant1Variant0Variant1Value {
-    fn from(value: &TextValueVariant1Variant0Variant1Value) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<::std::string::String>>
     for TextValueVariant1Variant0Variant1Value
@@ -104827,11 +97675,6 @@ impl ::std::convert::From<::std::vec::Vec<::std::string::String>>
 pub enum TextValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
-}
-impl ::std::convert::From<&Self> for TextValueVariant1Variant0Variant3Range {
-    fn from(value: &TextValueVariant1Variant0Variant3Range) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for TextValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -105001,11 +97844,6 @@ impl ::std::convert::From<bool> for TextValueVariant1Variant0Variant3Range {
 )]
 #[serde(deny_unknown_fields)]
 pub enum TextValueVariant1Variant1 {}
-impl ::std::convert::From<&Self> for TextValueVariant1Variant1 {
-    fn from(value: &TextValueVariant1Variant1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`TextValueVariant1Variant2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -105122,11 +97960,6 @@ impl ::std::convert::From<&Self> for TextValueVariant1Variant1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum TextValueVariant1Variant2 {}
-impl ::std::convert::From<&Self> for TextValueVariant1Variant2 {
-    fn from(value: &TextValueVariant1Variant2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`TickBand`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -105152,11 +97985,6 @@ impl ::std::convert::From<&Self> for TextValueVariant1Variant2 {
 pub enum TickBand {
     Variant0(TickBandVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for TickBand {
-    fn from(value: &TickBand) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<TickBandVariant0> for TickBand {
     fn from(value: TickBandVariant0) -> Self {
@@ -105198,11 +98026,6 @@ pub enum TickBandVariant0 {
     Center,
     #[serde(rename = "extent")]
     Extent,
-}
-impl ::std::convert::From<&Self> for TickBandVariant0 {
-    fn from(value: &TickBandVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for TickBandVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -105316,11 +98139,6 @@ pub enum TickCount {
     },
     Variant3(SignalRef),
 }
-impl ::std::convert::From<&Self> for TickCount {
-    fn from(value: &TickCount) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for TickCount {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -105384,11 +98202,6 @@ pub enum TickCountVariant1 {
     Month,
     #[serde(rename = "year")]
     Year,
-}
-impl ::std::convert::From<&Self> for TickCountVariant1 {
-    fn from(value: &TickCountVariant1) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for TickCountVariant1 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -105474,11 +98287,6 @@ pub enum TickCountVariant2Interval {
     Variant0(TickCountVariant2IntervalVariant0),
     Variant1(SignalRef),
 }
-impl ::std::convert::From<&Self> for TickCountVariant2Interval {
-    fn from(value: &TickCountVariant2Interval) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<TickCountVariant2IntervalVariant0> for TickCountVariant2Interval {
     fn from(value: TickCountVariant2IntervalVariant0) -> Self {
         Self::Variant0(value)
@@ -105537,11 +98345,6 @@ pub enum TickCountVariant2IntervalVariant0 {
     Month,
     #[serde(rename = "year")]
     Year,
-}
-impl ::std::convert::From<&Self> for TickCountVariant2IntervalVariant0 {
-    fn from(value: &TickCountVariant2IntervalVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for TickCountVariant2IntervalVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -105781,11 +98584,6 @@ pub struct TimeunitTransform {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub units: ::std::option::Option<TimeunitTransformUnits>,
 }
-impl ::std::convert::From<&TimeunitTransform> for TimeunitTransform {
-    fn from(value: &TimeunitTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`TimeunitTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -105824,11 +98622,6 @@ impl ::std::convert::From<&TimeunitTransform> for TimeunitTransform {
 pub enum TimeunitTransformAs {
     Array([TimeunitTransformAsArrayItem; 2usize]),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for TimeunitTransformAs {
-    fn from(value: &TimeunitTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for TimeunitTransformAs {
     fn default() -> Self {
@@ -105871,11 +98664,6 @@ pub enum TimeunitTransformAsArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for TimeunitTransformAsArrayItem {
-    fn from(value: &TimeunitTransformAsArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for TimeunitTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -105914,11 +98702,6 @@ pub enum TimeunitTransformExtent {
     Array(::std::vec::Vec<TimeunitTransformExtentArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for TimeunitTransformExtent {
-    fn from(value: &TimeunitTransformExtent) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<TimeunitTransformExtentArrayItem>>
     for TimeunitTransformExtent
 {
@@ -105953,11 +98736,6 @@ impl ::std::convert::From<SignalRef> for TimeunitTransformExtent {
 pub enum TimeunitTransformExtentArrayItem {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for TimeunitTransformExtentArrayItem {
-    fn from(value: &TimeunitTransformExtentArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for TimeunitTransformExtentArrayItem {
     fn from(value: f64) -> Self {
@@ -105995,11 +98773,6 @@ pub enum TimeunitTransformField {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for TimeunitTransformField {
-    fn from(value: &TimeunitTransformField) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for TimeunitTransformField {
     fn from(value: ScaleField) -> Self {
@@ -106040,11 +98813,6 @@ pub enum TimeunitTransformInterval {
     Boolean(bool),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for TimeunitTransformInterval {
-    fn from(value: &TimeunitTransformInterval) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for TimeunitTransformInterval {
     fn default() -> Self {
         TimeunitTransformInterval::Boolean(true)
@@ -106084,11 +98852,6 @@ pub enum TimeunitTransformMaxbins {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for TimeunitTransformMaxbins {
-    fn from(value: &TimeunitTransformMaxbins) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for TimeunitTransformMaxbins {
     fn default() -> Self {
         TimeunitTransformMaxbins::Number(40_f64)
@@ -106127,11 +98890,6 @@ impl ::std::convert::From<SignalRef> for TimeunitTransformMaxbins {
 pub enum TimeunitTransformStep {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for TimeunitTransformStep {
-    fn from(value: &TimeunitTransformStep) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for TimeunitTransformStep {
     fn default() -> Self {
@@ -106174,11 +98932,6 @@ impl ::std::convert::From<SignalRef> for TimeunitTransformStep {
 pub enum TimeunitTransformTimezone {
     Variant0(TimeunitTransformTimezoneVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for TimeunitTransformTimezone {
-    fn from(value: &TimeunitTransformTimezone) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for TimeunitTransformTimezone {
     fn default() -> Self {
@@ -106225,11 +98978,6 @@ pub enum TimeunitTransformTimezoneVariant0 {
     Local,
     #[serde(rename = "utc")]
     Utc,
-}
-impl ::std::convert::From<&Self> for TimeunitTransformTimezoneVariant0 {
-    fn from(value: &TimeunitTransformTimezoneVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for TimeunitTransformTimezoneVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -106298,11 +99046,6 @@ impl ::std::convert::TryFrom<::std::string::String> for TimeunitTransformTimezon
 pub enum TimeunitTransformType {
     #[serde(rename = "timeunit")]
     Timeunit,
-}
-impl ::std::convert::From<&Self> for TimeunitTransformType {
-    fn from(value: &TimeunitTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for TimeunitTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -106387,11 +99130,6 @@ pub enum TimeunitTransformUnits {
     Array(::std::vec::Vec<TimeunitTransformUnitsArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for TimeunitTransformUnits {
-    fn from(value: &TimeunitTransformUnits) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<TimeunitTransformUnitsArrayItem>>
     for TimeunitTransformUnits
 {
@@ -106438,11 +99176,6 @@ impl ::std::convert::From<SignalRef> for TimeunitTransformUnits {
 pub enum TimeunitTransformUnitsArrayItem {
     Variant0(TimeunitTransformUnitsArrayItemVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for TimeunitTransformUnitsArrayItem {
-    fn from(value: &TimeunitTransformUnitsArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<TimeunitTransformUnitsArrayItemVariant0>
     for TimeunitTransformUnitsArrayItem
@@ -106513,11 +99246,6 @@ pub enum TimeunitTransformUnitsArrayItemVariant0 {
     Seconds,
     #[serde(rename = "milliseconds")]
     Milliseconds,
-}
-impl ::std::convert::From<&Self> for TimeunitTransformUnitsArrayItemVariant0 {
-    fn from(value: &TimeunitTransformUnitsArrayItemVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for TimeunitTransformUnitsArrayItemVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -107062,11 +99790,6 @@ pub enum Title {
         zindex: ::std::option::Option<f64>,
     },
 }
-impl ::std::convert::From<&Self> for Title {
-    fn from(value: &Title) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`TitleObjectAlign`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -107093,11 +99816,6 @@ impl ::std::convert::From<&Self> for Title {
 pub enum TitleObjectAlign {
     Variant0(TitleObjectAlignVariant0),
     Variant1(AlignValue),
-}
-impl ::std::convert::From<&Self> for TitleObjectAlign {
-    fn from(value: &TitleObjectAlign) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<TitleObjectAlignVariant0> for TitleObjectAlign {
     fn from(value: TitleObjectAlignVariant0) -> Self {
@@ -107142,11 +99860,6 @@ pub enum TitleObjectAlignVariant0 {
     Right,
     #[serde(rename = "center")]
     Center,
-}
-impl ::std::convert::From<&Self> for TitleObjectAlignVariant0 {
-    fn from(value: &TitleObjectAlignVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for TitleObjectAlignVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -107218,11 +99931,6 @@ pub enum TitleObjectAnchor {
     Variant0(::std::option::Option<TitleObjectAnchorVariant0>),
     Variant1(AnchorValue),
 }
-impl ::std::convert::From<&Self> for TitleObjectAnchor {
-    fn from(value: &TitleObjectAnchor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::option::Option<TitleObjectAnchorVariant0>> for TitleObjectAnchor {
     fn from(value: ::std::option::Option<TitleObjectAnchorVariant0>) -> Self {
         Self::Variant0(value)
@@ -107267,11 +99975,6 @@ pub enum TitleObjectAnchorVariant0 {
     Middle,
     #[serde(rename = "end")]
     End,
-}
-impl ::std::convert::From<&Self> for TitleObjectAnchorVariant0 {
-    fn from(value: &TitleObjectAnchorVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for TitleObjectAnchorVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -107338,11 +100041,6 @@ pub enum TitleObjectAngle {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for TitleObjectAngle {
-    fn from(value: &TitleObjectAngle) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for TitleObjectAngle {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -107382,11 +100080,6 @@ impl ::std::convert::From<NumberValue> for TitleObjectAngle {
 pub enum TitleObjectBaseline {
     Variant0(TitleObjectBaselineVariant0),
     Variant1(BaselineValue),
-}
-impl ::std::convert::From<&Self> for TitleObjectBaseline {
-    fn from(value: &TitleObjectBaseline) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<TitleObjectBaselineVariant0> for TitleObjectBaseline {
     fn from(value: TitleObjectBaselineVariant0) -> Self {
@@ -107440,11 +100133,6 @@ pub enum TitleObjectBaselineVariant0 {
     LineTop,
     #[serde(rename = "line-bottom")]
     LineBottom,
-}
-impl ::std::convert::From<&Self> for TitleObjectBaselineVariant0 {
-    fn from(value: &TitleObjectBaselineVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for TitleObjectBaselineVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -107521,11 +100209,6 @@ pub enum TitleObjectColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for TitleObjectColor {
-    fn from(value: &TitleObjectColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for TitleObjectColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -107553,11 +100236,6 @@ impl ::std::convert::From<ColorValue> for TitleObjectColor {
 pub enum TitleObjectDx {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for TitleObjectDx {
-    fn from(value: &TitleObjectDx) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for TitleObjectDx {
     fn from(value: f64) -> Self {
@@ -107591,11 +100269,6 @@ impl ::std::convert::From<NumberValue> for TitleObjectDx {
 pub enum TitleObjectDy {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for TitleObjectDy {
-    fn from(value: &TitleObjectDy) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for TitleObjectDy {
     fn from(value: f64) -> Self {
@@ -107659,11 +100332,6 @@ pub struct TitleObjectEncode {
     )]
     pub subtype_1: ::std::option::Option<TitleObjectEncodeSubtype1>,
 }
-impl ::std::convert::From<&TitleObjectEncode> for TitleObjectEncode {
-    fn from(value: &TitleObjectEncode) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for TitleObjectEncode {
     fn default() -> Self {
         Self {
@@ -107695,11 +100363,6 @@ impl ::std::ops::Deref for TitleObjectEncodeSubtype0Key {
 impl ::std::convert::From<TitleObjectEncodeSubtype0Key> for ::std::string::String {
     fn from(value: TitleObjectEncodeSubtype0Key) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&TitleObjectEncodeSubtype0Key> for TitleObjectEncodeSubtype0Key {
-    fn from(value: &TitleObjectEncodeSubtype0Key) -> Self {
-        value.clone()
     }
 }
 impl ::std::str::FromStr for TitleObjectEncodeSubtype0Key {
@@ -107781,11 +100444,6 @@ pub struct TitleObjectEncodeSubtype1 {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
 }
-impl ::std::convert::From<&TitleObjectEncodeSubtype1> for TitleObjectEncodeSubtype1 {
-    fn from(value: &TitleObjectEncodeSubtype1) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for TitleObjectEncodeSubtype1 {
     fn default() -> Self {
         Self {
@@ -107818,11 +100476,6 @@ pub enum TitleObjectFont {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for TitleObjectFont {
-    fn from(value: &TitleObjectFont) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for TitleObjectFont {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -107850,11 +100503,6 @@ impl ::std::convert::From<StringValue> for TitleObjectFont {
 pub enum TitleObjectFontSize {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for TitleObjectFontSize {
-    fn from(value: &TitleObjectFontSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for TitleObjectFontSize {
     fn from(value: f64) -> Self {
@@ -107888,11 +100536,6 @@ impl ::std::convert::From<NumberValue> for TitleObjectFontSize {
 pub enum TitleObjectFontStyle {
     Variant0(::std::string::String),
     Variant1(StringValue),
-}
-impl ::std::convert::From<&Self> for TitleObjectFontStyle {
-    fn from(value: &TitleObjectFontStyle) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<StringValue> for TitleObjectFontStyle {
     fn from(value: StringValue) -> Self {
@@ -107946,11 +100589,6 @@ pub enum TitleObjectFontWeight {
     Variant0(MyEnum),
     Variant1(FontWeightValue),
 }
-impl ::std::convert::From<&Self> for TitleObjectFontWeight {
-    fn from(value: &TitleObjectFontWeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<MyEnum> for TitleObjectFontWeight {
     fn from(value: MyEnum) -> Self {
         Self::Variant0(value)
@@ -107986,11 +100624,6 @@ impl ::std::convert::From<FontWeightValue> for TitleObjectFontWeight {
 pub enum TitleObjectFrame {
     Variant0(TitleObjectFrameVariant0),
     Variant1(StringValue),
-}
-impl ::std::convert::From<&Self> for TitleObjectFrame {
-    fn from(value: &TitleObjectFrame) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<TitleObjectFrameVariant0> for TitleObjectFrame {
     fn from(value: TitleObjectFrameVariant0) -> Self {
@@ -108032,11 +100665,6 @@ pub enum TitleObjectFrameVariant0 {
     Group,
     #[serde(rename = "bounds")]
     Bounds,
-}
-impl ::std::convert::From<&Self> for TitleObjectFrameVariant0 {
-    fn from(value: &TitleObjectFrameVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for TitleObjectFrameVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -108101,11 +100729,6 @@ pub enum TitleObjectLimit {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for TitleObjectLimit {
-    fn from(value: &TitleObjectLimit) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for TitleObjectLimit {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -108139,11 +100762,6 @@ pub enum TitleObjectLineHeight {
     Variant0(f64),
     Variant1(NumberValue),
 }
-impl ::std::convert::From<&Self> for TitleObjectLineHeight {
-    fn from(value: &TitleObjectLineHeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for TitleObjectLineHeight {
     fn from(value: f64) -> Self {
         Self::Variant0(value)
@@ -108176,11 +100794,6 @@ impl ::std::convert::From<NumberValue> for TitleObjectLineHeight {
 pub enum TitleObjectOffset {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for TitleObjectOffset {
-    fn from(value: &TitleObjectOffset) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for TitleObjectOffset {
     fn from(value: f64) -> Self {
@@ -108221,11 +100834,6 @@ impl ::std::convert::From<NumberValue> for TitleObjectOffset {
 pub enum TitleObjectOrient {
     Variant0(TitleObjectOrientVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for TitleObjectOrient {
-    fn from(value: &TitleObjectOrient) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<TitleObjectOrientVariant0> for TitleObjectOrient {
     fn from(value: TitleObjectOrientVariant0) -> Self {
@@ -108277,11 +100885,6 @@ pub enum TitleObjectOrientVariant0 {
     Top,
     #[serde(rename = "bottom")]
     Bottom,
-}
-impl ::std::convert::From<&Self> for TitleObjectOrientVariant0 {
-    fn from(value: &TitleObjectOrientVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for TitleObjectOrientVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -108356,11 +100959,6 @@ pub enum TitleObjectSubtitleColor {
     String(::std::string::String),
     ColorValue(ColorValue),
 }
-impl ::std::convert::From<&Self> for TitleObjectSubtitleColor {
-    fn from(value: &TitleObjectSubtitleColor) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ColorValue> for TitleObjectSubtitleColor {
     fn from(value: ColorValue) -> Self {
         Self::ColorValue(value)
@@ -108389,11 +100987,6 @@ pub enum TitleObjectSubtitleFont {
     Variant0(::std::string::String),
     Variant1(StringValue),
 }
-impl ::std::convert::From<&Self> for TitleObjectSubtitleFont {
-    fn from(value: &TitleObjectSubtitleFont) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<StringValue> for TitleObjectSubtitleFont {
     fn from(value: StringValue) -> Self {
         Self::Variant1(value)
@@ -108421,11 +101014,6 @@ impl ::std::convert::From<StringValue> for TitleObjectSubtitleFont {
 pub enum TitleObjectSubtitleFontSize {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for TitleObjectSubtitleFontSize {
-    fn from(value: &TitleObjectSubtitleFontSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for TitleObjectSubtitleFontSize {
     fn from(value: f64) -> Self {
@@ -108459,11 +101047,6 @@ impl ::std::convert::From<NumberValue> for TitleObjectSubtitleFontSize {
 pub enum TitleObjectSubtitleFontStyle {
     Variant0(::std::string::String),
     Variant1(StringValue),
-}
-impl ::std::convert::From<&Self> for TitleObjectSubtitleFontStyle {
-    fn from(value: &TitleObjectSubtitleFontStyle) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<StringValue> for TitleObjectSubtitleFontStyle {
     fn from(value: StringValue) -> Self {
@@ -108517,11 +101100,6 @@ pub enum TitleObjectSubtitleFontWeight {
     Variant0(MyEnum),
     Variant1(FontWeightValue),
 }
-impl ::std::convert::From<&Self> for TitleObjectSubtitleFontWeight {
-    fn from(value: &TitleObjectSubtitleFontWeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<MyEnum> for TitleObjectSubtitleFontWeight {
     fn from(value: MyEnum) -> Self {
         Self::Variant0(value)
@@ -108554,11 +101132,6 @@ impl ::std::convert::From<FontWeightValue> for TitleObjectSubtitleFontWeight {
 pub enum TitleObjectSubtitleLineHeight {
     Variant0(f64),
     Variant1(NumberValue),
-}
-impl ::std::convert::From<&Self> for TitleObjectSubtitleLineHeight {
-    fn from(value: &TitleObjectSubtitleLineHeight) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for TitleObjectSubtitleLineHeight {
     fn from(value: f64) -> Self {
@@ -108788,11 +101361,6 @@ pub enum Transform {
     IdentifierTransform(IdentifierTransform),
     VoronoiTransform(VoronoiTransform),
     WordcloudTransform(WordcloudTransform),
-}
-impl ::std::convert::From<&Self> for Transform {
-    fn from(value: &Transform) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<CrossfilterTransform> for Transform {
     fn from(value: CrossfilterTransform) -> Self {
@@ -109184,11 +101752,6 @@ pub enum TransformMark {
     VoronoiTransform(VoronoiTransform),
     WordcloudTransform(WordcloudTransform),
 }
-impl ::std::convert::From<&Self> for TransformMark {
-    fn from(value: &TransformMark) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<CrossfilterTransform> for TransformMark {
     fn from(value: CrossfilterTransform) -> Self {
         Self::CrossfilterTransform(value)
@@ -109502,11 +102065,6 @@ pub struct TreeTransform {
     #[serde(rename = "type")]
     pub type_: TreeTransformType,
 }
-impl ::std::convert::From<&TreeTransform> for TreeTransform {
-    fn from(value: &TreeTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`TreeTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -109547,11 +102105,6 @@ impl ::std::convert::From<&TreeTransform> for TreeTransform {
 pub enum TreeTransformAs {
     Array([TreeTransformAsArrayItem; 4usize]),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for TreeTransformAs {
-    fn from(value: &TreeTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for TreeTransformAs {
     fn default() -> Self {
@@ -109596,11 +102149,6 @@ pub enum TreeTransformAsArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for TreeTransformAsArrayItem {
-    fn from(value: &TreeTransformAsArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for TreeTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -109632,11 +102180,6 @@ pub enum TreeTransformField {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for TreeTransformField {
-    fn from(value: &TreeTransformField) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for TreeTransformField {
     fn from(value: ScaleField) -> Self {
@@ -109679,11 +102222,6 @@ impl ::std::convert::From<Expr> for TreeTransformField {
 pub enum TreeTransformMethod {
     Variant0(TreeTransformMethodVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for TreeTransformMethod {
-    fn from(value: &TreeTransformMethod) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for TreeTransformMethod {
     fn default() -> Self {
@@ -109730,11 +102268,6 @@ pub enum TreeTransformMethodVariant0 {
     Tidy,
     #[serde(rename = "cluster")]
     Cluster,
-}
-impl ::std::convert::From<&Self> for TreeTransformMethodVariant0 {
-    fn from(value: &TreeTransformMethodVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for TreeTransformMethodVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -109811,11 +102344,6 @@ pub enum TreeTransformNodeSize {
     Array([TreeTransformNodeSizeArrayItem; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for TreeTransformNodeSize {
-    fn from(value: &TreeTransformNodeSize) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[TreeTransformNodeSizeArrayItem; 2usize]> for TreeTransformNodeSize {
     fn from(value: [TreeTransformNodeSizeArrayItem; 2usize]) -> Self {
         Self::Array(value)
@@ -109848,11 +102376,6 @@ impl ::std::convert::From<SignalRef> for TreeTransformNodeSize {
 pub enum TreeTransformNodeSizeArrayItem {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for TreeTransformNodeSizeArrayItem {
-    fn from(value: &TreeTransformNodeSizeArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for TreeTransformNodeSizeArrayItem {
     fn from(value: f64) -> Self {
@@ -109887,11 +102410,6 @@ impl ::std::convert::From<SignalRef> for TreeTransformNodeSizeArrayItem {
 pub enum TreeTransformSeparation {
     Boolean(bool),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for TreeTransformSeparation {
-    fn from(value: &TreeTransformSeparation) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for TreeTransformSeparation {
     fn default() -> Self {
@@ -109943,11 +102461,6 @@ pub enum TreeTransformSize {
     Array([TreeTransformSizeArrayItem; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for TreeTransformSize {
-    fn from(value: &TreeTransformSize) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[TreeTransformSizeArrayItem; 2usize]> for TreeTransformSize {
     fn from(value: [TreeTransformSizeArrayItem; 2usize]) -> Self {
         Self::Array(value)
@@ -109980,11 +102493,6 @@ impl ::std::convert::From<SignalRef> for TreeTransformSize {
 pub enum TreeTransformSizeArrayItem {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for TreeTransformSizeArrayItem {
-    fn from(value: &TreeTransformSizeArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for TreeTransformSizeArrayItem {
     fn from(value: f64) -> Self {
@@ -110023,11 +102531,6 @@ impl ::std::convert::From<SignalRef> for TreeTransformSizeArrayItem {
 pub enum TreeTransformType {
     #[serde(rename = "tree")]
     Tree,
-}
-impl ::std::convert::From<&Self> for TreeTransformType {
-    fn from(value: &TreeTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for TreeTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -110099,11 +102602,6 @@ pub struct TreelinksTransform {
     #[serde(rename = "type")]
     pub type_: TreelinksTransformType,
 }
-impl ::std::convert::From<&TreelinksTransform> for TreelinksTransform {
-    fn from(value: &TreelinksTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`TreelinksTransformType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -110131,11 +102629,6 @@ impl ::std::convert::From<&TreelinksTransform> for TreelinksTransform {
 pub enum TreelinksTransformType {
     #[serde(rename = "treelinks")]
     Treelinks,
-}
-impl ::std::convert::From<&Self> for TreelinksTransformType {
-    fn from(value: &TreelinksTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for TreelinksTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -110436,11 +102929,6 @@ pub struct TreemapTransform {
     #[serde(rename = "type")]
     pub type_: TreemapTransformType,
 }
-impl ::std::convert::From<&TreemapTransform> for TreemapTransform {
-    fn from(value: &TreemapTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`TreemapTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -110483,11 +102971,6 @@ impl ::std::convert::From<&TreemapTransform> for TreemapTransform {
 pub enum TreemapTransformAs {
     Array([TreemapTransformAsArrayItem; 6usize]),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for TreemapTransformAs {
-    fn from(value: &TreemapTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for TreemapTransformAs {
     fn default() -> Self {
@@ -110534,11 +103017,6 @@ pub enum TreemapTransformAsArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for TreemapTransformAsArrayItem {
-    fn from(value: &TreemapTransformAsArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for TreemapTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -110570,11 +103048,6 @@ pub enum TreemapTransformField {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for TreemapTransformField {
-    fn from(value: &TreemapTransformField) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for TreemapTransformField {
     fn from(value: ScaleField) -> Self {
@@ -110621,11 +103094,6 @@ impl ::std::convert::From<Expr> for TreemapTransformField {
 pub enum TreemapTransformMethod {
     Variant0(TreemapTransformMethodVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for TreemapTransformMethod {
-    fn from(value: &TreemapTransformMethod) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for TreemapTransformMethod {
     fn default() -> Self {
@@ -110684,11 +103152,6 @@ pub enum TreemapTransformMethodVariant0 {
     Slice,
     #[serde(rename = "slicedice")]
     Slicedice,
-}
-impl ::std::convert::From<&Self> for TreemapTransformMethodVariant0 {
-    fn from(value: &TreemapTransformMethodVariant0) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for TreemapTransformMethodVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -110761,11 +103224,6 @@ pub enum TreemapTransformPadding {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for TreemapTransformPadding {
-    fn from(value: &TreemapTransformPadding) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for TreemapTransformPadding {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -110798,11 +103256,6 @@ impl ::std::convert::From<SignalRef> for TreemapTransformPadding {
 pub enum TreemapTransformPaddingBottom {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for TreemapTransformPaddingBottom {
-    fn from(value: &TreemapTransformPaddingBottom) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for TreemapTransformPaddingBottom {
     fn from(value: f64) -> Self {
@@ -110837,11 +103290,6 @@ pub enum TreemapTransformPaddingInner {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for TreemapTransformPaddingInner {
-    fn from(value: &TreemapTransformPaddingInner) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for TreemapTransformPaddingInner {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -110874,11 +103322,6 @@ impl ::std::convert::From<SignalRef> for TreemapTransformPaddingInner {
 pub enum TreemapTransformPaddingLeft {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for TreemapTransformPaddingLeft {
-    fn from(value: &TreemapTransformPaddingLeft) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for TreemapTransformPaddingLeft {
     fn from(value: f64) -> Self {
@@ -110913,11 +103356,6 @@ pub enum TreemapTransformPaddingOuter {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for TreemapTransformPaddingOuter {
-    fn from(value: &TreemapTransformPaddingOuter) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for TreemapTransformPaddingOuter {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -110950,11 +103388,6 @@ impl ::std::convert::From<SignalRef> for TreemapTransformPaddingOuter {
 pub enum TreemapTransformPaddingRight {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for TreemapTransformPaddingRight {
-    fn from(value: &TreemapTransformPaddingRight) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for TreemapTransformPaddingRight {
     fn from(value: f64) -> Self {
@@ -110989,11 +103422,6 @@ pub enum TreemapTransformPaddingTop {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for TreemapTransformPaddingTop {
-    fn from(value: &TreemapTransformPaddingTop) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for TreemapTransformPaddingTop {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -111027,11 +103455,6 @@ impl ::std::convert::From<SignalRef> for TreemapTransformPaddingTop {
 pub enum TreemapTransformRatio {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for TreemapTransformRatio {
-    fn from(value: &TreemapTransformRatio) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for TreemapTransformRatio {
     fn default() -> Self {
@@ -111070,11 +103493,6 @@ impl ::std::convert::From<SignalRef> for TreemapTransformRatio {
 pub enum TreemapTransformRound {
     Boolean(bool),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for TreemapTransformRound {
-    fn from(value: &TreemapTransformRound) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<bool> for TreemapTransformRound {
     fn from(value: bool) -> Self {
@@ -111121,11 +103539,6 @@ pub enum TreemapTransformSize {
     Array([TreemapTransformSizeArrayItem; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for TreemapTransformSize {
-    fn from(value: &TreemapTransformSize) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[TreemapTransformSizeArrayItem; 2usize]> for TreemapTransformSize {
     fn from(value: [TreemapTransformSizeArrayItem; 2usize]) -> Self {
         Self::Array(value)
@@ -111158,11 +103571,6 @@ impl ::std::convert::From<SignalRef> for TreemapTransformSize {
 pub enum TreemapTransformSizeArrayItem {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for TreemapTransformSizeArrayItem {
-    fn from(value: &TreemapTransformSizeArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for TreemapTransformSizeArrayItem {
     fn from(value: f64) -> Self {
@@ -111201,11 +103609,6 @@ impl ::std::convert::From<SignalRef> for TreemapTransformSizeArrayItem {
 pub enum TreemapTransformType {
     #[serde(rename = "treemap")]
     Treemap,
-}
-impl ::std::convert::From<&Self> for TreemapTransformType {
-    fn from(value: &TreemapTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for TreemapTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -111369,11 +103772,6 @@ pub struct VoronoiTransform {
     pub x: VoronoiTransformX,
     pub y: VoronoiTransformY,
 }
-impl ::std::convert::From<&VoronoiTransform> for VoronoiTransform {
-    fn from(value: &VoronoiTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`VoronoiTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -111397,11 +103795,6 @@ impl ::std::convert::From<&VoronoiTransform> for VoronoiTransform {
 pub enum VoronoiTransformAs {
     String(::std::string::String),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for VoronoiTransformAs {
-    fn from(value: &VoronoiTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for VoronoiTransformAs {
     fn default() -> Self {
@@ -111448,11 +103841,6 @@ impl ::std::convert::From<SignalRef> for VoronoiTransformAs {
 pub enum VoronoiTransformExtent {
     Array([::serde_json::Value; 2usize]),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for VoronoiTransformExtent {
-    fn from(value: &VoronoiTransformExtent) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for VoronoiTransformExtent {
     fn default() -> Self {
@@ -111507,11 +103895,6 @@ pub enum VoronoiTransformSize {
     Array([VoronoiTransformSizeArrayItem; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for VoronoiTransformSize {
-    fn from(value: &VoronoiTransformSize) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[VoronoiTransformSizeArrayItem; 2usize]> for VoronoiTransformSize {
     fn from(value: [VoronoiTransformSizeArrayItem; 2usize]) -> Self {
         Self::Array(value)
@@ -111544,11 +103927,6 @@ impl ::std::convert::From<SignalRef> for VoronoiTransformSize {
 pub enum VoronoiTransformSizeArrayItem {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for VoronoiTransformSizeArrayItem {
-    fn from(value: &VoronoiTransformSizeArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for VoronoiTransformSizeArrayItem {
     fn from(value: f64) -> Self {
@@ -111587,11 +103965,6 @@ impl ::std::convert::From<SignalRef> for VoronoiTransformSizeArrayItem {
 pub enum VoronoiTransformType {
     #[serde(rename = "voronoi")]
     Voronoi,
-}
-impl ::std::convert::From<&Self> for VoronoiTransformType {
-    fn from(value: &VoronoiTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for VoronoiTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -111658,11 +104031,6 @@ pub enum VoronoiTransformX {
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for VoronoiTransformX {
-    fn from(value: &VoronoiTransformX) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleField> for VoronoiTransformX {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
@@ -111704,11 +104072,6 @@ pub enum VoronoiTransformY {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for VoronoiTransformY {
-    fn from(value: &VoronoiTransformY) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for VoronoiTransformY {
     fn from(value: ScaleField) -> Self {
@@ -111976,11 +104339,6 @@ pub struct WindowTransform {
     #[serde(rename = "type")]
     pub type_: WindowTransformType,
 }
-impl ::std::convert::From<&WindowTransform> for WindowTransform {
-    fn from(value: &WindowTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`WindowTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -112016,11 +104374,6 @@ impl ::std::convert::From<&WindowTransform> for WindowTransform {
 pub enum WindowTransformAs {
     Array(::std::vec::Vec<WindowTransformAsArrayItem>),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for WindowTransformAs {
-    fn from(value: &WindowTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<::std::vec::Vec<WindowTransformAsArrayItem>> for WindowTransformAs {
     fn from(value: ::std::vec::Vec<WindowTransformAsArrayItem>) -> Self {
@@ -112058,11 +104411,6 @@ pub enum WindowTransformAsArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
     Null,
-}
-impl ::std::convert::From<&Self> for WindowTransformAsArrayItem {
-    fn from(value: &WindowTransformAsArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<SignalRef> for WindowTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
@@ -112108,11 +104456,6 @@ pub enum WindowTransformFields {
     Array(::std::vec::Vec<WindowTransformFieldsArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for WindowTransformFields {
-    fn from(value: &WindowTransformFields) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<WindowTransformFieldsArrayItem>>
     for WindowTransformFields
 {
@@ -112155,11 +104498,6 @@ pub enum WindowTransformFieldsArrayItem {
     ParamField(ParamField),
     Expr(Expr),
     Null,
-}
-impl ::std::convert::From<&Self> for WindowTransformFieldsArrayItem {
-    fn from(value: &WindowTransformFieldsArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for WindowTransformFieldsArrayItem {
     fn from(value: ScaleField) -> Self {
@@ -112218,11 +104556,6 @@ pub enum WindowTransformFrame {
     Array([WindowTransformFrameArrayItem; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for WindowTransformFrame {
-    fn from(value: &WindowTransformFrame) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for WindowTransformFrame {
     fn default() -> Self {
         WindowTransformFrame::Array([
@@ -112267,11 +104600,6 @@ pub enum WindowTransformFrameArrayItem {
     Number(f64),
     SignalRef(SignalRef),
     Null,
-}
-impl ::std::convert::From<&Self> for WindowTransformFrameArrayItem {
-    fn from(value: &WindowTransformFrameArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for WindowTransformFrameArrayItem {
     fn from(value: f64) -> Self {
@@ -112319,11 +104647,6 @@ pub enum WindowTransformGroupby {
     Array(::std::vec::Vec<WindowTransformGroupbyArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for WindowTransformGroupby {
-    fn from(value: &WindowTransformGroupby) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<WindowTransformGroupbyArrayItem>>
     for WindowTransformGroupby
 {
@@ -112363,11 +104686,6 @@ pub enum WindowTransformGroupbyArrayItem {
     ParamField(ParamField),
     Expr(Expr),
 }
-impl ::std::convert::From<&Self> for WindowTransformGroupbyArrayItem {
-    fn from(value: &WindowTransformGroupbyArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<ScaleField> for WindowTransformGroupbyArrayItem {
     fn from(value: ScaleField) -> Self {
         Self::ScaleField(value)
@@ -112405,11 +104723,6 @@ impl ::std::convert::From<Expr> for WindowTransformGroupbyArrayItem {
 pub enum WindowTransformIgnorePeers {
     Boolean(bool),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for WindowTransformIgnorePeers {
-    fn from(value: &WindowTransformIgnorePeers) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<bool> for WindowTransformIgnorePeers {
     fn from(value: bool) -> Self {
@@ -112492,11 +104805,6 @@ pub enum WindowTransformOps {
     Array(::std::vec::Vec<WindowTransformOpsArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for WindowTransformOps {
-    fn from(value: &WindowTransformOps) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<WindowTransformOpsArrayItem>> for WindowTransformOps {
     fn from(value: ::std::vec::Vec<WindowTransformOpsArrayItem>) -> Self {
         Self::Array(value)
@@ -112567,11 +104875,6 @@ impl ::std::convert::From<SignalRef> for WindowTransformOps {
 pub enum WindowTransformOpsArrayItem {
     Variant0(WindowTransformOpsArrayItemVariant0),
     Variant1(SignalRef),
-}
-impl ::std::convert::From<&Self> for WindowTransformOpsArrayItem {
-    fn from(value: &WindowTransformOpsArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<WindowTransformOpsArrayItemVariant0> for WindowTransformOpsArrayItem {
     fn from(value: WindowTransformOpsArrayItemVariant0) -> Self {
@@ -112719,11 +105022,6 @@ pub enum WindowTransformOpsArrayItemVariant0 {
     #[serde(rename = "argmax")]
     Argmax,
 }
-impl ::std::convert::From<&Self> for WindowTransformOpsArrayItemVariant0 {
-    fn from(value: &WindowTransformOpsArrayItemVariant0) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for WindowTransformOpsArrayItemVariant0 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -112870,11 +105168,6 @@ pub enum WindowTransformParams {
     Array(::std::vec::Vec<WindowTransformParamsArrayItem>),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for WindowTransformParams {
-    fn from(value: &WindowTransformParams) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<WindowTransformParamsArrayItem>>
     for WindowTransformParams
 {
@@ -112914,11 +105207,6 @@ pub enum WindowTransformParamsArrayItem {
     SignalRef(SignalRef),
     Null,
 }
-impl ::std::convert::From<&Self> for WindowTransformParamsArrayItem {
-    fn from(value: &WindowTransformParamsArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for WindowTransformParamsArrayItem {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -112956,11 +105244,6 @@ impl ::std::convert::From<SignalRef> for WindowTransformParamsArrayItem {
 pub enum WindowTransformType {
     #[serde(rename = "window")]
     Window,
-}
-impl ::std::convert::From<&Self> for WindowTransformType {
-    fn from(value: &WindowTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for WindowTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -113269,11 +105552,6 @@ pub struct WordcloudTransform {
     #[serde(rename = "type")]
     pub type_: WordcloudTransformType,
 }
-impl ::std::convert::From<&WordcloudTransform> for WordcloudTransform {
-    fn from(value: &WordcloudTransform) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`WordcloudTransformAs`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -113317,11 +105595,6 @@ impl ::std::convert::From<&WordcloudTransform> for WordcloudTransform {
 pub enum WordcloudTransformAs {
     Array([WordcloudTransformAsArrayItem; 7usize]),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for WordcloudTransformAs {
-    fn from(value: &WordcloudTransformAs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for WordcloudTransformAs {
     fn default() -> Self {
@@ -113369,11 +105642,6 @@ pub enum WordcloudTransformAsArrayItem {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for WordcloudTransformAsArrayItem {
-    fn from(value: &WordcloudTransformAsArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for WordcloudTransformAsArrayItem {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -113410,11 +105678,6 @@ pub enum WordcloudTransformFont {
     SignalRef(SignalRef),
     Expr(Expr),
     ParamField(ParamField),
-}
-impl ::std::convert::From<&Self> for WordcloudTransformFont {
-    fn from(value: &WordcloudTransformFont) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for WordcloudTransformFont {
     fn default() -> Self {
@@ -113467,11 +105730,6 @@ pub enum WordcloudTransformFontSize {
     SignalRef(SignalRef),
     Expr(Expr),
     ParamField(ParamField),
-}
-impl ::std::convert::From<&Self> for WordcloudTransformFontSize {
-    fn from(value: &WordcloudTransformFontSize) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for WordcloudTransformFontSize {
     fn default() -> Self {
@@ -113539,11 +105797,6 @@ pub enum WordcloudTransformFontSizeRange {
     SignalRef(SignalRef),
     Null,
 }
-impl ::std::convert::From<&Self> for WordcloudTransformFontSizeRange {
-    fn from(value: &WordcloudTransformFontSizeRange) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for WordcloudTransformFontSizeRange {
     fn default() -> Self {
         WordcloudTransformFontSizeRange::Array(vec![
@@ -113587,11 +105840,6 @@ pub enum WordcloudTransformFontSizeRangeArrayItem {
     Number(f64),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for WordcloudTransformFontSizeRangeArrayItem {
-    fn from(value: &WordcloudTransformFontSizeRangeArrayItem) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for WordcloudTransformFontSizeRangeArrayItem {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -113633,11 +105881,6 @@ pub enum WordcloudTransformFontStyle {
     SignalRef(SignalRef),
     Expr(Expr),
     ParamField(ParamField),
-}
-impl ::std::convert::From<&Self> for WordcloudTransformFontStyle {
-    fn from(value: &WordcloudTransformFontStyle) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for WordcloudTransformFontStyle {
     fn default() -> Self {
@@ -113691,11 +105934,6 @@ pub enum WordcloudTransformFontWeight {
     Expr(Expr),
     ParamField(ParamField),
 }
-impl ::std::convert::From<&Self> for WordcloudTransformFontWeight {
-    fn from(value: &WordcloudTransformFontWeight) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for WordcloudTransformFontWeight {
     fn default() -> Self {
         WordcloudTransformFontWeight::String("normal".to_string())
@@ -113747,11 +105985,6 @@ pub enum WordcloudTransformPadding {
     Expr(Expr),
     ParamField(ParamField),
 }
-impl ::std::convert::From<&Self> for WordcloudTransformPadding {
-    fn from(value: &WordcloudTransformPadding) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<f64> for WordcloudTransformPadding {
     fn from(value: f64) -> Self {
         Self::Number(value)
@@ -113802,11 +106035,6 @@ pub enum WordcloudTransformRotate {
     SignalRef(SignalRef),
     Expr(Expr),
     ParamField(ParamField),
-}
-impl ::std::convert::From<&Self> for WordcloudTransformRotate {
-    fn from(value: &WordcloudTransformRotate) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for WordcloudTransformRotate {
     fn from(value: f64) -> Self {
@@ -113863,11 +106091,6 @@ pub enum WordcloudTransformSize {
     Array([WordcloudTransformSizeArrayItem; 2usize]),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for WordcloudTransformSize {
-    fn from(value: &WordcloudTransformSize) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[WordcloudTransformSizeArrayItem; 2usize]> for WordcloudTransformSize {
     fn from(value: [WordcloudTransformSizeArrayItem; 2usize]) -> Self {
         Self::Array(value)
@@ -113900,11 +106123,6 @@ impl ::std::convert::From<SignalRef> for WordcloudTransformSize {
 pub enum WordcloudTransformSizeArrayItem {
     Number(f64),
     SignalRef(SignalRef),
-}
-impl ::std::convert::From<&Self> for WordcloudTransformSizeArrayItem {
-    fn from(value: &WordcloudTransformSizeArrayItem) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<f64> for WordcloudTransformSizeArrayItem {
     fn from(value: f64) -> Self {
@@ -113939,11 +106157,6 @@ pub enum WordcloudTransformSpiral {
     String(::std::string::String),
     SignalRef(SignalRef),
 }
-impl ::std::convert::From<&Self> for WordcloudTransformSpiral {
-    fn from(value: &WordcloudTransformSpiral) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<SignalRef> for WordcloudTransformSpiral {
     fn from(value: SignalRef) -> Self {
         Self::SignalRef(value)
@@ -113975,11 +106188,6 @@ pub enum WordcloudTransformText {
     ScaleField(ScaleField),
     ParamField(ParamField),
     Expr(Expr),
-}
-impl ::std::convert::From<&Self> for WordcloudTransformText {
-    fn from(value: &WordcloudTransformText) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<ScaleField> for WordcloudTransformText {
     fn from(value: ScaleField) -> Self {
@@ -114023,11 +106231,6 @@ impl ::std::convert::From<Expr> for WordcloudTransformText {
 pub enum WordcloudTransformType {
     #[serde(rename = "wordcloud")]
     Wordcloud,
-}
-impl ::std::convert::From<&Self> for WordcloudTransformType {
-    fn from(value: &WordcloudTransformType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for WordcloudTransformType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {

--- a/typify/tests/schemas/arrays-and-tuples.rs
+++ b/typify/tests/schemas/arrays-and-tuples.rs
@@ -51,11 +51,6 @@ impl ::std::convert::From<ArraySansItems> for Vec<::serde_json::Value> {
         value.0
     }
 }
-impl ::std::convert::From<&ArraySansItems> for ArraySansItems {
-    fn from(value: &ArraySansItems) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<Vec<::serde_json::Value>> for ArraySansItems {
     fn from(value: Vec<::serde_json::Value>) -> Self {
         Self(value)
@@ -98,11 +93,6 @@ impl ::std::convert::From<LessSimpleTwoTuple> for (::std::string::String, ::std:
         value.0
     }
 }
-impl ::std::convert::From<&LessSimpleTwoTuple> for LessSimpleTwoTuple {
-    fn from(value: &LessSimpleTwoTuple) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<(::std::string::String, ::std::string::String)> for LessSimpleTwoTuple {
     fn from(value: (::std::string::String, ::std::string::String)) -> Self {
         Self(value)
@@ -135,11 +125,6 @@ impl ::std::ops::Deref for SimpleTwoArray {
 impl ::std::convert::From<SimpleTwoArray> for [::std::string::String; 2usize] {
     fn from(value: SimpleTwoArray) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&SimpleTwoArray> for SimpleTwoArray {
-    fn from(value: &SimpleTwoArray) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<[::std::string::String; 2usize]> for SimpleTwoArray {
@@ -181,11 +166,6 @@ impl ::std::convert::From<SimpleTwoTuple> for (::std::string::String, ::std::str
         value.0
     }
 }
-impl ::std::convert::From<&SimpleTwoTuple> for SimpleTwoTuple {
-    fn from(value: &SimpleTwoTuple) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<(::std::string::String, ::std::string::String)> for SimpleTwoTuple {
     fn from(value: (::std::string::String, ::std::string::String)) -> Self {
         Self(value)
@@ -225,11 +205,6 @@ impl ::std::convert::From<UnsimpleTwoTuple> for (::std::string::String, ::std::s
         value.0
     }
 }
-impl ::std::convert::From<&UnsimpleTwoTuple> for UnsimpleTwoTuple {
-    fn from(value: &UnsimpleTwoTuple) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<(::std::string::String, ::std::string::String)> for UnsimpleTwoTuple {
     fn from(value: (::std::string::String, ::std::string::String)) -> Self {
         Self(value)
@@ -263,11 +238,6 @@ impl ::std::ops::Deref for YoloTwoArray {
 impl ::std::convert::From<YoloTwoArray> for [::serde_json::Value; 2usize] {
     fn from(value: YoloTwoArray) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&YoloTwoArray> for YoloTwoArray {
-    fn from(value: &YoloTwoArray) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<[::serde_json::Value; 2usize]> for YoloTwoArray {

--- a/typify/tests/schemas/deny-list.rs
+++ b/typify/tests/schemas/deny-list.rs
@@ -65,11 +65,6 @@ pub struct TestType {
     pub where_not: TestTypeWhereNot,
     pub why_not: TestTypeWhyNot,
 }
-impl ::std::convert::From<&TestType> for TestType {
-    fn from(value: &TestType) -> Self {
-        value.clone()
-    }
-}
 impl TestType {
     pub fn builder() -> builder::TestType {
         Default::default()
@@ -103,11 +98,6 @@ impl ::std::ops::Deref for TestTypeWhereNot {
 impl ::std::convert::From<TestTypeWhereNot> for ::std::string::String {
     fn from(value: TestTypeWhereNot) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&TestTypeWhereNot> for TestTypeWhereNot {
-    fn from(value: &TestTypeWhereNot) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::TryFrom<::std::string::String> for TestTypeWhereNot {
@@ -158,11 +148,6 @@ impl ::std::ops::Deref for TestTypeWhyNot {
 impl ::std::convert::From<TestTypeWhyNot> for ::std::string::String {
     fn from(value: TestTypeWhyNot) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&TestTypeWhyNot> for TestTypeWhyNot {
-    fn from(value: &TestTypeWhyNot) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::TryFrom<::std::string::String> for TestTypeWhyNot {

--- a/typify/tests/schemas/extraneous-enum.rs
+++ b/typify/tests/schemas/extraneous-enum.rs
@@ -52,11 +52,6 @@ pub struct LetterBox {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub letter: ::std::option::Option<LetterBoxLetter>,
 }
-impl ::std::convert::From<&LetterBox> for LetterBox {
-    fn from(value: &LetterBox) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for LetterBox {
     fn default() -> Self {
         Self {
@@ -102,11 +97,6 @@ pub enum LetterBoxLetter {
     A,
     #[serde(rename = "b")]
     B,
-}
-impl ::std::convert::From<&Self> for LetterBoxLetter {
-    fn from(value: &LetterBoxLetter) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for LetterBoxLetter {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {

--- a/typify/tests/schemas/id-or-name.rs
+++ b/typify/tests/schemas/id-or-name.rs
@@ -59,11 +59,6 @@ pub enum IdOrName {
     Id(::uuid::Uuid),
     Name(Name),
 }
-impl ::std::convert::From<&Self> for IdOrName {
-    fn from(value: &IdOrName) -> Self {
-        value.clone()
-    }
-}
 impl ::std::str::FromStr for IdOrName {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -141,11 +136,6 @@ impl ::std::convert::From<Name> for IdOrName {
 pub enum IdOrNameRedundant {
     Uuid(::uuid::Uuid),
     String(Name),
-}
-impl ::std::convert::From<&Self> for IdOrNameRedundant {
-    fn from(value: &IdOrNameRedundant) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for IdOrNameRedundant {
     type Err = self::error::ConversionError;
@@ -234,11 +224,6 @@ pub enum IdOrYolo {
     Id(::uuid::Uuid),
     Yolo(IdOrYoloYolo),
 }
-impl ::std::convert::From<&Self> for IdOrYolo {
-    fn from(value: &IdOrYolo) -> Self {
-        value.clone()
-    }
-}
 impl ::std::str::FromStr for IdOrYolo {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -316,11 +301,6 @@ impl ::std::convert::From<IdOrYoloYolo> for ::std::string::String {
         value.0
     }
 }
-impl ::std::convert::From<&IdOrYoloYolo> for IdOrYoloYolo {
-    fn from(value: &IdOrYoloYolo) -> Self {
-        value.clone()
-    }
-}
 impl ::std::str::FromStr for IdOrYoloYolo {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -392,11 +372,6 @@ impl ::std::ops::Deref for Name {
 impl ::std::convert::From<Name> for ::std::string::String {
     fn from(value: Name) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&Name> for Name {
-    fn from(value: &Name) -> Self {
-        value.clone()
     }
 }
 impl ::std::str::FromStr for Name {

--- a/typify/tests/schemas/maps.rs
+++ b/typify/tests/schemas/maps.rs
@@ -53,11 +53,6 @@ impl ::std::convert::From<DeadSimple>
         value.0
     }
 }
-impl ::std::convert::From<&DeadSimple> for DeadSimple {
-    fn from(value: &DeadSimple) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::serde_json::Map<::std::string::String, ::serde_json::Value>>
     for DeadSimple
 {
@@ -98,11 +93,6 @@ impl ::std::ops::Deref for Eh {
 impl ::std::convert::From<Eh> for ::std::string::String {
     fn from(value: Eh) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&Eh> for Eh {
-    fn from(value: &Eh) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<::std::string::String> for Eh {
@@ -154,11 +144,6 @@ impl ::std::convert::From<MapWithDateKeys>
         value.0
     }
 }
-impl ::std::convert::From<&MapWithDateKeys> for MapWithDateKeys {
-    fn from(value: &MapWithDateKeys) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::collections::HashMap<::chrono::naive::NaiveDate, Value>>
     for MapWithDateKeys
 {
@@ -203,11 +188,6 @@ impl ::std::convert::From<MapWithDateTimeKeys>
         value.0
     }
 }
-impl ::std::convert::From<&MapWithDateTimeKeys> for MapWithDateTimeKeys {
-    fn from(value: &MapWithDateTimeKeys) -> Self {
-        value.clone()
-    }
-}
 impl
     ::std::convert::From<
         ::std::collections::HashMap<::chrono::DateTime<::chrono::offset::Utc>, Value>,
@@ -249,11 +229,6 @@ impl ::std::convert::From<MapWithKeys> for ::std::collections::HashMap<Eh, Value
         value.0
     }
 }
-impl ::std::convert::From<&MapWithKeys> for MapWithKeys {
-    fn from(value: &MapWithKeys) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::collections::HashMap<Eh, Value>> for MapWithKeys {
     fn from(value: ::std::collections::HashMap<Eh, Value>) -> Self {
         Self(value)
@@ -291,11 +266,6 @@ impl ::std::ops::Deref for Value {
 impl ::std::convert::From<Value> for ::std::string::String {
     fn from(value: Value) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&Value> for Value {
-    fn from(value: &Value) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<::std::string::String> for Value {

--- a/typify/tests/schemas/maps_custom.rs
+++ b/typify/tests/schemas/maps_custom.rs
@@ -53,11 +53,6 @@ impl ::std::convert::From<DeadSimple>
         value.0
     }
 }
-impl ::std::convert::From<&DeadSimple> for DeadSimple {
-    fn from(value: &DeadSimple) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::serde_json::Map<::std::string::String, ::serde_json::Value>>
     for DeadSimple
 {
@@ -98,11 +93,6 @@ impl ::std::ops::Deref for Eh {
 impl ::std::convert::From<Eh> for ::std::string::String {
     fn from(value: Eh) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&Eh> for Eh {
-    fn from(value: &Eh) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<::std::string::String> for Eh {
@@ -154,11 +144,6 @@ impl ::std::convert::From<MapWithDateKeys>
         value.0
     }
 }
-impl ::std::convert::From<&MapWithDateKeys> for MapWithDateKeys {
-    fn from(value: &MapWithDateKeys) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<std::collections::BTreeMap<::chrono::naive::NaiveDate, Value>>
     for MapWithDateKeys
 {
@@ -203,11 +188,6 @@ impl ::std::convert::From<MapWithDateTimeKeys>
         value.0
     }
 }
-impl ::std::convert::From<&MapWithDateTimeKeys> for MapWithDateTimeKeys {
-    fn from(value: &MapWithDateTimeKeys) -> Self {
-        value.clone()
-    }
-}
 impl
     ::std::convert::From<
         std::collections::BTreeMap<::chrono::DateTime<::chrono::offset::Utc>, Value>,
@@ -249,11 +229,6 @@ impl ::std::convert::From<MapWithKeys> for std::collections::BTreeMap<Eh, Value>
         value.0
     }
 }
-impl ::std::convert::From<&MapWithKeys> for MapWithKeys {
-    fn from(value: &MapWithKeys) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<std::collections::BTreeMap<Eh, Value>> for MapWithKeys {
     fn from(value: std::collections::BTreeMap<Eh, Value>) -> Self {
         Self(value)
@@ -291,11 +266,6 @@ impl ::std::ops::Deref for Value {
 impl ::std::convert::From<Value> for ::std::string::String {
     fn from(value: Value) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&Value> for Value {
-    fn from(value: &Value) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<::std::string::String> for Value {

--- a/typify/tests/schemas/merged-schemas.rs
+++ b/typify/tests/schemas/merged-schemas.rs
@@ -44,11 +44,6 @@ pub struct BarProp {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub bar: ::std::option::Option<::serde_json::Value>,
 }
-impl ::std::convert::From<&BarProp> for BarProp {
-    fn from(value: &BarProp) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for BarProp {
     fn default() -> Self {
         Self {
@@ -84,11 +79,6 @@ impl BarProp {
 pub struct ButNotThat {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub this: ::std::option::Option<::serde_json::Value>,
-}
-impl ::std::convert::From<&ButNotThat> for ButNotThat {
-    fn from(value: &ButNotThat) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for ButNotThat {
     fn default() -> Self {
@@ -130,11 +120,6 @@ pub struct CommentedTypeMerged {
     pub x: ::std::option::Option<::serde_json::Value>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub y: ::std::option::Option<::serde_json::Value>,
-}
-impl ::std::convert::From<&CommentedTypeMerged> for CommentedTypeMerged {
-    fn from(value: &CommentedTypeMerged) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for CommentedTypeMerged {
     fn default() -> Self {
@@ -202,11 +187,6 @@ pub enum HereAndThere {
         foo: ::std::option::Option<::std::string::String>,
     },
 }
-impl ::std::convert::From<&Self> for HereAndThere {
-    fn from(value: &HereAndThere) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`JsonResponseBase`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -226,11 +206,6 @@ impl ::std::convert::From<&Self> for HereAndThere {
 pub struct JsonResponseBase {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub result: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&JsonResponseBase> for JsonResponseBase {
-    fn from(value: &JsonResponseBase) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for JsonResponseBase {
     fn default() -> Self {
@@ -270,11 +245,6 @@ impl JsonResponseBase {
 pub struct JsonSuccess {
     pub msg: ::std::string::String,
     pub result: JsonSuccessResult,
-}
-impl ::std::convert::From<&JsonSuccess> for JsonSuccess {
-    fn from(value: &JsonSuccess) -> Self {
-        value.clone()
-    }
 }
 impl JsonSuccess {
     pub fn builder() -> builder::JsonSuccess {
@@ -317,11 +287,6 @@ pub struct JsonSuccessBase {
     pub msg: ::std::string::String,
     pub result: JsonSuccessBaseResult,
 }
-impl ::std::convert::From<&JsonSuccessBase> for JsonSuccessBase {
-    fn from(value: &JsonSuccessBase) -> Self {
-        value.clone()
-    }
-}
 impl JsonSuccessBase {
     pub fn builder() -> builder::JsonSuccessBase {
         Default::default()
@@ -355,11 +320,6 @@ impl JsonSuccessBase {
 pub enum JsonSuccessBaseResult {
     #[serde(rename = "success")]
     Success,
-}
-impl ::std::convert::From<&Self> for JsonSuccessBaseResult {
-    fn from(value: &JsonSuccessBaseResult) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for JsonSuccessBaseResult {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -427,11 +387,6 @@ impl ::std::convert::TryFrom<::std::string::String> for JsonSuccessBaseResult {
 pub enum JsonSuccessResult {
     #[serde(rename = "success")]
     Success,
-}
-impl ::std::convert::From<&Self> for JsonSuccessResult {
-    fn from(value: &JsonSuccessResult) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for JsonSuccessResult {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -516,11 +471,6 @@ impl ::std::convert::TryFrom<::std::string::String> for JsonSuccessResult {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct MergeEmpty {}
-impl ::std::convert::From<&MergeEmpty> for MergeEmpty {
-    fn from(value: &MergeEmpty) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for MergeEmpty {
     fn default() -> Self {
         Self {}
@@ -560,11 +510,6 @@ impl ::std::ops::Deref for NarrowNumber {
 impl ::std::convert::From<NarrowNumber> for ::std::num::NonZeroU64 {
     fn from(value: NarrowNumber) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&NarrowNumber> for NarrowNumber {
-    fn from(value: &NarrowNumber) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<::std::num::NonZeroU64> for NarrowNumber {
@@ -631,11 +576,6 @@ pub struct OrderDependentMerge {
     pub bar: ::std::option::Option<::serde_json::Value>,
     pub baz: bool,
 }
-impl ::std::convert::From<&OrderDependentMerge> for OrderDependentMerge {
-    fn from(value: &OrderDependentMerge) -> Self {
-        value.clone()
-    }
-}
 impl OrderDependentMerge {
     pub fn builder() -> builder::OrderDependentMerge {
         Default::default()
@@ -671,11 +611,6 @@ impl OrderDependentMerge {
 pub struct Pickingone {
     pub suspended_by: PickingoneSuspendedBy,
 }
-impl ::std::convert::From<&Pickingone> for Pickingone {
-    fn from(value: &Pickingone) -> Self {
-        value.clone()
-    }
-}
 impl Pickingone {
     pub fn builder() -> builder::Pickingone {
         Default::default()
@@ -707,11 +642,6 @@ impl Pickingone {
 pub struct PickingoneInstallation {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub suspended_by: ::std::option::Option<PickingoneUser>,
-}
-impl ::std::convert::From<&PickingoneInstallation> for PickingoneInstallation {
-    fn from(value: &PickingoneInstallation) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for PickingoneInstallation {
     fn default() -> Self {
@@ -760,11 +690,6 @@ pub struct PickingoneSuspendedBy {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub email: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&PickingoneSuspendedBy> for PickingoneSuspendedBy {
-    fn from(value: &PickingoneSuspendedBy) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for PickingoneSuspendedBy {
     fn default() -> Self {
         Self {
@@ -799,11 +724,6 @@ impl PickingoneSuspendedBy {
 pub struct PickingoneUser {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub email: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&PickingoneUser> for PickingoneUser {
-    fn from(value: &PickingoneUser) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for PickingoneUser {
     fn default() -> Self {
@@ -853,11 +773,6 @@ impl PickingoneUser {
 pub struct TrimFat {
     pub a: ::serde_json::Value,
 }
-impl ::std::convert::From<&TrimFat> for TrimFat {
-    fn from(value: &TrimFat) -> Self {
-        value.clone()
-    }
-}
 impl TrimFat {
     pub fn builder() -> builder::TrimFat {
         Default::default()
@@ -906,11 +821,6 @@ impl TrimFat {
 pub struct UnchangedByMerge {
     pub tag: UnchangedByMergeTag,
 }
-impl ::std::convert::From<&UnchangedByMerge> for UnchangedByMerge {
-    fn from(value: &UnchangedByMerge) -> Self {
-        value.clone()
-    }
-}
 impl UnchangedByMerge {
     pub fn builder() -> builder::UnchangedByMerge {
         Default::default()
@@ -943,11 +853,6 @@ impl UnchangedByMerge {
 pub enum UnchangedByMergeTag {
     #[serde(rename = "something")]
     Something,
-}
-impl ::std::convert::From<&Self> for UnchangedByMergeTag {
-    fn from(value: &UnchangedByMergeTag) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for UnchangedByMergeTag {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -1050,11 +955,6 @@ impl ::std::convert::TryFrom<::std::string::String> for UnchangedByMergeTag {
 )]
 #[serde(deny_unknown_fields)]
 pub enum Unresolvable {}
-impl ::std::convert::From<&Self> for Unresolvable {
-    fn from(value: &Unresolvable) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`Unsatisfiable1`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -1092,11 +992,6 @@ impl ::std::convert::From<&Self> for Unresolvable {
 )]
 #[serde(deny_unknown_fields)]
 pub enum Unsatisfiable1 {}
-impl ::std::convert::From<&Self> for Unsatisfiable1 {
-    fn from(value: &Unsatisfiable1) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`Unsatisfiable2`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -1150,11 +1045,6 @@ impl ::std::convert::From<&Self> for Unsatisfiable1 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum Unsatisfiable2 {}
-impl ::std::convert::From<&Self> for Unsatisfiable2 {
-    fn from(value: &Unsatisfiable2) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`Unsatisfiable3`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -1195,11 +1085,6 @@ impl ::std::convert::From<&Self> for Unsatisfiable2 {
 )]
 #[serde(deny_unknown_fields)]
 pub enum Unsatisfiable3 {}
-impl ::std::convert::From<&Self> for Unsatisfiable3 {
-    fn from(value: &Unsatisfiable3) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`Unsatisfiable3A`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -1223,11 +1108,6 @@ impl ::std::convert::From<&Self> for Unsatisfiable3 {
 pub struct Unsatisfiable3A {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub action: ::std::option::Option<Unsatisfiable3C>,
-}
-impl ::std::convert::From<&Unsatisfiable3A> for Unsatisfiable3A {
-    fn from(value: &Unsatisfiable3A) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for Unsatisfiable3A {
     fn default() -> Self {
@@ -1269,11 +1149,6 @@ impl Unsatisfiable3A {
 pub enum Unsatisfiable3B {
     #[serde(rename = "bar")]
     Bar,
-}
-impl ::std::convert::From<&Self> for Unsatisfiable3B {
-    fn from(value: &Unsatisfiable3B) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for Unsatisfiable3B {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -1341,11 +1216,6 @@ impl ::std::convert::TryFrom<::std::string::String> for Unsatisfiable3B {
 pub enum Unsatisfiable3C {
     #[serde(rename = "foo")]
     Foo,
-}
-impl ::std::convert::From<&Self> for Unsatisfiable3C {
-    fn from(value: &Unsatisfiable3C) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for Unsatisfiable3C {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -1524,11 +1394,6 @@ pub enum WeirdEnum {
         #[serde(rename = "pattern-regex")]
         pattern_regex: ::std::string::String,
     },
-}
-impl ::std::convert::From<&Self> for WeirdEnum {
-    fn from(value: &WeirdEnum) -> Self {
-        value.clone()
-    }
 }
 #[doc = r" Types for composing complex structures."]
 pub mod builder {

--- a/typify/tests/schemas/more_types.rs
+++ b/typify/tests/schemas/more_types.rs
@@ -48,11 +48,6 @@ pub mod error {
 pub struct ObjectWithNoExtra {
     pub foo: ::std::string::String,
 }
-impl ::std::convert::From<&ObjectWithNoExtra> for ObjectWithNoExtra {
-    fn from(value: &ObjectWithNoExtra) -> Self {
-        value.clone()
-    }
-}
 impl ObjectWithNoExtra {
     pub fn builder() -> builder::ObjectWithNoExtra {
         Default::default()
@@ -78,11 +73,6 @@ impl ObjectWithNoExtra {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 pub struct ObjectWithOkExtra {
     pub foo: ::std::string::String,
-}
-impl ::std::convert::From<&ObjectWithOkExtra> for ObjectWithOkExtra {
-    fn from(value: &ObjectWithOkExtra) -> Self {
-        value.clone()
-    }
 }
 impl ObjectWithOkExtra {
     pub fn builder() -> builder::ObjectWithOkExtra {
@@ -115,11 +105,6 @@ pub struct ObjectWithStringExtra {
     #[serde(flatten)]
     pub extra: ::std::collections::HashMap<::std::string::String, ::std::string::String>,
 }
-impl ::std::convert::From<&ObjectWithStringExtra> for ObjectWithStringExtra {
-    fn from(value: &ObjectWithStringExtra) -> Self {
-        value.clone()
-    }
-}
 impl ObjectWithStringExtra {
     pub fn builder() -> builder::ObjectWithStringExtra {
         Default::default()
@@ -149,11 +134,6 @@ pub struct ObjectWithWhichExtra {
     #[serde(flatten)]
     pub extra: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
 }
-impl ::std::convert::From<&ObjectWithWhichExtra> for ObjectWithWhichExtra {
-    fn from(value: &ObjectWithWhichExtra) -> Self {
-        value.clone()
-    }
-}
 impl ObjectWithWhichExtra {
     pub fn builder() -> builder::ObjectWithWhichExtra {
         Default::default()
@@ -180,11 +160,6 @@ impl ObjectWithWhichExtra {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 pub struct ObjectWithYesExtra {
     pub foo: ::std::string::String,
-}
-impl ::std::convert::From<&ObjectWithYesExtra> for ObjectWithYesExtra {
-    fn from(value: &ObjectWithYesExtra) -> Self {
-        value.clone()
-    }
 }
 impl ObjectWithYesExtra {
     pub fn builder() -> builder::ObjectWithYesExtra {

--- a/typify/tests/schemas/multiple-instance-types.rs
+++ b/typify/tests/schemas/multiple-instance-types.rs
@@ -44,11 +44,6 @@ pub enum IntOrStr {
     String(::std::string::String),
     Integer(i64),
 }
-impl ::std::convert::From<&Self> for IntOrStr {
-    fn from(value: &IntOrStr) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for IntOrStr {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
@@ -88,11 +83,6 @@ pub enum OneOfSeveral {
     Array(::std::vec::Vec<::serde_json::Value>),
     String(::std::string::String),
     Integer(i64),
-}
-impl ::std::convert::From<&Self> for OneOfSeveral {
-    fn from(value: &OneOfSeveral) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<bool> for OneOfSeveral {
     fn from(value: bool) -> Self {
@@ -146,11 +136,6 @@ impl ::std::convert::From<ReallyJustNull> for () {
         value.0
     }
 }
-impl ::std::convert::From<&ReallyJustNull> for ReallyJustNull {
-    fn from(value: &ReallyJustNull) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<()> for ReallyJustNull {
     fn from(value: ()) -> Self {
         Self(value)
@@ -188,11 +173,6 @@ impl ::std::convert::From<SeriouslyAnything> for ::serde_json::Value {
         value.0
     }
 }
-impl ::std::convert::From<&SeriouslyAnything> for SeriouslyAnything {
-    fn from(value: &SeriouslyAnything) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::serde_json::Value> for SeriouslyAnything {
     fn from(value: ::serde_json::Value) -> Self {
         Self(value)
@@ -224,11 +204,6 @@ pub enum YesNoMaybe {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         value: ::std::option::Option<::std::string::String>,
     },
-}
-impl ::std::convert::From<&Self> for YesNoMaybe {
-    fn from(value: &YesNoMaybe) -> Self {
-        value.clone()
-    }
 }
 impl ::std::convert::From<bool> for YesNoMaybe {
     fn from(value: bool) -> Self {

--- a/typify/tests/schemas/noisy-types.rs
+++ b/typify/tests/schemas/noisy-types.rs
@@ -60,11 +60,6 @@ impl ::std::convert::From<ArrayBs> for ::std::vec::Vec<bool> {
         value.0
     }
 }
-impl ::std::convert::From<&ArrayBs> for ArrayBs {
-    fn from(value: &ArrayBs) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<bool>> for ArrayBs {
     fn from(value: ::std::vec::Vec<bool>) -> Self {
         Self(value)
@@ -100,11 +95,6 @@ impl ::std::ops::Deref for IntegerBs {
 impl ::std::convert::From<IntegerBs> for u64 {
     fn from(value: IntegerBs) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&IntegerBs> for IntegerBs {
-    fn from(value: &IntegerBs) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<u64> for IntegerBs {
@@ -163,11 +153,6 @@ impl ::std::fmt::Display for IntegerBs {
 pub struct ObjectBs {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub ok: ::std::option::Option<bool>,
-}
-impl ::std::convert::From<&ObjectBs> for ObjectBs {
-    fn from(value: &ObjectBs) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for ObjectBs {
     fn default() -> Self {

--- a/typify/tests/schemas/property-pattern.rs
+++ b/typify/tests/schemas/property-pattern.rs
@@ -57,11 +57,6 @@ pub struct TestGrammarForPatternProperties {
     pub rules:
         ::std::collections::HashMap<TestGrammarForPatternPropertiesRulesKey, ::std::string::String>,
 }
-impl ::std::convert::From<&TestGrammarForPatternProperties> for TestGrammarForPatternProperties {
-    fn from(value: &TestGrammarForPatternProperties) -> Self {
-        value.clone()
-    }
-}
 impl TestGrammarForPatternProperties {
     pub fn builder() -> builder::TestGrammarForPatternProperties {
         Default::default()
@@ -90,13 +85,6 @@ impl ::std::ops::Deref for TestGrammarForPatternPropertiesRulesKey {
 impl ::std::convert::From<TestGrammarForPatternPropertiesRulesKey> for ::std::string::String {
     fn from(value: TestGrammarForPatternPropertiesRulesKey) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&TestGrammarForPatternPropertiesRulesKey>
-    for TestGrammarForPatternPropertiesRulesKey
-{
-    fn from(value: &TestGrammarForPatternPropertiesRulesKey) -> Self {
-        value.clone()
     }
 }
 impl ::std::str::FromStr for TestGrammarForPatternPropertiesRulesKey {

--- a/typify/tests/schemas/reflexive.rs
+++ b/typify/tests/schemas/reflexive.rs
@@ -55,11 +55,6 @@ pub struct Node {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub value: ::std::option::Option<i64>,
 }
-impl ::std::convert::From<&Node> for Node {
-    fn from(value: &Node) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for Node {
     fn default() -> Self {
         Self {

--- a/typify/tests/schemas/rust-collisions.rs
+++ b/typify/tests/schemas/rust-collisions.rs
@@ -47,11 +47,6 @@ pub mod error {
 pub struct Box {
     pub data: ::std::string::String,
 }
-impl ::std::convert::From<&Box> for Box {
-    fn from(value: &Box) -> Self {
-        value.clone()
-    }
-}
 impl Box {
     pub fn builder() -> builder::Box {
         Default::default()
@@ -78,11 +73,6 @@ impl Box {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 pub struct Copy {
     pub value: i64,
-}
-impl ::std::convert::From<&Copy> for Copy {
-    fn from(value: &Copy) -> Self {
-        value.clone()
-    }
 }
 impl Copy {
     pub fn builder() -> builder::Copy {
@@ -120,11 +110,6 @@ pub struct DoubleOptionCollision {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub option: ::std::option::Option<DoubleOptionCollisionOption>,
 }
-impl ::std::convert::From<&DoubleOptionCollision> for DoubleOptionCollision {
-    fn from(value: &DoubleOptionCollision) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for DoubleOptionCollision {
     fn default() -> Self {
         Self {
@@ -160,11 +145,6 @@ pub struct DoubleOptionCollisionOption {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub option: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&DoubleOptionCollisionOption> for DoubleOptionCollisionOption {
-    fn from(value: &DoubleOptionCollisionOption) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for DoubleOptionCollisionOption {
     fn default() -> Self {
         Self {
@@ -199,11 +179,6 @@ impl DoubleOptionCollisionOption {
 pub struct Drop {
     pub cleanup: bool,
 }
-impl ::std::convert::From<&Drop> for Drop {
-    fn from(value: &Drop) -> Self {
-        value.clone()
-    }
-}
 impl Drop {
     pub fn builder() -> builder::Drop {
         Default::default()
@@ -235,11 +210,6 @@ pub struct FlattenedKeywords {
     pub normal: ::std::string::String,
     #[serde(flatten)]
     pub extra: ::std::collections::HashMap<::std::string::String, ::std::string::String>,
-}
-impl ::std::convert::From<&FlattenedKeywords> for FlattenedKeywords {
-    fn from(value: &FlattenedKeywords) -> Self {
-        value.clone()
-    }
 }
 impl FlattenedKeywords {
     pub fn builder() -> builder::FlattenedKeywords {
@@ -285,11 +255,6 @@ pub enum FormatCollision {
     QuoteUnquote,
     #[serde(rename = "xyz")]
     Xyz,
-}
-impl ::std::convert::From<&Self> for FormatCollision {
-    fn from(value: &FormatCollision) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for FormatCollision {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -395,11 +360,6 @@ pub enum KeywordFieldsEnum {
     },
     Array([::std::string::String; 2usize]),
 }
-impl ::std::convert::From<&Self> for KeywordFieldsEnum {
-    fn from(value: &KeywordFieldsEnum) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<[::std::string::String; 2usize]> for KeywordFieldsEnum {
     fn from(value: [::std::string::String; 2usize]) -> Self {
         Self::Array(value)
@@ -446,11 +406,6 @@ impl ::std::convert::From<[::std::string::String; 2usize]> for KeywordFieldsEnum
 pub struct MapOfKeywords {
     pub keyword_map:
         ::std::collections::HashMap<::std::string::String, MapOfKeywordsKeywordMapValue>,
-}
-impl ::std::convert::From<&MapOfKeywords> for MapOfKeywords {
-    fn from(value: &MapOfKeywords) -> Self {
-        value.clone()
-    }
 }
 impl MapOfKeywords {
     pub fn builder() -> builder::MapOfKeywords {
@@ -524,11 +479,6 @@ pub enum MapOfKeywordsKeywordMapValue {
     Use,
     #[serde(rename = "where")]
     Where,
-}
-impl ::std::convert::From<&Self> for MapOfKeywordsKeywordMapValue {
-    fn from(value: &MapOfKeywordsKeywordMapValue) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for MapOfKeywordsKeywordMapValue {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -638,11 +588,6 @@ pub struct NestedTypeCollisions {
     pub type_: TypeWithOptionField,
     pub types: ::std::vec::Vec<TypeWithOptionField>,
 }
-impl ::std::convert::From<&NestedTypeCollisions> for NestedTypeCollisions {
-    fn from(value: &NestedTypeCollisions) -> Self {
-        value.clone()
-    }
-}
 impl NestedTypeCollisions {
     pub fn builder() -> builder::NestedTypeCollisions {
         Default::default()
@@ -671,11 +616,6 @@ pub struct NestedTypeCollisionsOptionType {
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub type_: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&NestedTypeCollisionsOptionType> for NestedTypeCollisionsOptionType {
-    fn from(value: &NestedTypeCollisionsOptionType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for NestedTypeCollisionsOptionType {
     fn default() -> Self {
@@ -711,11 +651,6 @@ impl NestedTypeCollisionsOptionType {
 pub struct Option {
     pub maybe: ::std::string::String,
 }
-impl ::std::convert::From<&Option> for Option {
-    fn from(value: &Option) -> Self {
-        value.clone()
-    }
-}
 impl Option {
     pub fn builder() -> builder::Option {
         Default::default()
@@ -742,11 +677,6 @@ impl Option {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 pub struct Pin {
     pub pointer: ::std::string::String,
-}
-impl ::std::convert::From<&Pin> for Pin {
-    fn from(value: &Pin) -> Self {
-        value.clone()
-    }
 }
 impl Pin {
     pub fn builder() -> builder::Pin {
@@ -1070,11 +1000,6 @@ pub struct RustKeywordMonster {
     #[serde(rename = "yield")]
     pub yield_: ::std::string::String,
 }
-impl ::std::convert::From<&RustKeywordMonster> for RustKeywordMonster {
-    fn from(value: &RustKeywordMonster) -> Self {
-        value.clone()
-    }
-}
 impl RustKeywordMonster {
     pub fn builder() -> builder::RustKeywordMonster {
         Default::default()
@@ -1101,11 +1026,6 @@ impl RustKeywordMonster {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 pub struct Send {
     pub message: ::std::string::String,
-}
-impl ::std::convert::From<&Send> for Send {
-    fn from(value: &Send) -> Self {
-        value.clone()
-    }
 }
 impl Send {
     pub fn builder() -> builder::Send {
@@ -1220,11 +1140,6 @@ pub struct Std {
     pub str: StdStr,
     pub string: StdString,
 }
-impl ::std::convert::From<&Std> for Std {
-    fn from(value: &Std) -> Self {
-        value.clone()
-    }
-}
 impl Std {
     pub fn builder() -> builder::Std {
         Default::default()
@@ -1251,11 +1166,6 @@ impl Std {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 pub struct StdBoxed {
     pub value: ::std::string::String,
-}
-impl ::std::convert::From<&StdBoxed> for StdBoxed {
-    fn from(value: &StdBoxed) -> Self {
-        value.clone()
-    }
 }
 impl StdBoxed {
     pub fn builder() -> builder::StdBoxed {
@@ -1284,11 +1194,6 @@ impl StdBoxed {
 pub struct StdConvert {
     pub value: ::std::string::String,
 }
-impl ::std::convert::From<&StdConvert> for StdConvert {
-    fn from(value: &StdConvert) -> Self {
-        value.clone()
-    }
-}
 impl StdConvert {
     pub fn builder() -> builder::StdConvert {
         Default::default()
@@ -1315,11 +1220,6 @@ impl StdConvert {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 pub struct StdFmt {
     pub value: ::std::string::String,
-}
-impl ::std::convert::From<&StdFmt> for StdFmt {
-    fn from(value: &StdFmt) -> Self {
-        value.clone()
-    }
 }
 impl StdFmt {
     pub fn builder() -> builder::StdFmt {
@@ -1348,11 +1248,6 @@ impl StdFmt {
 pub struct StdOption {
     pub value: ::std::string::String,
 }
-impl ::std::convert::From<&StdOption> for StdOption {
-    fn from(value: &StdOption) -> Self {
-        value.clone()
-    }
-}
 impl StdOption {
     pub fn builder() -> builder::StdOption {
         Default::default()
@@ -1379,11 +1274,6 @@ impl StdOption {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 pub struct StdResult {
     pub value: ::std::string::String,
-}
-impl ::std::convert::From<&StdResult> for StdResult {
-    fn from(value: &StdResult) -> Self {
-        value.clone()
-    }
 }
 impl StdResult {
     pub fn builder() -> builder::StdResult {
@@ -1412,11 +1302,6 @@ impl StdResult {
 pub struct StdStr {
     pub value: ::std::string::String,
 }
-impl ::std::convert::From<&StdStr> for StdStr {
-    fn from(value: &StdStr) -> Self {
-        value.clone()
-    }
-}
 impl StdStr {
     pub fn builder() -> builder::StdStr {
         Default::default()
@@ -1444,11 +1329,6 @@ impl StdStr {
 pub struct StdString {
     pub value: ::std::string::String,
 }
-impl ::std::convert::From<&StdString> for StdString {
-    fn from(value: &StdString) -> Self {
-        value.clone()
-    }
-}
 impl StdString {
     pub fn builder() -> builder::StdString {
         Default::default()
@@ -1475,11 +1355,6 @@ impl StdString {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 pub struct String {
     pub text: ::std::string::String,
-}
-impl ::std::convert::From<&String> for String {
-    fn from(value: &String) -> Self {
-        value.clone()
-    }
 }
 impl String {
     pub fn builder() -> builder::String {
@@ -1520,11 +1395,6 @@ pub enum StringEnum {
     Two,
     #[serde(rename = "three")]
     Three,
-}
-impl ::std::convert::From<&Self> for StringEnum {
-    fn from(value: &StringEnum) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for StringEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -1592,11 +1462,6 @@ impl ::std::ops::Deref for StringNewtype {
 impl ::std::convert::From<StringNewtype> for ::std::string::String {
     fn from(value: StringNewtype) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&StringNewtype> for StringNewtype {
-    fn from(value: &StringNewtype) -> Self {
-        value.clone()
     }
 }
 impl ::std::str::FromStr for StringNewtype {
@@ -1667,11 +1532,6 @@ impl<'de> ::serde::Deserialize<'de> for StringNewtype {
 pub struct Sync {
     pub data: ::std::string::String,
 }
-impl ::std::convert::From<&Sync> for Sync {
-    fn from(value: &Sync) -> Self {
-        value.clone()
-    }
-}
 impl Sync {
     pub fn builder() -> builder::Sync {
         Default::default()
@@ -1694,7 +1554,6 @@ pub struct TestSchemaWithVariousDefinitionsTypeNamesAndPropertiesThatLikelyConfl
 );
 impl :: std :: ops :: Deref for TestSchemaWithVariousDefinitionsTypeNamesAndPropertiesThatLikelyConflictWithBuiltInRustTypesAndKeywords { type Target = :: serde_json :: Value ; fn deref (& self) -> & :: serde_json :: Value { & self . 0 } }
 impl :: std :: convert :: From < TestSchemaWithVariousDefinitionsTypeNamesAndPropertiesThatLikelyConflictWithBuiltInRustTypesAndKeywords > for :: serde_json :: Value { fn from (value : TestSchemaWithVariousDefinitionsTypeNamesAndPropertiesThatLikelyConflictWithBuiltInRustTypesAndKeywords) -> Self { value . 0 } }
-impl :: std :: convert :: From < & TestSchemaWithVariousDefinitionsTypeNamesAndPropertiesThatLikelyConflictWithBuiltInRustTypesAndKeywords > for TestSchemaWithVariousDefinitionsTypeNamesAndPropertiesThatLikelyConflictWithBuiltInRustTypesAndKeywords { fn from (value : & TestSchemaWithVariousDefinitionsTypeNamesAndPropertiesThatLikelyConflictWithBuiltInRustTypesAndKeywords) -> Self { value . clone () } }
 impl :: std :: convert :: From < :: serde_json :: Value > for TestSchemaWithVariousDefinitionsTypeNamesAndPropertiesThatLikelyConflictWithBuiltInRustTypesAndKeywords { fn from (value : :: serde_json :: Value) -> Self { Self (value) } }
 #[doc = "`TypeWithOptionField`"]
 #[doc = r""]
@@ -1726,11 +1585,6 @@ pub struct TypeWithOptionField {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub optional_field: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&TypeWithOptionField> for TypeWithOptionField {
-    fn from(value: &TypeWithOptionField) -> Self {
-        value.clone()
-    }
-}
 impl TypeWithOptionField {
     pub fn builder() -> builder::TypeWithOptionField {
         Default::default()
@@ -1760,11 +1614,6 @@ impl TypeWithOptionField {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 pub struct Vec {
     pub items: ::std::vec::Vec<::std::string::String>,
-}
-impl ::std::convert::From<&Vec> for Vec {
-    fn from(value: &Vec) -> Self {
-        value.clone()
-    }
 }
 impl Vec {
     pub fn builder() -> builder::Vec {

--- a/typify/tests/schemas/simple-types.rs
+++ b/typify/tests/schemas/simple-types.rs
@@ -42,11 +42,6 @@ pub mod error {
 pub struct AnythingWorks {
     pub value: ::serde_json::Value,
 }
-impl ::std::convert::From<&AnythingWorks> for AnythingWorks {
-    fn from(value: &AnythingWorks) -> Self {
-        value.clone()
-    }
-}
 impl AnythingWorks {
     pub fn builder() -> builder::AnythingWorks {
         Default::default()
@@ -72,11 +67,6 @@ impl AnythingWorks {
 pub struct FloatsArentTerribleImTold {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub flush_timeout: ::std::option::Option<f32>,
-}
-impl ::std::convert::From<&FloatsArentTerribleImTold> for FloatsArentTerribleImTold {
-    fn from(value: &FloatsArentTerribleImTold) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for FloatsArentTerribleImTold {
     fn default() -> Self {
@@ -124,11 +114,6 @@ impl ::std::ops::Deref for JustOne {
 impl ::std::convert::From<JustOne> for ::std::string::String {
     fn from(value: JustOne) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&JustOne> for JustOne {
-    fn from(value: &JustOne) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<::std::string::String> for JustOne {
@@ -204,11 +189,6 @@ pub struct UintMinimumAndMaximum {
     pub min_non_zero: ::std::num::NonZeroU64,
     pub min_uint_non_zero: ::std::num::NonZeroU64,
     pub no_bounds: u64,
-}
-impl ::std::convert::From<&UintMinimumAndMaximum> for UintMinimumAndMaximum {
-    fn from(value: &UintMinimumAndMaximum) -> Self {
-        value.clone()
-    }
 }
 impl UintMinimumAndMaximum {
     pub fn builder() -> builder::UintMinimumAndMaximum {

--- a/typify/tests/schemas/string-enum-with-default.rs
+++ b/typify/tests/schemas/string-enum-with-default.rs
@@ -61,11 +61,6 @@ pub enum TestEnum {
     #[serde(rename = "success")]
     Success,
 }
-impl ::std::convert::From<&Self> for TestEnum {
-    fn from(value: &TestEnum) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for TestEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {

--- a/typify/tests/schemas/type-with-modified-generation.rs
+++ b/typify/tests/schemas/type-with-modified-generation.rs
@@ -62,11 +62,6 @@ pub struct TestType {
     pub patched_type: TypeThatHasMoreDerives,
     pub replaced_type: String,
 }
-impl ::std::convert::From<&TestType> for TestType {
-    fn from(value: &TestType) -> Self {
-        value.clone()
-    }
-}
 impl TestType {
     pub fn builder() -> builder::TestType {
         Default::default()
@@ -101,11 +96,6 @@ impl ::std::convert::From<TypeThatHasMoreDerives>
 {
     fn from(value: TypeThatHasMoreDerives) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&TypeThatHasMoreDerives> for TypeThatHasMoreDerives {
-    fn from(value: &TypeThatHasMoreDerives) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<::std::collections::HashMap<::std::string::String, ::std::string::String>>

--- a/typify/tests/schemas/types-with-defaults.rs
+++ b/typify/tests/schemas/types-with-defaults.rs
@@ -47,11 +47,6 @@ pub struct Doodad {
     #[serde(default = "defaults::doodad_when")]
     pub when: ::chrono::DateTime<::chrono::offset::Utc>,
 }
-impl ::std::convert::From<&Doodad> for Doodad {
-    fn from(value: &Doodad) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for Doodad {
     fn default() -> Self {
         Self {
@@ -106,11 +101,6 @@ pub struct MrDefaultNumbers {
     #[serde(default = "defaults::default_nzu64::<::std::num::NonZeroU8, 2>")]
     pub little_u8: ::std::num::NonZeroU8,
 }
-impl ::std::convert::From<&MrDefaultNumbers> for MrDefaultNumbers {
-    fn from(value: &MrDefaultNumbers) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for MrDefaultNumbers {
     fn default() -> Self {
         Self {
@@ -157,11 +147,6 @@ impl MrDefaultNumbers {
 pub struct OuterThing {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub thing: ::std::option::Option<ThingWithDefaults>,
-}
-impl ::std::convert::From<&OuterThing> for OuterThing {
-    fn from(value: &OuterThing) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for OuterThing {
     fn default() -> Self {
@@ -216,11 +201,6 @@ pub struct TestBed {
     #[serde(default = "defaults::test_bed_id")]
     pub id: ::uuid::Uuid,
 }
-impl ::std::convert::From<&TestBed> for TestBed {
-    fn from(value: &TestBed) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for TestBed {
     fn default() -> Self {
         Self {
@@ -268,11 +248,6 @@ pub struct ThingWithDefaults {
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub type_: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&ThingWithDefaults> for ThingWithDefaults {
-    fn from(value: &ThingWithDefaults) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for ThingWithDefaults {
     fn default() -> Self {

--- a/typify/tests/schemas/types-with-more-impls.rs
+++ b/typify/tests/schemas/types-with-more-impls.rs
@@ -50,11 +50,6 @@ impl ::std::convert::From<PatternString> for ::std::string::String {
         value.0
     }
 }
-impl ::std::convert::From<&PatternString> for PatternString {
-    fn from(value: &PatternString) -> Self {
-        value.clone()
-    }
-}
 impl ::std::str::FromStr for PatternString {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -129,11 +124,6 @@ impl ::std::ops::Deref for Sub10Primes {
 impl ::std::convert::From<Sub10Primes> for u32 {
     fn from(value: Sub10Primes) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&Sub10Primes> for Sub10Primes {
-    fn from(value: &Sub10Primes) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::TryFrom<u32> for Sub10Primes {

--- a/typify/tests/schemas/untyped-enum-with-null.rs
+++ b/typify/tests/schemas/untyped-enum-with-null.rs
@@ -54,11 +54,6 @@ pub mod error {
 pub struct TestType {
     pub value: ::std::option::Option<TestTypeValue>,
 }
-impl ::std::convert::From<&TestType> for TestType {
-    fn from(value: &TestType) -> Self {
-        value.clone()
-    }
-}
 impl TestType {
     pub fn builder() -> builder::TestType {
         Default::default()
@@ -98,11 +93,6 @@ pub enum TestTypeValue {
     Middle,
     #[serde(rename = "end")]
     End,
-}
-impl ::std::convert::From<&Self> for TestTypeValue {
-    fn from(value: &TestTypeValue) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for TestTypeValue {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {

--- a/typify/tests/schemas/various-enums.rs
+++ b/typify/tests/schemas/various-enums.rs
@@ -58,11 +58,6 @@ pub enum AlternativeEnum {
     Choice2,
     Choice3,
 }
-impl ::std::convert::From<&Self> for AlternativeEnum {
-    fn from(value: &AlternativeEnum) -> Self {
-        value.clone()
-    }
-}
 impl ::std::fmt::Display for AlternativeEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
@@ -135,11 +130,6 @@ impl ::std::default::Default for AlternativeEnum {
 )]
 #[serde(deny_unknown_fields)]
 pub enum AnyOfNoStrings {}
-impl ::std::convert::From<&Self> for AnyOfNoStrings {
-    fn from(value: &AnyOfNoStrings) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`AnyOfNothing`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -164,11 +154,6 @@ impl ::std::convert::From<&Self> for AnyOfNoStrings {
 )]
 #[serde(deny_unknown_fields)]
 pub enum AnyOfNothing {}
-impl ::std::convert::From<&Self> for AnyOfNothing {
-    fn from(value: &AnyOfNothing) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`CommentedVariants`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -215,11 +200,6 @@ pub enum CommentedVariants {
     B,
     #[doc = "a pirate's favorite letter"]
     C,
-}
-impl ::std::convert::From<&Self> for CommentedVariants {
-    fn from(value: &CommentedVariants) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for CommentedVariants {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -296,11 +276,6 @@ pub struct DiskAttachment {
     pub alternate: AlternativeEnum,
     pub state: DiskAttachmentState,
 }
-impl ::std::convert::From<&DiskAttachment> for DiskAttachment {
-    fn from(value: &DiskAttachment) -> Self {
-        value.clone()
-    }
-}
 impl DiskAttachment {
     pub fn builder() -> builder::DiskAttachment {
         Default::default()
@@ -338,11 +313,6 @@ pub enum DiskAttachmentState {
     Detached,
     Destroyed,
     Faulted,
-}
-impl ::std::convert::From<&Self> for DiskAttachmentState {
-    fn from(value: &DiskAttachmentState) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for DiskAttachmentState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -414,11 +384,6 @@ pub struct EmptyObject {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub prop: ::std::option::Option<EmptyObjectProp>,
 }
-impl ::std::convert::From<&EmptyObject> for EmptyObject {
-    fn from(value: &EmptyObject) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for EmptyObject {
     fn default() -> Self {
         Self {
@@ -458,11 +423,6 @@ impl ::std::convert::From<EmptyObjectProp>
 {
     fn from(value: EmptyObjectProp) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&EmptyObjectProp> for EmptyObjectProp {
-    fn from(value: &EmptyObjectProp) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::TryFrom<::serde_json::Map<::std::string::String, ::serde_json::Value>>
@@ -580,11 +540,6 @@ pub enum EnumAndConstant {
     #[serde(rename = "fish")]
     Fish { float: ::std::string::String },
 }
-impl ::std::convert::From<&Self> for EnumAndConstant {
-    fn from(value: &EnumAndConstant) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`IpNet`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -618,11 +573,6 @@ impl ::std::convert::From<&Self> for EnumAndConstant {
 pub enum IpNet {
     V4(Ipv4Net),
     V6(Ipv6Net),
-}
-impl ::std::convert::From<&Self> for IpNet {
-    fn from(value: &IpNet) -> Self {
-        value.clone()
-    }
 }
 impl ::std::str::FromStr for IpNet {
     type Err = self::error::ConversionError;
@@ -701,11 +651,6 @@ impl ::std::convert::From<Ipv4Net> for ::std::string::String {
         value.0
     }
 }
-impl ::std::convert::From<&Ipv4Net> for Ipv4Net {
-    fn from(value: &Ipv4Net) -> Self {
-        value.clone()
-    }
-}
 impl ::std::str::FromStr for Ipv4Net {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -774,11 +719,6 @@ impl ::std::ops::Deref for Ipv6Net {
 impl ::std::convert::From<Ipv6Net> for ::std::string::String {
     fn from(value: Ipv6Net) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&Ipv6Net> for Ipv6Net {
-    fn from(value: &Ipv6Net) -> Self {
-        value.clone()
     }
 }
 impl ::std::str::FromStr for Ipv6Net {
@@ -865,11 +805,6 @@ pub enum JankNames {
     Variant1(::std::collections::HashMap<::std::string::String, ::std::string::String>),
     Variant2(::std::collections::HashMap<::std::string::String, i64>),
 }
-impl ::std::convert::From<&Self> for JankNames {
-    fn from(value: &JankNames) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::collections::HashMap<::std::string::String, ::std::string::String>>
     for JankNames
 {
@@ -906,11 +841,6 @@ impl ::std::convert::From<::std::collections::HashMap<::std::string::String, i64
 )]
 #[serde(deny_unknown_fields)]
 pub enum Never {}
-impl ::std::convert::From<&Self> for Never {
-    fn from(value: &Never) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`NeverEver`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -933,11 +863,6 @@ impl ::std::convert::From<&Self> for Never {
 )]
 #[serde(deny_unknown_fields)]
 pub enum NeverEver {}
-impl ::std::convert::From<&Self> for NeverEver {
-    fn from(value: &NeverEver) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`NeverEverForever`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -960,11 +885,6 @@ impl ::std::convert::From<&Self> for NeverEver {
 )]
 #[serde(deny_unknown_fields)]
 pub enum NeverEverForever {}
-impl ::std::convert::From<&Self> for NeverEverForever {
-    fn from(value: &NeverEverForever) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`NullStringEnumWithUnknownFormat`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -1000,11 +920,6 @@ impl ::std::convert::From<NullStringEnumWithUnknownFormat>
 {
     fn from(value: NullStringEnumWithUnknownFormat) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&NullStringEnumWithUnknownFormat> for NullStringEnumWithUnknownFormat {
-    fn from(value: &NullStringEnumWithUnknownFormat) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<::std::option::Option<NullStringEnumWithUnknownFormatInner>>
@@ -1049,11 +964,6 @@ pub enum NullStringEnumWithUnknownFormatInner {
     B,
     #[serde(rename = "c")]
     C,
-}
-impl ::std::convert::From<&Self> for NullStringEnumWithUnknownFormatInner {
-    fn from(value: &NullStringEnumWithUnknownFormatInner) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for NullStringEnumWithUnknownFormatInner {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -1153,11 +1063,6 @@ pub enum OneOfMissingTitle {
         baz: ::std::option::Option<i64>,
     },
 }
-impl ::std::convert::From<&Self> for OneOfMissingTitle {
-    fn from(value: &OneOfMissingTitle) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`OneOfRawType`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -1180,11 +1085,6 @@ impl ::std::convert::From<&Self> for OneOfMissingTitle {
 pub enum OneOfRawType {
     String(::std::string::String),
     Integer(i64),
-}
-impl ::std::convert::From<&Self> for OneOfRawType {
-    fn from(value: &OneOfRawType) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for OneOfRawType {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -1238,11 +1138,6 @@ pub enum OneOfTypes {
     #[serde(rename = "foo")]
     Foo(::std::string::String),
 }
-impl ::std::convert::From<&Self> for OneOfTypes {
-    fn from(value: &OneOfTypes) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<i64> for OneOfTypes {
     fn from(value: i64) -> Self {
         Self::Bar(value)
@@ -1277,11 +1172,6 @@ impl ::std::ops::Deref for OptionAnyofConst {
 impl ::std::convert::From<OptionAnyofConst> for ::std::option::Option<::std::string::String> {
     fn from(value: OptionAnyofConst) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&OptionAnyofConst> for OptionAnyofConst {
-    fn from(value: &OptionAnyofConst) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<::std::option::Option<::std::string::String>> for OptionAnyofConst {
@@ -1322,11 +1212,6 @@ impl ::std::convert::From<OptionAnyofEnum> for ::std::option::Option<::std::stri
         value.0
     }
 }
-impl ::std::convert::From<&OptionAnyofEnum> for OptionAnyofEnum {
-    fn from(value: &OptionAnyofEnum) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::option::Option<::std::string::String>> for OptionAnyofEnum {
     fn from(value: ::std::option::Option<::std::string::String>) -> Self {
         Self(value)
@@ -1363,11 +1248,6 @@ impl ::std::convert::From<OptionAnyofNull> for ::std::option::Option<::std::stri
         value.0
     }
 }
-impl ::std::convert::From<&OptionAnyofNull> for OptionAnyofNull {
-    fn from(value: &OptionAnyofNull) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::option::Option<::std::string::String>> for OptionAnyofNull {
     fn from(value: ::std::option::Option<::std::string::String>) -> Self {
         Self(value)
@@ -1402,11 +1282,6 @@ impl ::std::ops::Deref for OptionOneofConst {
 impl ::std::convert::From<OptionOneofConst> for ::std::option::Option<::std::string::String> {
     fn from(value: OptionOneofConst) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&OptionOneofConst> for OptionOneofConst {
-    fn from(value: &OptionOneofConst) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<::std::option::Option<::std::string::String>> for OptionOneofConst {
@@ -1447,11 +1322,6 @@ impl ::std::convert::From<OptionOneofEnum> for ::std::option::Option<::std::stri
         value.0
     }
 }
-impl ::std::convert::From<&OptionOneofEnum> for OptionOneofEnum {
-    fn from(value: &OptionOneofEnum) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::option::Option<::std::string::String>> for OptionOneofEnum {
     fn from(value: ::std::option::Option<::std::string::String>) -> Self {
         Self(value)
@@ -1486,11 +1356,6 @@ impl ::std::ops::Deref for OptionOneofNull {
 impl ::std::convert::From<OptionOneofNull> for ::std::option::Option<::std::string::String> {
     fn from(value: OptionOneofNull) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&OptionOneofNull> for OptionOneofNull {
-    fn from(value: &OptionOneofNull) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<::std::option::Option<::std::string::String>> for OptionOneofNull {
@@ -1530,11 +1395,6 @@ impl ::std::ops::Deref for ReferenceDef {
 impl ::std::convert::From<ReferenceDef> for ::std::string::String {
     fn from(value: ReferenceDef) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&ReferenceDef> for ReferenceDef {
-    fn from(value: &ReferenceDef) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<::std::string::String> for ReferenceDef {
@@ -1591,11 +1451,6 @@ pub enum References {
     Array(::std::vec::Vec<::std::string::String>),
     Object(::std::collections::HashMap<::std::string::String, ReferencesObjectValue>),
 }
-impl ::std::convert::From<&Self> for References {
-    fn from(value: &References) -> Self {
-        value.clone()
-    }
-}
 impl ::std::convert::From<::std::vec::Vec<::std::string::String>> for References {
     fn from(value: ::std::vec::Vec<::std::string::String>) -> Self {
         Self::Array(value)
@@ -1632,11 +1487,6 @@ impl ::std::convert::From<::std::collections::HashMap<::std::string::String, Ref
 pub enum ReferencesObjectValue {
     StringVersion(StringVersion),
     ReferenceDef(ReferenceDef),
-}
-impl ::std::convert::From<&Self> for ReferencesObjectValue {
-    fn from(value: &ReferencesObjectValue) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for ReferencesObjectValue {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -1692,11 +1542,6 @@ pub enum ShouldBeExclusive {
     Variant0 { id: ::std::string::String },
     Variant1 { reference: ::std::string::String },
 }
-impl ::std::convert::From<&Self> for ShouldBeExclusive {
-    fn from(value: &ShouldBeExclusive) -> Self {
-        value.clone()
-    }
-}
 #[doc = "`StringVersion`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -1729,11 +1574,6 @@ impl ::std::ops::Deref for StringVersion {
 impl ::std::convert::From<StringVersion> for ::std::string::String {
     fn from(value: StringVersion) -> Self {
         value.0
-    }
-}
-impl ::std::convert::From<&StringVersion> for StringVersion {
-    fn from(value: &StringVersion) -> Self {
-        value.clone()
     }
 }
 impl ::std::convert::From<::std::string::String> for StringVersion {
@@ -1785,11 +1625,6 @@ pub enum VariantsDifferByPunct {
     X25gbasext,
     #[serde(rename = "2,5,GBASE,T")]
     X2x5xgbasext,
-}
-impl ::std::convert::From<&Self> for VariantsDifferByPunct {
-    fn from(value: &VariantsDifferByPunct) -> Self {
-        value.clone()
-    }
 }
 impl ::std::fmt::Display for VariantsDifferByPunct {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {

--- a/typify/tests/schemas/x-rust-type.rs
+++ b/typify/tests/schemas/x-rust-type.rs
@@ -50,11 +50,6 @@ pub struct AllTheThings {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub path: ::std::option::Option<::std::path::PathBuf>,
 }
-impl ::std::convert::From<&AllTheThings> for AllTheThings {
-    fn from(value: &AllTheThings) -> Self {
-        value.clone()
-    }
-}
 impl ::std::default::Default for AllTheThings {
     fn default() -> Self {
         Self {
@@ -90,11 +85,6 @@ impl AllTheThings {
 )]
 #[serde(deny_unknown_fields)]
 pub enum Marker {}
-impl ::std::convert::From<&Self> for Marker {
-    fn from(value: &Marker) -> Self {
-        value.clone()
-    }
-}
 #[doc = r" Types for composing complex structures."]
 pub mod builder {
     #[derive(Clone, Debug)]


### PR DESCRIPTION
the current codegen implements `From<&Self> for Self` for a number of types. This is non-idiomatic since this doesn't match the intended semantics of the `From` trait and implicitly clones the object. It's also redundant with the `Clone` trait, which is the idiomatic and explicit way to turn a reference into an object.

This PR removes this implementation. This is a breaking change for downstream users that are passing references- the caller will now need to explicitly clone