### PR TITLE
refactor!: remove non-idiomatic From<&String> trait impls

### DIFF
--- a/cargo-typify/README.md
+++ b/cargo-typify/README.md
@@ -90,12 +90,6 @@ impl std::convert::TryFrom<&str> for IdOrName {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String> for IdOrName {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
 impl std::convert::TryFrom<String> for IdOrName {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
@@ -153,12 +147,6 @@ impl std::str::FromStr for Name {
 impl std::convert::TryFrom<&str> for Name {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
-        value.parse()
-    }
-}
-impl std::convert::TryFrom<&String> for Name {
-    type Error = &'static str;
-    fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -1409,16 +1409,6 @@ impl TypeEntry {
                                     value.parse()
                                 }
                             }
-                            impl ::std::convert::TryFrom<&String> for #type_name {
-                                type Error = <#inner_type_name as
-                                    ::std::str::FromStr>::Err;
-
-                                fn try_from(value: &String) ->
-                                    ::std::result::Result<Self, Self::Error>
-                                {
-                                    value.parse()
-                                }
-                            }
                             impl ::std::convert::TryFrom<String> for #type_name {
                                 type Error = <#inner_type_name as
                                     ::std::str::FromStr>::Err;

--- a/typify/tests/schemas/merged-schemas.rs
+++ b/typify/tests/schemas/merged-schemas.rs
@@ -529,12 +529,6 @@ impl ::std::convert::TryFrom<&str> for NarrowNumber {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&String> for NarrowNumber {
-    type Error = <::std::num::NonZeroU64 as ::std::str::FromStr>::Err;
-    fn try_from(value: &String) -> ::std::result::Result<Self, Self::Error> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<String> for NarrowNumber {
     type Error = <::std::num::NonZeroU64 as ::std::str::FromStr>::Err;
     fn try_from(value: String) -> ::std::result::Result<Self, Self::Error> {

--- a/typify/tests/schemas/noisy-types.rs
+++ b/typify/tests/schemas/noisy-types.rs
@@ -114,12 +114,6 @@ impl ::std::convert::TryFrom<&str> for IntegerBs {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&String> for IntegerBs {
-    type Error = <u64 as ::std::str::FromStr>::Err;
-    fn try_from(value: &String) -> ::std::result::Result<Self, Self::Error> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<String> for IntegerBs {
     type Error = <u64 as ::std::str::FromStr>::Err;
     fn try_from(value: String) -> ::std::result::Result<Self, Self::Error> {


### PR DESCRIPTION
the codegen is outputting both `From<&str>` and `From<&String>` implementations. since `&String` auto-dereferences to `&str` this is redundant and non-idiomatic.

This is in principle a breaking change, but unlikely to have a significant impact on downstream users due to the auto-deferencing (though it's possible some patterns are doing some funny type inference that could be affected by this change)