### PR TITLE
Re-export regress to avoid a peer dependency

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,8 @@
 
 https://github.com/oxidecomputer/typify/compare/v0.6.2\...HEAD[Full list of commits]
 
+* `import_types!` no longer requires consumers to declare `regress` as a direct dependency. The macro now references `regress` through a re-export from `typify`. Users of the macro may drop `regress` from their `Cargo.toml`. The `TypeSpace` builder API is unchanged for `cargo-typify` and `build.rs` callers, who continue to emit `::regress` by default; a new `TypeSpaceSettings::with_regress_crate` setter allows overriding the path.
+
 == 0.6.2 (released 2026-04-24)
 
 https://github.com/oxidecomputer/typify/compare/v0.6.1\...v0.6.2[Full list of commits]

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -308,6 +308,8 @@ pub struct TypeSpaceSettings {
     patch: BTreeMap<String, TypeSpacePatch>,
     replace: BTreeMap<String, TypeSpaceReplace>,
     convert: Vec<TypeSpaceConversion>,
+
+    regress_crate: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -560,6 +562,22 @@ impl TypeSpaceSettings {
     pub fn with_map_type<T: Into<MapType>>(&mut self, map_type: T) -> &mut Self {
         self.map_type = map_type.into();
         self
+    }
+
+    /// Override the path used to reference the [`regress`] crate in generated
+    /// code. The default `::regress` requires consumers to declare `regress`
+    /// as a direct dependency. The `typify` crate sets this to
+    /// `::typify::regress` so that consumers of the `import_types!` macro do
+    /// not need a direct `regress` dependency.
+    pub fn with_regress_crate<S: ToString>(&mut self, path: S) -> &mut Self {
+        self.regress_crate = Some(path.to_string());
+        self
+    }
+
+    /// The configured regress crate path, or the default `::regress`.
+    pub(crate) fn regress_crate_path(&self) -> syn::Path {
+        let s = self.regress_crate.as_deref().unwrap_or("::regress");
+        syn::parse_str(s).expect("regress_crate must parse as a path")
     }
 }
 

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -1555,9 +1555,10 @@ impl TypeEntry {
 
                 let pat = pattern.as_ref().map(|p| {
                     let err = format!("doesn't match pattern \"{}\"", p);
+                    let regress = type_space.settings.regress_crate_path();
                     quote! {
-                        static PATTERN: ::std::sync::LazyLock<::regress::Regex> = ::std::sync::LazyLock::new(|| {
-                            ::regress::Regex::new(#p).unwrap()
+                        static PATTERN: ::std::sync::LazyLock<#regress::Regex> = ::std::sync::LazyLock::new(|| {
+                            #regress::Regex::new(#p).unwrap()
                         });
                         if PATTERN.find(value).is_none() {
                             return Err(#err.into());

--- a/typify-macro/src/lib.rs
+++ b/typify-macro/src/lib.rs
@@ -191,7 +191,7 @@ impl From<MacroPatch> for TypeSpacePatch {
 
 fn do_import_types(item: TokenStream) -> Result<TokenStream, syn::Error> {
     // Allow the caller to give us either a simple string or a compound object.
-    let (schema, settings) = if let Ok(ll) = syn::parse::<LitStr>(item.clone()) {
+    let (schema, mut settings) = if let Ok(ll) = syn::parse::<LitStr>(item.clone()) {
         (ll, TypeSpaceSettings::default())
     } else {
         let MacroSettings {
@@ -244,6 +244,11 @@ fn do_import_types(item: TokenStream) -> Result<TokenStream, syn::Error> {
 
         (schema.into_inner(), settings)
     };
+
+    // Macro consumers depend on the `typify` crate, which re-exports `regress`.
+    // Routing the generated path through the re-export saves callers from
+    // having to declare `regress` themselves as a peer dependency of `typify`.
+    settings.with_regress_crate("::typify::regress");
 
     let dir = std::env::var("CARGO_MANIFEST_DIR").map_or_else(
         |_| std::env::current_dir().unwrap(),

--- a/typify/Cargo.toml
+++ b/typify/Cargo.toml
@@ -16,6 +16,7 @@ macro = ["typify-macro"]
 [dependencies]
 typify-macro = { workspace = true, optional = true }
 typify-impl = { workspace = true }
+regress = { workspace = true }
 
 [dev-dependencies]
 chrono = { workspace = true }
@@ -23,7 +24,6 @@ env_logger = { workspace = true }
 expectorate = { workspace = true }
 glob = { workspace = true }
 quote = { workspace = true }
-regress = { workspace = true }
 rustfmt-wrapper = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }

--- a/typify/src/lib.rs
+++ b/typify/src/lib.rs
@@ -148,6 +148,9 @@
 
 #![deny(missing_docs)]
 
+#[doc(hidden)]
+pub use regress;
+
 pub use typify_impl::accept_as_ident;
 pub use typify_impl::CrateVers;
 pub use typify_impl::Error;


### PR DESCRIPTION
The `import_types!` macro currently emits validation code that references `::regress::Regex`, forcing every macro consumer to declare `regress` as a direct dependency. This commit re-exports `regress` from `typify` under a `#[doc(hidden)]` alias, and routes the macro's emitted path through `::typify::regress`, so callers can drop the `regress` entry from `Cargo.toml`.

The default emitted path remains `::regress`, so `cargo-typify`, `build.rs` users, and direct `typify-impl` callers are unaffected. A new `TypeSpaceSettings::with_regress_crate` setter exposes the override.