### PR TITLE
fix: avoid duplicate nullable type emission

### DIFF
--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -96,7 +96,7 @@ impl TypeSpace {
                     // new name for the inner type; otherwise, the inner type
                     // can just have this name.
                     let inner_type_name = match &type_name {
-                        Name::Required(name) => Name::Suggested(format!("{}Inner", name)),
+                        Name::Required(name) => Name::Required(format!("{}Inner", name)),
                         _ => type_name,
                     };
                     self.convert_option(inner_type_name, metadata, &ss)

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -915,9 +915,15 @@ impl TypeSpace {
         );
 
         // Add all types.
-        self.id_to_entry
-            .values()
-            .for_each(|type_entry| type_entry.output(self, &mut output));
+        let mut output_names = BTreeSet::new();
+        self.id_to_entry.values().for_each(|type_entry| {
+            if type_entry
+                .name()
+                .is_none_or(|name| output_names.insert(name.clone()))
+            {
+                type_entry.output(self, &mut output);
+            }
+        });
 
         // Add all shared default functions.
         self.defaults

--- a/typify-impl/tests/test_generation.rs
+++ b/typify-impl/tests/test_generation.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 Oxide Computer Company
 
 use quote::quote;
-use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
+use schemars::{gen::SchemaGenerator, schema::RootSchema, schema::Schema, JsonSchema};
 use serde::Serialize;
 use typify_impl::{TypeSpace, TypeSpacePatch, TypeSpaceSettings};
 
@@ -111,4 +111,73 @@ fn test_generation() {
     let fmt = rustfmt_wrapper::rustfmt(file.to_string()).unwrap();
 
     expectorate::assert_contents("tests/generator.out", fmt.as_str());
+}
+
+#[test]
+fn test_required_nullable_object_with_title_uses_distinct_inner_name() {
+    let schema: RootSchema = serde_json::from_value(serde_json::json!({
+        "definitions": {
+            "aaa-wrapper": {
+                "type": "object",
+                "properties": {
+                    "author_association": {
+                        "title": "author_association",
+                        "type": "string",
+                        "enum": ["OWNER", "MEMBER"]
+                    }
+                }
+            },
+            "author-association": {
+                "title": "author_association",
+                "type": "string",
+                "enum": ["OWNER", "MEMBER"]
+            },
+            "simple-user": {
+                "title": "Simple User",
+                "type": "object",
+                "properties": {
+                    "login": {
+                        "type": "string"
+                    }
+                },
+                "required": ["login"]
+            },
+            "auto-merge": {
+                "title": "Auto merge",
+                "type": ["object", "null"],
+                "properties": {
+                    "enabled_by": {
+                        "$ref": "#/definitions/simple-user"
+                    },
+                    "merge_method": {
+                        "type": "string",
+                        "enum": ["merge", "squash", "rebase"]
+                    },
+                    "commit_title": {
+                        "type": "string"
+                    },
+                    "commit_message": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "enabled_by",
+                    "merge_method",
+                    "commit_title",
+                    "commit_message"
+                ]
+            }
+        }
+    }))
+    .unwrap();
+
+    let mut type_space = TypeSpace::default();
+    type_space.add_root_schema(schema).unwrap();
+
+    let fmt = rustfmt_wrapper::rustfmt(type_space.to_stream().to_string()).unwrap();
+
+    assert!(fmt.contains("pub struct AutoMerge(pub ::std::option::Option<AutoMergeInner>);"));
+    assert!(fmt.contains("pub struct AutoMergeInner {"));
+    assert!(!fmt.contains("pub struct AutoMerge(pub ::std::option::Option<AutoMerge>);"));
+    assert_eq!(fmt.matches("pub enum AuthorAssociation {").count(), 1);
 }


### PR DESCRIPTION
## Summary

Fixes #1011.

This is a typify bug, not a progenitor bug. Progenitor converts OpenAPI `nullable: true` object schemas into JSON Schema `type: ["object", "null"]`, which typify already treats as `Option<T>`. The failure was in typify's registration/output flow for named schemas.

## Root cause

There are two related paths that could emit duplicate type definitions with the same Rust name:

1. For a required nullable definition with a metadata title, typify intended to name the inner type `<Name>Inner`, but passed that as `Name::Suggested`. The schema title then won and the inner type reused the outer name, producing a self-recursive newtype such as:

   ```rust
   pub struct AutoMerge(pub Option<AutoMerge>);
   pub struct AutoMerge { ... }
   ```

2. A referenced definition can be preallocated with one `TypeId` while an earlier inline schema with the same title has already registered the same Rust type name under another `TypeId`. Emitting every `id_to_entry` value then produced duplicate items.

## Reproducer

The regression test adds a small JSON Schema equivalent to the OpenAPI shape from the GitHub spec:

- `auto-merge` has title `Auto merge` and type `["object", "null"]`
- it references `simple-user`
- an earlier inline `author_association` enum shares the title of a later referenced definition

The test asserts that `AutoMerge` wraps `Option<AutoMergeInner>`, does not wrap `Option<AutoMerge>`, and emits `AuthorAssociation` only once.

## Verification

- `cargo fmt`
- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 cargo test -p typify-impl test_required_nullable_object_with_title_uses_distinct_inner_name`
- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 cargo test --workspace`
- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 cargo clippy --workspace`
- End-to-end check through the downstream Printing Press repro with local `[patch.crates-io]`:
  - minimal repro `cargo check` passes
  - generated GitHub output has `bad_self_recursive = 0`
  - checked duplicate names (`AutoMerge`, `AuthorAssociation`, `IssueField`, `IssueType`, `CodespaceMachine`) each emit once
EOF 2>&1