### PR TITLE
fix unwrap panic with internally tagged enums

### DIFF
--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -1550,8 +1550,9 @@ impl TypeSpace {
         subschemas: &'a [Schema],
     ) -> Result<(TypeEntry, &'a Option<Box<Metadata>>)> {
         debug!(
-            "one_of {}",
-            serde_json::to_string_pretty(subschemas).unwrap()
+            "one_of {:?} {}",
+            type_name,
+            serde_json::to_string_pretty(subschemas).unwrap(),
         );
 
         // TODO it would probably be smart to do a pass through the schema

--- a/typify-impl/src/enums.rs
+++ b/typify-impl/src/enums.rs
@@ -368,7 +368,12 @@ impl TypeSpace {
                     _ => unreachable!(),
                 }
 
-                self.internal_variant(type_name.clone(), metadata, validation, tag)
+                self.internal_variant(
+                    get_type_name(&type_name, metadata),
+                    metadata,
+                    validation,
+                    tag,
+                )
             })
             .collect::<Result<Vec<_>>>()
             .ok()?;
@@ -386,7 +391,7 @@ impl TypeSpace {
 
     fn internal_variant(
         &mut self,
-        enum_type_name: Name,
+        enum_type_name: Option<String>,
         metadata: &Option<Box<schemars::schema::Metadata>>,
         validation: &ObjectValidation,
         tag: &str,
@@ -413,8 +418,7 @@ impl TypeSpace {
             new_validation.properties.remove(tag);
             new_validation.required.remove(tag);
 
-            let (properties, _) =
-                self.struct_members(enum_type_name.into_option(), &new_validation)?;
+            let (properties, _) = self.struct_members(enum_type_name, &new_validation)?;
             Ok(Variant::new(
                 variant_name.to_string(),
                 metadata_title_and_description(metadata),


### PR DESCRIPTION
The problem occurs when an internally tagged enum derives its name from the title of the schema. In that situation, if a variant contains a property that is itself a type that requires a name (e.g. a struct), we fail to pass down a name that can be used and fail on the None. Instead, we need to pass down the name we'll eventually choose for the generated enum so that subtypes can derive a name from that root.

Closes #1019 