### PR TITLE
Restrict TypeSpace::break_cycles to crate visibility

### DIFF
--- a/typify-impl/src/cycles.rs
+++ b/typify-impl/src/cycles.rs
@@ -17,7 +17,7 @@ impl TypeSpace {
     /// We need to root out any containment cycles, breaking them by inserting
     /// a `Box` type. Our choice of *where* to break cycles is more arbitrary
     /// than optimal, but is well beyond sufficient.
-    pub fn break_cycles(&mut self, range: Range<u64>) {
+    pub(crate) fn break_cycles(&mut self, range: Range<u64>) {
         enum Node {
             Start {
                 type_id: TypeId,


### PR DESCRIPTION
## What

Changes `TypeSpace::break_cycles` from `pub` to `pub(crate)`.

## Why

`break_cycles` lives in the private `cycles` module, but inherent-impl method visibility ignores module privacy, so the `pub` marker made it part of typify-impl's public API (it shows up on docs.rs). The method takes a raw `Range<u64>` of internal type IDs, so it can't be used meaningfully by external callers, and invoking it with arbitrary ranges could corrupt the type space. All call sites are internal to the crate.

## Notes

- Technically this is a semver-visible API removal, so it should land in a minor/breaking release rather than a patch — but the method has no legitimate external use.
- `grep -rn break_cycles` confirms the only caller is in `typify-impl/src/lib.rs`; nothing in the `typify` facade crate, `typify-macro`, or `cargo-typify` uses it.
- Full workspace test suite passes.