### PR TITLE
Report malformed schema JSON as a compile error instead of panicking

### DIFF
--- a/typify-macro/src/lib.rs
+++ b/typify-macro/src/lib.rs
@@ -252,14 +252,19 @@ fn do_import_types(item: TokenStream) -> Result<TokenStream, syn::Error> {
 
     let path = dir.join(schema.value());
 
-    let root_schema: schemars::schema::RootSchema =
-        serde_json::from_reader(std::fs::File::open(&path).map_err(|e| {
-            syn::Error::new(
-                schema.span(),
-                format!("couldn't read file {}: {}", schema.value(), e),
-            )
-        })?)
-        .unwrap();
+    let file = std::fs::File::open(&path).map_err(|e| {
+        syn::Error::new(
+            schema.span(),
+            format!("couldn't read file {}: {}", schema.value(), e),
+        )
+    })?;
+
+    let root_schema: schemars::schema::RootSchema = serde_json::from_reader(file).map_err(|e| {
+        syn::Error::new(
+            schema.span(),
+            format!("couldn't parse file {}: {}", schema.value(), e),
+        )
+    })?;
 
     let mut type_space = TypeSpace::new(&settings);
     type_space

--- a/typify/tests/compile-fail/malformed-schema.rs
+++ b/typify/tests/compile-fail/malformed-schema.rs
@@ -1,0 +1,6 @@
+use typify::import_types;
+
+// Cargo.toml exists in trybuild's generated crate but is not valid JSON.
+import_types!("Cargo.toml");
+
+fn main() {}

--- a/typify/tests/compile-fail/malformed-schema.stderr
+++ b/typify/tests/compile-fail/malformed-schema.stderr
@@ -1,0 +1,5 @@
+error: couldn't parse file Cargo.toml: invalid type: sequence, expected struct RootSchema at line 1 column 1
+ --> tests/compile-fail/malformed-schema.rs:4:15
+  |
+4 | import_types!("Cargo.toml");
+  |               ^^^^^^^^^^^^

--- a/typify/tests/compile_fail.rs
+++ b/typify/tests/compile_fail.rs
@@ -1,0 +1,6 @@
+// Copyright 2026 Oxide Computer Company
+
+#[test]
+fn test_compile_fail() {
+    trybuild::TestCases::new().compile_fail("tests/compile-fail/*.rs");
+}


### PR DESCRIPTION
## Problem

`import_types!` unwraps the result of `serde_json::from_reader`, so a JSON syntax error in the schema file (stray comma, truncated file, ...) panics the proc macro. Users see an opaque error with no indication of what went wrong or where:

```
error: proc macro panicked
 --> src/main.rs:1:1
  |
1 | typify::import_types!(schema = "bad.json");
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: message: called `Result::unwrap()` on an `Err` value: Error("key must be a string", line: 4, column: 34)
```

## Fix

Map the parse error to a spanned `syn::Error`, matching the existing handling of file-open failures. serde_json's line/column information is preserved in the message:

```
error: couldn't parse file bad.json: key must be a string at line 4 column 34
 --> src/main.rs:1:32
  |
1 | typify::import_types!(schema = "bad.json");
  |                                ^^^^^^^^^^
```

This addresses the malformed-JSON half of the diagnostics concerns raised in #516.

## Trade-offs

None.

## Testing

- `cargo test --workspace --locked` passes.
- The repo's trybuild usage only covers `pass` cases (no `compile_fail` harness), so the before/after output above was verified manually with a scratch crate depending on `typify` by path with a malformed `bad.json`.