### PR TITLE
Qualify Some/String/Vec paths in generated code

### DIFF
--- a/cargo-typify/tests/outputs/attr.rs
+++ b/cargo-typify/tests/outputs/attr.rs
@@ -23,8 +23,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }

--- a/cargo-typify/tests/outputs/builder.rs
+++ b/cargo-typify/tests/outputs/builder.rs
@@ -23,8 +23,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }

--- a/cargo-typify/tests/outputs/custom_btree_map.rs
+++ b/cargo-typify/tests/outputs/custom_btree_map.rs
@@ -23,8 +23,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }

--- a/cargo-typify/tests/outputs/derive.rs
+++ b/cargo-typify/tests/outputs/derive.rs
@@ -23,8 +23,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }

--- a/cargo-typify/tests/outputs/multi_derive.rs
+++ b/cargo-typify/tests/outputs/multi_derive.rs
@@ -23,8 +23,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }

--- a/cargo-typify/tests/outputs/no-builder.rs
+++ b/cargo-typify/tests/outputs/no-builder.rs
@@ -23,8 +23,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -906,8 +906,8 @@ impl TypeSpace {
                         Self(value.into())
                     }
                 }
-                impl From<String> for ConversionError {
-                    fn from(value: String) -> Self {
+                impl From<::std::string::String> for ConversionError {
+                    fn from(value: ::std::string::String) -> Self {
                         Self(value.into())
                     }
                 }

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -1411,11 +1411,11 @@ impl TypeEntry {
                                     value.parse()
                                 }
                             }
-                            impl ::std::convert::TryFrom<String> for #type_name {
+                            impl ::std::convert::TryFrom<::std::string::String> for #type_name {
                                 type Error = <#inner_type_name as
                                     ::std::str::FromStr>::Err;
 
-                                fn try_from(value: String) ->
+                                fn try_from(value: ::std::string::String) ->
                                     ::std::result::Result<Self, Self::Error>
                                 {
                                     value.parse()
@@ -1496,7 +1496,7 @@ impl TypeEntry {
                                     ].into_iter().collect()),
                                     ..::std::default::Default::default()
                                 };
-                                schema.subschemas().not = Some(
+                                schema.subschemas().not = ::std::option::Option::Some(
                                     ::std::boxed::Box::new(not.into())
                                 );
                                 schema.into()
@@ -1809,7 +1809,7 @@ impl TypeEntry {
                 let item = inner_ty.type_ident(type_space, type_mod);
                 // TODO we'll want this to be a Set of some kind, but we need
                 // to get the derives right first.
-                quote! { Vec<#item> }
+                quote! { ::std::vec::Vec<#item> }
             }
 
             TypeEntryDetails::Tuple(items) => {

--- a/typify-impl/tests/generator.out
+++ b/typify-impl/tests/generator.out
@@ -19,8 +19,8 @@ mod types {
                 Self(value.into())
             }
         }
-        impl From<String> for ConversionError {
-            fn from(value: String) -> Self {
+        impl From<::std::string::String> for ConversionError {
+            fn from(value: ::std::string::String) -> Self {
                 Self(value.into())
             }
         }

--- a/typify-impl/tests/github.out
+++ b/typify-impl/tests/github.out
@@ -18,8 +18,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }

--- a/typify-impl/tests/vega.out
+++ b/typify-impl/tests/vega.out
@@ -18,8 +18,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }

--- a/typify/tests/schemas.rs
+++ b/typify/tests/schemas.rs
@@ -51,6 +51,20 @@ fn test_various_enums_json_schema() {
     trybuild::TestCases::new().pass("tests/schemas/various-enums-json-schema.rs");
 }
 
+/// Ensure that generated `JsonSchema` implementations do not collide with a
+/// schema type named `Some`.
+#[test]
+fn test_some_collision_json_schema() {
+    validate_schema(
+        "tests/schemas/some-collision.json".into(),
+        "tests/schemas/some-collision-json-schema.rs".into(),
+        TypeSpaceSettings::default().with_derive("schemars::JsonSchema".to_string()),
+    )
+    .unwrap();
+
+    trybuild::TestCases::new().pass("tests/schemas/some-collision-json-schema.rs");
+}
+
 fn validate_schema(
     path: std::path::PathBuf,
     out_path: std::path::PathBuf,

--- a/typify/tests/schemas/arrays-and-tuples.rs
+++ b/typify/tests/schemas/arrays-and-tuples.rs
@@ -19,8 +19,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }
@@ -39,20 +39,20 @@ pub mod error {
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(transparent)]
-pub struct ArraySansItems(pub Vec<::serde_json::Value>);
+pub struct ArraySansItems(pub ::std::vec::Vec<::serde_json::Value>);
 impl ::std::ops::Deref for ArraySansItems {
-    type Target = Vec<::serde_json::Value>;
-    fn deref(&self) -> &Vec<::serde_json::Value> {
+    type Target = ::std::vec::Vec<::serde_json::Value>;
+    fn deref(&self) -> &::std::vec::Vec<::serde_json::Value> {
         &self.0
     }
 }
-impl ::std::convert::From<ArraySansItems> for Vec<::serde_json::Value> {
+impl ::std::convert::From<ArraySansItems> for ::std::vec::Vec<::serde_json::Value> {
     fn from(value: ArraySansItems) -> Self {
         value.0
     }
 }
-impl ::std::convert::From<Vec<::serde_json::Value>> for ArraySansItems {
-    fn from(value: Vec<::serde_json::Value>) -> Self {
+impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ArraySansItems {
+    fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
         Self(value)
     }
 }

--- a/typify/tests/schemas/deny-list.rs
+++ b/typify/tests/schemas/deny-list.rs
@@ -19,8 +19,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }

--- a/typify/tests/schemas/extraneous-enum.rs
+++ b/typify/tests/schemas/extraneous-enum.rs
@@ -19,8 +19,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }

--- a/typify/tests/schemas/id-or-name.rs
+++ b/typify/tests/schemas/id-or-name.rs
@@ -19,8 +19,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }

--- a/typify/tests/schemas/maps.rs
+++ b/typify/tests/schemas/maps.rs
@@ -19,8 +19,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }

--- a/typify/tests/schemas/maps_custom.rs
+++ b/typify/tests/schemas/maps_custom.rs
@@ -19,8 +19,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }

--- a/typify/tests/schemas/merged-schemas.rs
+++ b/typify/tests/schemas/merged-schemas.rs
@@ -19,8 +19,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }
@@ -518,9 +518,9 @@ impl ::std::convert::TryFrom<&str> for MergeNumberBounds {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<String> for MergeNumberBounds {
+impl ::std::convert::TryFrom<::std::string::String> for MergeNumberBounds {
     type Error = <f64 as ::std::str::FromStr>::Err;
-    fn try_from(value: String) -> ::std::result::Result<Self, Self::Error> {
+    fn try_from(value: ::std::string::String) -> ::std::result::Result<Self, Self::Error> {
         value.parse()
     }
 }
@@ -651,9 +651,9 @@ impl ::std::convert::TryFrom<&str> for NarrowNumber {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<String> for NarrowNumber {
+impl ::std::convert::TryFrom<::std::string::String> for NarrowNumber {
     type Error = <::std::num::NonZeroU64 as ::std::str::FromStr>::Err;
-    fn try_from(value: String) -> ::std::result::Result<Self, Self::Error> {
+    fn try_from(value: ::std::string::String) -> ::std::result::Result<Self, Self::Error> {
         value.parse()
     }
 }

--- a/typify/tests/schemas/more_types.rs
+++ b/typify/tests/schemas/more_types.rs
@@ -19,8 +19,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }

--- a/typify/tests/schemas/multiple-instance-types.rs
+++ b/typify/tests/schemas/multiple-instance-types.rs
@@ -19,8 +19,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }

--- a/typify/tests/schemas/noisy-types.rs
+++ b/typify/tests/schemas/noisy-types.rs
@@ -19,8 +19,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }
@@ -114,9 +114,9 @@ impl ::std::convert::TryFrom<&str> for IntegerBs {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<String> for IntegerBs {
+impl ::std::convert::TryFrom<::std::string::String> for IntegerBs {
     type Error = <u64 as ::std::str::FromStr>::Err;
-    fn try_from(value: String) -> ::std::result::Result<Self, Self::Error> {
+    fn try_from(value: ::std::string::String) -> ::std::result::Result<Self, Self::Error> {
         value.parse()
     }
 }

--- a/typify/tests/schemas/property-pattern.rs
+++ b/typify/tests/schemas/property-pattern.rs
@@ -19,8 +19,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }

--- a/typify/tests/schemas/reflexive.rs
+++ b/typify/tests/schemas/reflexive.rs
@@ -19,8 +19,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }

--- a/typify/tests/schemas/rust-collisions.rs
+++ b/typify/tests/schemas/rust-collisions.rs
@@ -19,8 +19,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }

--- a/typify/tests/schemas/simple-types.rs
+++ b/typify/tests/schemas/simple-types.rs
@@ -19,8 +19,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }

--- a/typify/tests/schemas/some-collision-json-schema.rs
+++ b/typify/tests/schemas/some-collision-json-schema.rs
@@ -1,0 +1,160 @@
+#![deny(warnings)]
+#[doc = r" Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
+            Self(value.into())
+        }
+    }
+}
+#[doc = "`DenyValueWithSomeCollision`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"integer\","]
+#[doc = "  \"not\": {"]
+#[doc = "    \"enum\": ["]
+#[doc = "      1"]
+#[doc = "    ]"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
+pub struct DenyValueWithSomeCollision(f64);
+impl ::std::ops::Deref for DenyValueWithSomeCollision {
+    type Target = f64;
+    fn deref(&self) -> &f64 {
+        &self.0
+    }
+}
+impl ::std::convert::From<DenyValueWithSomeCollision> for f64 {
+    fn from(value: DenyValueWithSomeCollision) -> Self {
+        value.0
+    }
+}
+impl ::std::convert::TryFrom<f64> for DenyValueWithSomeCollision {
+    type Error = self::error::ConversionError;
+    fn try_from(value: f64) -> ::std::result::Result<Self, self::error::ConversionError> {
+        if [1_f64].contains(&value) {
+            Err("invalid value".into())
+        } else {
+            Ok(Self(value))
+        }
+    }
+}
+impl<'de> ::serde::Deserialize<'de> for DenyValueWithSomeCollision {
+    fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
+    where
+        D: ::serde::Deserializer<'de>,
+    {
+        Self::try_from(<f64>::deserialize(deserializer)?)
+            .map_err(|e| <D::Error as ::serde::de::Error>::custom(e.to_string()))
+    }
+}
+impl ::schemars::JsonSchema for DenyValueWithSomeCollision {
+    fn schema_name() -> ::std::string::String {
+        "DenyValueWithSomeCollision".to_string()
+    }
+    fn json_schema(gen: &mut ::schemars::gen::SchemaGenerator) -> ::schemars::schema::Schema {
+        let mut schema = <f64 as ::schemars::JsonSchema>::json_schema(gen).into_object();
+        let not = ::schemars::schema::SchemaObject {
+            enum_values: ::std::option::Option::Some(
+                [::serde_json::from_str("1").unwrap()].into_iter().collect(),
+            ),
+            ..::std::default::Default::default()
+        };
+        schema.subschemas().not = ::std::option::Option::Some(::std::boxed::Box::new(not.into()));
+        schema.into()
+    }
+}
+#[doc = "`Some`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
+#[doc = "    \"value\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"value\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, schemars :: JsonSchema)]
+pub struct Some {
+    pub value: ::std::string::String,
+}
+impl Some {
+    pub fn builder() -> builder::Some {
+        Default::default()
+    }
+}
+#[doc = r" Types for composing complex structures."]
+pub mod builder {
+    #[derive(Clone, Debug)]
+    pub struct Some {
+        value: ::std::result::Result<::std::string::String, ::std::string::String>,
+    }
+    impl ::std::default::Default for Some {
+        fn default() -> Self {
+            Self {
+                value: Err("no value supplied for value".to_string()),
+            }
+        }
+    }
+    impl Some {
+        pub fn value<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::string::String>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.value = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for value: {e}"));
+            self
+        }
+    }
+    impl ::std::convert::TryFrom<Some> for super::Some {
+        type Error = super::error::ConversionError;
+        fn try_from(value: Some) -> ::std::result::Result<Self, super::error::ConversionError> {
+            Ok(Self {
+                value: value.value?,
+            })
+        }
+    }
+    impl ::std::convert::From<super::Some> for Some {
+        fn from(value: super::Some) -> Self {
+            Self {
+                value: Ok(value.value),
+            }
+        }
+    }
+}
+fn main() {}

--- a/typify/tests/schemas/some-collision.json
+++ b/typify/tests/schemas/some-collision.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Some": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "DenyValueWithSomeCollision": {
+      "type": "integer",
+      "not": {
+        "enum": [
+          1
+        ]
+      }
+    }
+  }
+}

--- a/typify/tests/schemas/some-collision.rs
+++ b/typify/tests/schemas/some-collision.rs
@@ -1,0 +1,144 @@
+#![deny(warnings)]
+#[doc = r" Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
+            Self(value.into())
+        }
+    }
+}
+#[doc = "`DenyValueWithSomeCollision`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"integer\","]
+#[doc = "  \"not\": {"]
+#[doc = "    \"enum\": ["]
+#[doc = "      1"]
+#[doc = "    ]"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
+pub struct DenyValueWithSomeCollision(f64);
+impl ::std::ops::Deref for DenyValueWithSomeCollision {
+    type Target = f64;
+    fn deref(&self) -> &f64 {
+        &self.0
+    }
+}
+impl ::std::convert::From<DenyValueWithSomeCollision> for f64 {
+    fn from(value: DenyValueWithSomeCollision) -> Self {
+        value.0
+    }
+}
+impl ::std::convert::TryFrom<f64> for DenyValueWithSomeCollision {
+    type Error = self::error::ConversionError;
+    fn try_from(value: f64) -> ::std::result::Result<Self, self::error::ConversionError> {
+        if [1_f64].contains(&value) {
+            Err("invalid value".into())
+        } else {
+            Ok(Self(value))
+        }
+    }
+}
+impl<'de> ::serde::Deserialize<'de> for DenyValueWithSomeCollision {
+    fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
+    where
+        D: ::serde::Deserializer<'de>,
+    {
+        Self::try_from(<f64>::deserialize(deserializer)?)
+            .map_err(|e| <D::Error as ::serde::de::Error>::custom(e.to_string()))
+    }
+}
+#[doc = "`Some`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
+#[doc = "    \"value\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"value\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+pub struct Some {
+    pub value: ::std::string::String,
+}
+impl Some {
+    pub fn builder() -> builder::Some {
+        Default::default()
+    }
+}
+#[doc = r" Types for composing complex structures."]
+pub mod builder {
+    #[derive(Clone, Debug)]
+    pub struct Some {
+        value: ::std::result::Result<::std::string::String, ::std::string::String>,
+    }
+    impl ::std::default::Default for Some {
+        fn default() -> Self {
+            Self {
+                value: Err("no value supplied for value".to_string()),
+            }
+        }
+    }
+    impl Some {
+        pub fn value<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::string::String>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.value = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for value: {e}"));
+            self
+        }
+    }
+    impl ::std::convert::TryFrom<Some> for super::Some {
+        type Error = super::error::ConversionError;
+        fn try_from(value: Some) -> ::std::result::Result<Self, super::error::ConversionError> {
+            Ok(Self {
+                value: value.value?,
+            })
+        }
+    }
+    impl ::std::convert::From<super::Some> for Some {
+        fn from(value: super::Some) -> Self {
+            Self {
+                value: Ok(value.value),
+            }
+        }
+    }
+}
+fn main() {}

--- a/typify/tests/schemas/string-enum-with-default.rs
+++ b/typify/tests/schemas/string-enum-with-default.rs
@@ -19,8 +19,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }

--- a/typify/tests/schemas/type-with-modified-generation.rs
+++ b/typify/tests/schemas/type-with-modified-generation.rs
@@ -19,8 +19,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }

--- a/typify/tests/schemas/types-with-defaults.rs
+++ b/typify/tests/schemas/types-with-defaults.rs
@@ -19,8 +19,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }
@@ -303,9 +303,9 @@ impl ::std::convert::TryFrom<&str> for UInt {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<String> for UInt {
+impl ::std::convert::TryFrom<::std::string::String> for UInt {
     type Error = <i64 as ::std::str::FromStr>::Err;
-    fn try_from(value: String) -> ::std::result::Result<Self, Self::Error> {
+    fn try_from(value: ::std::string::String) -> ::std::result::Result<Self, Self::Error> {
         value.parse()
     }
 }

--- a/typify/tests/schemas/types-with-more-impls.rs
+++ b/typify/tests/schemas/types-with-more-impls.rs
@@ -19,8 +19,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }

--- a/typify/tests/schemas/untyped-enum-with-null.rs
+++ b/typify/tests/schemas/untyped-enum-with-null.rs
@@ -19,8 +19,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }

--- a/typify/tests/schemas/various-enums-json-schema.rs
+++ b/typify/tests/schemas/various-enums-json-schema.rs
@@ -19,8 +19,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }
@@ -1013,7 +1013,7 @@ impl ::schemars::JsonSchema for NotBlockSize {
             ),
             ..::std::default::Default::default()
         };
-        schema.subschemas().not = Some(::std::boxed::Box::new(not.into()));
+        schema.subschemas().not = ::std::option::Option::Some(::std::boxed::Box::new(not.into()));
         schema.into()
     }
 }

--- a/typify/tests/schemas/various-enums.rs
+++ b/typify/tests/schemas/various-enums.rs
@@ -19,8 +19,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }

--- a/typify/tests/schemas/x-rust-type.rs
+++ b/typify/tests/schemas/x-rust-type.rs
@@ -19,8 +19,8 @@ pub mod error {
             Self(value.into())
         }
     }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
+    impl From<::std::string::String> for ConversionError {
+        fn from(value: ::std::string::String) -> Self {
             Self(value.into())
         }
     }


### PR DESCRIPTION
Generated code mostly uses fully-qualified paths (`::std::...`) so that output compiles even when the schema defines types named `Some`, `String`, or `Vec` (see the `rust-collisions` test schema). A few emitted blocks still used bare paths:

- the `schemars::JsonSchema` impl for deny-value newtypes used bare `Some`
- the `TryFrom` impl proxied through an inner type's `FromStr` used bare `String`
- the `ConversionError` `From` impl used bare `String`
- sets were rendered as bare `Vec<T>`

This qualifies all of these. Pure path qualification — no change to the set of impls generated (+83/−83 across goldens).

An earlier revision of this PR also re-introduced a `TryFrom<&String>` impl at the FromStr-proxy site; that was dropped since it reverts #946, which deliberately removed it as non-idiomatic.
