### PR TITLE
Fix handling of float default values

### DIFF
--- a/typify-impl/src/defaults.rs
+++ b/typify-impl/src/defaults.rs
@@ -308,7 +308,7 @@ impl TypeEntry {
                     if value == 0.0 {
                         Ok(DefaultKind::Intrinsic)
                     } else {
-                        Ok(DefaultKind::Generic(DefaultImpl::I64))
+                        Ok(DefaultKind::Specific)
                     }
                 } else {
                     Err(Error::invalid_value())
@@ -790,6 +790,24 @@ mod tests {
         ));
         assert!(matches!(
             type_entry.validate_value(&type_space, &json!("howdy")),
+            Ok(DefaultKind::Specific),
+        ));
+    }
+
+    #[test]
+    fn test_default_float() {
+        let (type_space, type_id) = get_type::<f64>();
+        let type_entry = type_space.id_to_entry.get(&type_id).unwrap();
+
+        assert!(type_entry
+            .validate_value(&type_space, &json!(true))
+            .is_err());
+        assert!(matches!(
+            type_entry.validate_value(&type_space, &json!(0.0)),
+            Ok(DefaultKind::Intrinsic),
+        ));
+        assert!(matches!(
+            type_entry.validate_value(&type_space, &json!(0.1)),
             Ok(DefaultKind::Specific),
         ));
     }

--- a/typify-impl/src/structs.rs
+++ b/typify-impl/src/structs.rs
@@ -461,12 +461,12 @@ fn has_default(
         }
         // Default specified is the same as the implicit default: 0
         (Some(TypeEntryDetails::Integer(_)), Some(serde_json::Value::Number(n)))
-            if n.as_u64() == Some(0) =>
+            if n.as_f64() == Some(0.0) =>
         {
             StructPropertyState::Optional
         }
         // Default specified is the same as the implicit default: 0.0
-        (Some(TypeEntryDetails::Integer(_)), Some(serde_json::Value::Number(n)))
+        (Some(TypeEntryDetails::Float(_)), Some(serde_json::Value::Number(n)))
             if n.as_f64() == Some(0.0) =>
         {
             StructPropertyState::Optional

--- a/typify-impl/tests/vega.out
+++ b/typify-impl/tests/vega.out
@@ -103609,13 +103609,6 @@ pub mod defaults {
     pub(super) fn default_bool<const V: bool>() -> bool {
         V
     }
-    pub(super) fn default_i64<T, const V: i64>() -> T
-    where
-        T: ::std::convert::TryFrom<i64>,
-        <T as ::std::convert::TryFrom<i64>>::Error: ::std::fmt::Debug,
-    {
-        T::try_from(V).unwrap()
-    }
     pub(super) fn aggregate_transform_drop() -> super::AggregateTransformDrop {
         super::AggregateTransformDrop::Boolean(true)
     }

--- a/typify/tests/schemas/types-with-defaults.json
+++ b/typify/tests/schemas/types-with-defaults.json
@@ -86,6 +86,19 @@
         }
       }
     },
+    "MrDefaultFloats": {
+      "type": "object",
+      "properties": {
+        "frequency": {
+          "type": "number",
+          "default": 0.1
+        },
+        "zfreq": {
+          "type": "number",
+          "default": 0.0
+        }
+      }
+    },
     "UInt": {
       "type": "integer"
     },

--- a/typify/tests/schemas/types-with-defaults.rs
+++ b/typify/tests/schemas/types-with-defaults.rs
@@ -59,6 +59,46 @@ impl Doodad {
         Default::default()
     }
 }
+#[doc = "`MrDefaultFloats`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"frequency\": {"]
+#[doc = "      \"default\": 0.1,"]
+#[doc = "      \"type\": \"number\""]
+#[doc = "    },"]
+#[doc = "    \"zfreq\": {"]
+#[doc = "      \"default\": 0.0,"]
+#[doc = "      \"type\": \"number\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+pub struct MrDefaultFloats {
+    #[serde(default = "defaults::mr_default_floats_frequency")]
+    pub frequency: f64,
+    #[serde(default)]
+    pub zfreq: f64,
+}
+impl ::std::default::Default for MrDefaultFloats {
+    fn default() -> Self {
+        Self {
+            frequency: defaults::mr_default_floats_frequency(),
+            zfreq: Default::default(),
+        }
+    }
+}
+impl MrDefaultFloats {
+    pub fn builder() -> builder::MrDefaultFloats {
+        Default::default()
+    }
+}
 #[doc = "`MrDefaultNumbers`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -391,6 +431,60 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
+    pub struct MrDefaultFloats {
+        frequency: ::std::result::Result<f64, ::std::string::String>,
+        zfreq: ::std::result::Result<f64, ::std::string::String>,
+    }
+    impl ::std::default::Default for MrDefaultFloats {
+        fn default() -> Self {
+            Self {
+                frequency: Ok(super::defaults::mr_default_floats_frequency()),
+                zfreq: Ok(Default::default()),
+            }
+        }
+    }
+    impl MrDefaultFloats {
+        pub fn frequency<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<f64>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.frequency = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for frequency: {e}"));
+            self
+        }
+        pub fn zfreq<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<f64>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.zfreq = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for zfreq: {e}"));
+            self
+        }
+    }
+    impl ::std::convert::TryFrom<MrDefaultFloats> for super::MrDefaultFloats {
+        type Error = super::error::ConversionError;
+        fn try_from(
+            value: MrDefaultFloats,
+        ) -> ::std::result::Result<Self, super::error::ConversionError> {
+            Ok(Self {
+                frequency: value.frequency?,
+                zfreq: value.zfreq?,
+            })
+        }
+    }
+    impl ::std::convert::From<super::MrDefaultFloats> for MrDefaultFloats {
+        fn from(value: super::MrDefaultFloats) -> Self {
+            Self {
+                frequency: Ok(value.frequency),
+                zfreq: Ok(value.zfreq),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
     pub struct MrDefaultNumbers {
         big_nullable: ::std::result::Result<
             ::std::option::Option<::std::num::NonZeroU64>,
@@ -671,6 +765,9 @@ pub mod defaults {
             "\"1970-01-01T00:00:00Z\"",
         )
         .unwrap()
+    }
+    pub(super) fn mr_default_floats_frequency() -> f64 {
+        0.1_f64
     }
     pub(super) fn mr_default_numbers_big_nullable() -> ::std::option::Option<::std::num::NonZeroU64>
     {


### PR DESCRIPTION
## Problem

Two related bugs in float default-value handling:

1. In `has_default` (`typify-impl/src/structs.rs`) there were two consecutive match arms for `TypeEntryDetails::Integer` with a numeric default — the second arm (guarded by `n.as_f64() == Some(0.0)`, commented "implicit default: 0.0") was clearly intended to match `TypeEntryDetails::Float` but matched `Integer` instead, making it unreachable. As a result, a property like `{"type": "number", "default": 0.0}` was not recognized as having the intrinsic default, and a bespoke `defaults::xxx()` function returning `0.0_f64` was generated instead of a plain `#[serde(default)]`.

2. In `validate_value` (`typify-impl/src/defaults.rs`), a non-zero float default returned `DefaultKind::Generic(DefaultImpl::I64)`. That registers the shared `default_i64` helper in the generated `defaults` module, but `default_fn` has no `Float` arm, so a bespoke function is generated anyway and `default_i64` is emitted dead/unused (it couldn't be used for floats regardless, since `f64: TryFrom<i64>` doesn't hold). This shows up today as an unused `default_i64` in the `vega.out` test output.

## Fix

- `has_default`: the first arm now matches integers with a zero default via `n.as_f64() == Some(0.0)` (subsuming the previous `as_u64() == Some(0)` check and also handling a default written as `0.0`), and the second arm now matches `Float` as intended.
- `validate_value`: non-zero float defaults now return `DefaultKind::Specific`, matching how `default_fn` actually handles them, so the unusable `default_i64` helper is no longer registered.

Regression coverage: a `MrDefaultFloats` type (one zero and one non-zero float default) added to `typify/tests/schemas/types-with-defaults.json`, plus a `test_default_float` unit test in `typify-impl/src/defaults.rs`.

## Trade-offs

Previously-generated bespoke zero-default functions (e.g. `fn xxx_zfreq() -> f64 { 0.0_f64 }`) disappear from output in favor of plain `#[serde(default)]`, and the dead `default_i64` helper is no longer emitted when only float defaults required it — a cosmetic change to generated code with identical runtime behavior.

Related to (but not fully fixing) #442, and a follow-up to #976.
