### PR TITLE
Remove stray println! from merge code

### DIFF
--- a/typify-impl/src/merge.rs
+++ b/typify-impl/src/merge.rs
@@ -286,11 +286,10 @@ pub(crate) fn try_merge_with_subschemas(
     };
 
     if if_schema.is_some() || then_schema.is_some() || else_schema.is_some() {
-        println!(
-            "{}",
+        unimplemented!(
+            "if/then/else schemas are not supported: {}",
             serde_json::to_string_pretty(&maybe_subschemas).unwrap()
         );
-        unimplemented!("if/then/else schemas are not supported");
     }
 
     if let Some(all_of) = all_of {


### PR DESCRIPTION
typify-impl/src/merge.rs contained a leftover debug `println!` that dumps the raw subschema JSON to stdout whenever an if/then/else schema is encountered, polluting the stdout of any build using the macro or CLI. This folds that JSON into the `unimplemented!` panic message instead, so the diagnostic is preserved where it is actually seen. No functional change otherwise.