### PR TITLE
Derive Default for structs when all field defaults are intrinsic

### DIFF
--- a/cargo-typify/tests/outputs/attr.rs
+++ b/cargo-typify/tests/outputs/attr.rs
@@ -174,18 +174,10 @@ pub struct Veggie {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[extra_attr]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct Veggies {
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub fruits: ::std::vec::Vec<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub vegetables: ::std::vec::Vec<Veggie>,
-}
-impl ::std::default::Default for Veggies {
-    fn default() -> Self {
-        Self {
-            fruits: Default::default(),
-            vegetables: Default::default(),
-        }
-    }
 }

--- a/cargo-typify/tests/outputs/builder.rs
+++ b/cargo-typify/tests/outputs/builder.rs
@@ -175,20 +175,12 @@ impl Veggie {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct Veggies {
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub fruits: ::std::vec::Vec<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub vegetables: ::std::vec::Vec<Veggie>,
-}
-impl ::std::default::Default for Veggies {
-    fn default() -> Self {
-        Self {
-            fruits: Default::default(),
-            vegetables: Default::default(),
-        }
-    }
 }
 impl Veggies {
     pub fn builder() -> builder::Veggies {

--- a/cargo-typify/tests/outputs/custom_btree_map.rs
+++ b/cargo-typify/tests/outputs/custom_btree_map.rs
@@ -176,20 +176,12 @@ impl Veggie {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct Veggies {
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub fruits: ::std::vec::Vec<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub vegetables: ::std::vec::Vec<Veggie>,
-}
-impl ::std::default::Default for Veggies {
-    fn default() -> Self {
-        Self {
-            fruits: Default::default(),
-            vegetables: Default::default(),
-        }
-    }
 }
 impl Veggies {
     pub fn builder() -> builder::Veggies {

--- a/cargo-typify/tests/outputs/derive.rs
+++ b/cargo-typify/tests/outputs/derive.rs
@@ -170,18 +170,10 @@ pub struct Veggie {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, ExtraDerive)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default, ExtraDerive)]
 pub struct Veggies {
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub fruits: ::std::vec::Vec<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub vegetables: ::std::vec::Vec<Veggie>,
-}
-impl ::std::default::Default for Veggies {
-    fn default() -> Self {
-        Self {
-            fruits: Default::default(),
-            vegetables: Default::default(),
-        }
-    }
 }

--- a/cargo-typify/tests/outputs/multi_derive.rs
+++ b/cargo-typify/tests/outputs/multi_derive.rs
@@ -177,19 +177,17 @@ pub struct Veggie {
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(
-    :: serde :: Deserialize, :: serde :: Serialize, AnotherDerive, Clone, Debug, ExtraDerive,
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    AnotherDerive,
+    Clone,
+    Debug,
+    Default,
+    ExtraDerive,
 )]
 pub struct Veggies {
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub fruits: ::std::vec::Vec<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub vegetables: ::std::vec::Vec<Veggie>,
-}
-impl ::std::default::Default for Veggies {
-    fn default() -> Self {
-        Self {
-            fruits: Default::default(),
-            vegetables: Default::default(),
-        }
-    }
 }

--- a/cargo-typify/tests/outputs/no-builder.rs
+++ b/cargo-typify/tests/outputs/no-builder.rs
@@ -170,18 +170,10 @@ pub struct Veggie {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct Veggies {
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub fruits: ::std::vec::Vec<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub vegetables: ::std::vec::Vec<Veggie>,
-}
-impl ::std::default::Default for Veggies {
-    fn default() -> Self {
-        Self {
-            fruits: Default::default(),
-            vegetables: Default::default(),
-        }
-    }
 }

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -1093,7 +1093,7 @@ impl TypeEntry {
         type_space: &TypeSpace,
         output: &mut OutputSpace,
         struct_details: &TypeEntryStruct,
-        derive_set: BTreeSet<&str>,
+        mut derive_set: BTreeSet<&str>,
     ) {
         enum PropDefault {
             None(String),
@@ -1175,6 +1175,19 @@ impl TypeEntry {
             });
         });
 
+        // If there's no whole-type default value and every property's default
+        // is the intrinsic `Default::default()`, the hand-written `impl Default`
+        // would be exactly what `#[derive(Default)]` produces (and would trip
+        // clippy's `derivable_impls` lint downstream). In that case we derive
+        // `Default` rather than emitting the manual impl below.
+        let derive_default = default.is_none()
+            && prop_default
+                .iter()
+                .all(|pd| matches!(pd, PropDefault::Default(_)));
+        if derive_default {
+            derive_set.insert("Default");
+        }
+
         let derives = strings_to_derives(
             derive_set,
             &self.extra_derives,
@@ -1215,6 +1228,8 @@ impl TypeEntry {
                     }
                 },
             );
+        } else if derive_default {
+            // Handled above via `#[derive(Default)]`.
         } else if let Some(prop_default) = prop_default
             .iter()
             .map(|pd| match pd {

--- a/typify-impl/tests/github.out
+++ b/typify-impl/tests/github.out
@@ -154,7 +154,7 @@ pub struct AlertInstance {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct AlertInstanceLocation {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -167,17 +167,6 @@ pub struct AlertInstanceLocation {
     pub start_column: ::std::option::Option<i64>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub start_line: ::std::option::Option<i64>,
-}
-impl ::std::default::Default for AlertInstanceLocation {
-    fn default() -> Self {
-        Self {
-            end_column: Default::default(),
-            end_line: Default::default(),
-            path: Default::default(),
-            start_column: Default::default(),
-            start_line: Default::default(),
-        }
-    }
 }
 #[doc = "`AlertInstanceMessage`"]
 #[doc = r""]
@@ -195,18 +184,11 @@ impl ::std::default::Default for AlertInstanceLocation {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct AlertInstanceMessage {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub text: ::std::option::Option<::std::string::String>,
-}
-impl ::std::default::Default for AlertInstanceMessage {
-    fn default() -> Self {
-        Self {
-            text: Default::default(),
-        }
-    }
 }
 #[doc = "State of a code scanning alert."]
 #[doc = r""]
@@ -1192,7 +1174,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AppEventsItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct AppPermissions {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -1265,46 +1247,6 @@ pub struct AppPermissions {
     pub vulnerability_alerts: ::std::option::Option<AppPermissionsVulnerabilityAlerts>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub workflows: ::std::option::Option<AppPermissionsWorkflows>,
-}
-impl ::std::default::Default for AppPermissions {
-    fn default() -> Self {
-        Self {
-            actions: Default::default(),
-            administration: Default::default(),
-            checks: Default::default(),
-            content_references: Default::default(),
-            contents: Default::default(),
-            deployments: Default::default(),
-            discussions: Default::default(),
-            emails: Default::default(),
-            environments: Default::default(),
-            issues: Default::default(),
-            members: Default::default(),
-            metadata: Default::default(),
-            organization_administration: Default::default(),
-            organization_hooks: Default::default(),
-            organization_packages: Default::default(),
-            organization_plan: Default::default(),
-            organization_projects: Default::default(),
-            organization_secrets: Default::default(),
-            organization_self_hosted_runners: Default::default(),
-            organization_user_blocking: Default::default(),
-            packages: Default::default(),
-            pages: Default::default(),
-            pull_requests: Default::default(),
-            repository_hooks: Default::default(),
-            repository_projects: Default::default(),
-            secret_scanning_alerts: Default::default(),
-            secrets: Default::default(),
-            security_events: Default::default(),
-            security_scanning_alert: Default::default(),
-            single_file: Default::default(),
-            statuses: Default::default(),
-            team_discussions: Default::default(),
-            vulnerability_alerts: Default::default(),
-            workflows: Default::default(),
-        }
-    }
 }
 #[doc = "`AppPermissionsActions`"]
 #[doc = r""]
@@ -4343,7 +4285,7 @@ impl ::std::convert::TryFrom<::std::string::String> for BranchProtectionRuleEdit
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct BranchProtectionRuleEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -4352,14 +4294,6 @@ pub struct BranchProtectionRuleEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub authorized_actors_only:
         ::std::option::Option<BranchProtectionRuleEditedChangesAuthorizedActorsOnly>,
-}
-impl ::std::default::Default for BranchProtectionRuleEditedChanges {
-    fn default() -> Self {
-        Self {
-            authorized_actor_names: Default::default(),
-            authorized_actors_only: Default::default(),
-        }
-    }
 }
 #[doc = "`BranchProtectionRuleEditedChangesAuthorizedActorNames`"]
 #[doc = r""]
@@ -6091,19 +6025,12 @@ impl ::std::convert::TryFrom<::std::string::String> for CheckRunCompletedCheckRu
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCompletedRequestedAction {
     #[doc = "The integrator reference of the action requested by the user."]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub identifier: ::std::option::Option<::std::string::String>,
-}
-impl ::std::default::Default for CheckRunCompletedRequestedAction {
-    fn default() -> Self {
-        Self {
-            identifier: Default::default(),
-        }
-    }
 }
 #[doc = "`CheckRunCreated`"]
 #[doc = r""]
@@ -7263,19 +7190,12 @@ impl ::std::convert::TryFrom<::std::string::String> for CheckRunCreatedCheckRunS
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCreatedRequestedAction {
     #[doc = "The integrator reference of the action requested by the user."]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub identifier: ::std::option::Option<::std::string::String>,
-}
-impl ::std::default::Default for CheckRunCreatedRequestedAction {
-    fn default() -> Self {
-        Self {
-            identifier: Default::default(),
-        }
-    }
 }
 #[doc = "A deployment to a repository environment. This will only be populated if the check run was created by a GitHub Actions workflow job that references an environment."]
 #[doc = r""]
@@ -8720,19 +8640,12 @@ impl ::std::convert::TryFrom<::std::string::String> for CheckRunRequestedActionC
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRequestedActionRequestedAction {
     #[doc = "The integrator reference of the action requested by the user."]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub identifier: ::std::option::Option<::std::string::String>,
-}
-impl ::std::default::Default for CheckRunRequestedActionRequestedAction {
-    fn default() -> Self {
-        Self {
-            identifier: Default::default(),
-        }
-    }
 }
 #[doc = "`CheckRunRerequested`"]
 #[doc = r""]
@@ -9846,19 +9759,12 @@ impl ::std::convert::TryFrom<::std::string::String> for CheckRunRerequestedCheck
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRerequestedRequestedAction {
     #[doc = "The integrator reference of the action requested by the user."]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub identifier: ::std::option::Option<::std::string::String>,
-}
-impl ::std::default::Default for CheckRunRerequestedRequestedAction {
-    fn default() -> Self {
-        Self {
-            identifier: Default::default(),
-        }
-    }
 }
 #[doc = "`CheckSuiteCompleted`"]
 #[doc = r""]
@@ -12892,7 +12798,7 @@ pub struct CodeScanningAlertClosedByUserAlertInstancesItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertClosedByUserAlertInstancesItemLocation {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -12905,17 +12811,6 @@ pub struct CodeScanningAlertClosedByUserAlertInstancesItemLocation {
     pub start_column: ::std::option::Option<i64>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub start_line: ::std::option::Option<i64>,
-}
-impl ::std::default::Default for CodeScanningAlertClosedByUserAlertInstancesItemLocation {
-    fn default() -> Self {
-        Self {
-            end_column: Default::default(),
-            end_line: Default::default(),
-            path: Default::default(),
-            start_column: Default::default(),
-            start_line: Default::default(),
-        }
-    }
 }
 #[doc = "`CodeScanningAlertClosedByUserAlertInstancesItemMessage`"]
 #[doc = r""]
@@ -12933,18 +12828,11 @@ impl ::std::default::Default for CodeScanningAlertClosedByUserAlertInstancesItem
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertClosedByUserAlertInstancesItemMessage {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub text: ::std::option::Option<::std::string::String>,
-}
-impl ::std::default::Default for CodeScanningAlertClosedByUserAlertInstancesItemMessage {
-    fn default() -> Self {
-        Self {
-            text: Default::default(),
-        }
-    }
 }
 #[doc = "`CodeScanningAlertClosedByUserAlertInstancesItemState`"]
 #[doc = r""]
@@ -13807,7 +13695,7 @@ pub struct CodeScanningAlertCreatedAlertInstancesItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertCreatedAlertInstancesItemLocation {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -13820,17 +13708,6 @@ pub struct CodeScanningAlertCreatedAlertInstancesItemLocation {
     pub start_column: ::std::option::Option<i64>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub start_line: ::std::option::Option<i64>,
-}
-impl ::std::default::Default for CodeScanningAlertCreatedAlertInstancesItemLocation {
-    fn default() -> Self {
-        Self {
-            end_column: Default::default(),
-            end_line: Default::default(),
-            path: Default::default(),
-            start_column: Default::default(),
-            start_line: Default::default(),
-        }
-    }
 }
 #[doc = "`CodeScanningAlertCreatedAlertInstancesItemMessage`"]
 #[doc = r""]
@@ -13848,18 +13725,11 @@ impl ::std::default::Default for CodeScanningAlertCreatedAlertInstancesItemLocat
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertCreatedAlertInstancesItemMessage {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub text: ::std::option::Option<::std::string::String>,
-}
-impl ::std::default::Default for CodeScanningAlertCreatedAlertInstancesItemMessage {
-    fn default() -> Self {
-        Self {
-            text: Default::default(),
-        }
-    }
 }
 #[doc = "`CodeScanningAlertCreatedAlertInstancesItemState`"]
 #[doc = r""]
@@ -14914,7 +14784,7 @@ pub struct CodeScanningAlertFixedAlertInstancesItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertFixedAlertInstancesItemLocation {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -14927,17 +14797,6 @@ pub struct CodeScanningAlertFixedAlertInstancesItemLocation {
     pub start_column: ::std::option::Option<i64>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub start_line: ::std::option::Option<i64>,
-}
-impl ::std::default::Default for CodeScanningAlertFixedAlertInstancesItemLocation {
-    fn default() -> Self {
-        Self {
-            end_column: Default::default(),
-            end_line: Default::default(),
-            path: Default::default(),
-            start_column: Default::default(),
-            start_line: Default::default(),
-        }
-    }
 }
 #[doc = "`CodeScanningAlertFixedAlertInstancesItemMessage`"]
 #[doc = r""]
@@ -14955,18 +14814,11 @@ impl ::std::default::Default for CodeScanningAlertFixedAlertInstancesItemLocatio
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertFixedAlertInstancesItemMessage {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub text: ::std::option::Option<::std::string::String>,
-}
-impl ::std::default::Default for CodeScanningAlertFixedAlertInstancesItemMessage {
-    fn default() -> Self {
-        Self {
-            text: Default::default(),
-        }
-    }
 }
 #[doc = "`CodeScanningAlertFixedAlertInstancesItemState`"]
 #[doc = r""]
@@ -15826,7 +15678,7 @@ pub struct CodeScanningAlertReopenedAlertInstancesItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedAlertInstancesItemLocation {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -15839,17 +15691,6 @@ pub struct CodeScanningAlertReopenedAlertInstancesItemLocation {
     pub start_column: ::std::option::Option<i64>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub start_line: ::std::option::Option<i64>,
-}
-impl ::std::default::Default for CodeScanningAlertReopenedAlertInstancesItemLocation {
-    fn default() -> Self {
-        Self {
-            end_column: Default::default(),
-            end_line: Default::default(),
-            path: Default::default(),
-            start_column: Default::default(),
-            start_line: Default::default(),
-        }
-    }
 }
 #[doc = "`CodeScanningAlertReopenedAlertInstancesItemMessage`"]
 #[doc = r""]
@@ -15867,18 +15708,11 @@ impl ::std::default::Default for CodeScanningAlertReopenedAlertInstancesItemLoca
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedAlertInstancesItemMessage {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub text: ::std::option::Option<::std::string::String>,
-}
-impl ::std::default::Default for CodeScanningAlertReopenedAlertInstancesItemMessage {
-    fn default() -> Self {
-        Self {
-            text: Default::default(),
-        }
-    }
 }
 #[doc = "`CodeScanningAlertReopenedAlertInstancesItemState`"]
 #[doc = r""]
@@ -16708,7 +16542,7 @@ pub struct CodeScanningAlertReopenedByUserAlertInstancesItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedByUserAlertInstancesItemLocation {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -16721,17 +16555,6 @@ pub struct CodeScanningAlertReopenedByUserAlertInstancesItemLocation {
     pub start_column: ::std::option::Option<i64>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub start_line: ::std::option::Option<i64>,
-}
-impl ::std::default::Default for CodeScanningAlertReopenedByUserAlertInstancesItemLocation {
-    fn default() -> Self {
-        Self {
-            end_column: Default::default(),
-            end_line: Default::default(),
-            path: Default::default(),
-            start_column: Default::default(),
-            start_line: Default::default(),
-        }
-    }
 }
 #[doc = "`CodeScanningAlertReopenedByUserAlertInstancesItemMessage`"]
 #[doc = r""]
@@ -16749,18 +16572,11 @@ impl ::std::default::Default for CodeScanningAlertReopenedByUserAlertInstancesIt
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedByUserAlertInstancesItemMessage {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub text: ::std::option::Option<::std::string::String>,
-}
-impl ::std::default::Default for CodeScanningAlertReopenedByUserAlertInstancesItemMessage {
-    fn default() -> Self {
-        Self {
-            text: Default::default(),
-        }
-    }
 }
 #[doc = "`CodeScanningAlertReopenedByUserAlertInstancesItemState`"]
 #[doc = r""]
@@ -18837,14 +18653,9 @@ pub struct DeploymentCreatedDeployment {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct DeploymentCreatedDeploymentPayload {}
-impl ::std::default::Default for DeploymentCreatedDeploymentPayload {
-    fn default() -> Self {
-        Self {}
-    }
-}
 #[doc = "`DeploymentEvent`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -19270,14 +19081,9 @@ pub struct DeploymentStatusCreatedDeployment {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct DeploymentStatusCreatedDeploymentPayload {}
-impl ::std::default::Default for DeploymentStatusCreatedDeploymentPayload {
-    fn default() -> Self {
-        Self {}
-    }
-}
 #[doc = "The [deployment status](https://docs.github.com/en/rest/reference/repos#list-deployment-statuses)."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -22308,21 +22114,13 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionEditedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub body: ::std::option::Option<DiscussionEditedChangesBody>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<DiscussionEditedChangesTitle>,
-}
-impl ::std::default::Default for DiscussionEditedChanges {
-    fn default() -> Self {
-        Self {
-            body: Default::default(),
-            title: Default::default(),
-        }
-    }
 }
 #[doc = "`DiscussionEditedChangesBody`"]
 #[doc = r""]
@@ -27445,7 +27243,7 @@ pub struct InstallationNewPermissionsAcceptedRepositoriesItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationPermissions {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -27522,47 +27320,6 @@ pub struct InstallationPermissions {
     pub vulnerability_alerts: ::std::option::Option<InstallationPermissionsVulnerabilityAlerts>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub workflows: ::std::option::Option<InstallationPermissionsWorkflows>,
-}
-impl ::std::default::Default for InstallationPermissions {
-    fn default() -> Self {
-        Self {
-            actions: Default::default(),
-            administration: Default::default(),
-            checks: Default::default(),
-            content_references: Default::default(),
-            contents: Default::default(),
-            deployments: Default::default(),
-            discussions: Default::default(),
-            emails: Default::default(),
-            environments: Default::default(),
-            issues: Default::default(),
-            members: Default::default(),
-            metadata: Default::default(),
-            organization_administration: Default::default(),
-            organization_events: Default::default(),
-            organization_hooks: Default::default(),
-            organization_packages: Default::default(),
-            organization_plan: Default::default(),
-            organization_projects: Default::default(),
-            organization_secrets: Default::default(),
-            organization_self_hosted_runners: Default::default(),
-            organization_user_blocking: Default::default(),
-            packages: Default::default(),
-            pages: Default::default(),
-            pull_requests: Default::default(),
-            repository_hooks: Default::default(),
-            repository_projects: Default::default(),
-            secret_scanning_alerts: Default::default(),
-            secrets: Default::default(),
-            security_events: Default::default(),
-            security_scanning_alert: Default::default(),
-            single_file: Default::default(),
-            statuses: Default::default(),
-            team_discussions: Default::default(),
-            vulnerability_alerts: Default::default(),
-            workflows: Default::default(),
-        }
-    }
 }
 #[doc = "`InstallationPermissionsActions`"]
 #[doc = r""]
@@ -30090,7 +29847,7 @@ pub struct InstallationRepositoriesAddedRepositoriesAddedItem {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationRepositoriesAddedRepositoriesRemovedItem {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -30106,17 +29863,6 @@ pub struct InstallationRepositoriesAddedRepositoriesRemovedItem {
     #[doc = "Whether the repository is private or public."]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub private: ::std::option::Option<bool>,
-}
-impl ::std::default::Default for InstallationRepositoriesAddedRepositoriesRemovedItem {
-    fn default() -> Self {
-        Self {
-            full_name: Default::default(),
-            id: Default::default(),
-            name: Default::default(),
-            node_id: Default::default(),
-            private: Default::default(),
-        }
-    }
 }
 #[doc = "Describe whether all repositories have been selected or there's a selection involved"]
 #[doc = r""]
@@ -31478,7 +31224,7 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationSuspendInsta
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationSuspendInstallationPermissions {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -31571,47 +31317,6 @@ pub struct InstallationSuspendInstallationPermissions {
         ::std::option::Option<InstallationSuspendInstallationPermissionsVulnerabilityAlerts>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub workflows: ::std::option::Option<InstallationSuspendInstallationPermissionsWorkflows>,
-}
-impl ::std::default::Default for InstallationSuspendInstallationPermissions {
-    fn default() -> Self {
-        Self {
-            actions: Default::default(),
-            administration: Default::default(),
-            checks: Default::default(),
-            content_references: Default::default(),
-            contents: Default::default(),
-            deployments: Default::default(),
-            discussions: Default::default(),
-            emails: Default::default(),
-            environments: Default::default(),
-            issues: Default::default(),
-            members: Default::default(),
-            metadata: Default::default(),
-            organization_administration: Default::default(),
-            organization_events: Default::default(),
-            organization_hooks: Default::default(),
-            organization_packages: Default::default(),
-            organization_plan: Default::default(),
-            organization_projects: Default::default(),
-            organization_secrets: Default::default(),
-            organization_self_hosted_runners: Default::default(),
-            organization_user_blocking: Default::default(),
-            packages: Default::default(),
-            pages: Default::default(),
-            pull_requests: Default::default(),
-            repository_hooks: Default::default(),
-            repository_projects: Default::default(),
-            secret_scanning_alerts: Default::default(),
-            secrets: Default::default(),
-            security_events: Default::default(),
-            security_scanning_alert: Default::default(),
-            single_file: Default::default(),
-            statuses: Default::default(),
-            team_discussions: Default::default(),
-            vulnerability_alerts: Default::default(),
-            workflows: Default::default(),
-        }
-    }
 }
 #[doc = "`InstallationSuspendInstallationPermissionsActions`"]
 #[doc = r""]
@@ -35309,7 +35014,7 @@ impl ::std::convert::TryFrom<::std::string::String>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationUnsuspendInstallationPermissions {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -35404,47 +35109,6 @@ pub struct InstallationUnsuspendInstallationPermissions {
         ::std::option::Option<InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub workflows: ::std::option::Option<InstallationUnsuspendInstallationPermissionsWorkflows>,
-}
-impl ::std::default::Default for InstallationUnsuspendInstallationPermissions {
-    fn default() -> Self {
-        Self {
-            actions: Default::default(),
-            administration: Default::default(),
-            checks: Default::default(),
-            content_references: Default::default(),
-            contents: Default::default(),
-            deployments: Default::default(),
-            discussions: Default::default(),
-            emails: Default::default(),
-            environments: Default::default(),
-            issues: Default::default(),
-            members: Default::default(),
-            metadata: Default::default(),
-            organization_administration: Default::default(),
-            organization_events: Default::default(),
-            organization_hooks: Default::default(),
-            organization_packages: Default::default(),
-            organization_plan: Default::default(),
-            organization_projects: Default::default(),
-            organization_secrets: Default::default(),
-            organization_self_hosted_runners: Default::default(),
-            organization_user_blocking: Default::default(),
-            packages: Default::default(),
-            pages: Default::default(),
-            pull_requests: Default::default(),
-            repository_hooks: Default::default(),
-            repository_projects: Default::default(),
-            secret_scanning_alerts: Default::default(),
-            secrets: Default::default(),
-            security_events: Default::default(),
-            security_scanning_alert: Default::default(),
-            single_file: Default::default(),
-            statuses: Default::default(),
-            team_discussions: Default::default(),
-            vulnerability_alerts: Default::default(),
-            workflows: Default::default(),
-        }
-    }
 }
 #[doc = "`InstallationUnsuspendInstallationPermissionsActions`"]
 #[doc = r""]
@@ -39974,18 +39638,11 @@ impl ::std::convert::TryFrom<::std::string::String> for IssueCommentEditedAction
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub body: ::std::option::Option<IssueCommentEditedChangesBody>,
-}
-impl ::std::default::Default for IssueCommentEditedChanges {
-    fn default() -> Self {
-        Self {
-            body: Default::default(),
-        }
-    }
 }
 #[doc = "`IssueCommentEditedChangesBody`"]
 #[doc = r""]
@@ -40504,7 +40161,7 @@ impl ::std::convert::From<IssueCommentEdited> for IssueCommentEvent {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct IssuePullRequest {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -40515,16 +40172,6 @@ pub struct IssuePullRequest {
     pub patch_url: ::std::option::Option<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub url: ::std::option::Option<::std::string::String>,
-}
-impl ::std::default::Default for IssuePullRequest {
-    fn default() -> Self {
-        Self {
-            diff_url: Default::default(),
-            html_url: Default::default(),
-            patch_url: Default::default(),
-            url: Default::default(),
-        }
-    }
 }
 #[doc = "State of the issue; either 'open' or 'closed'"]
 #[doc = r""]
@@ -41037,7 +40684,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesClosedIssueActiveL
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesClosedIssuePullRequest {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -41048,16 +40695,6 @@ pub struct IssuesClosedIssuePullRequest {
     pub patch_url: ::std::option::Option<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub url: ::std::option::Option<::std::string::String>,
-}
-impl ::std::default::Default for IssuesClosedIssuePullRequest {
-    fn default() -> Self {
-        Self {
-            diff_url: Default::default(),
-            html_url: Default::default(),
-            patch_url: Default::default(),
-            url: Default::default(),
-        }
-    }
 }
 #[doc = "`IssuesClosedIssueState`"]
 #[doc = r""]
@@ -41534,7 +41171,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesDemilestonedIssueA
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesDemilestonedIssuePullRequest {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -41545,16 +41182,6 @@ pub struct IssuesDemilestonedIssuePullRequest {
     pub patch_url: ::std::option::Option<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub url: ::std::option::Option<::std::string::String>,
-}
-impl ::std::default::Default for IssuesDemilestonedIssuePullRequest {
-    fn default() -> Self {
-        Self {
-            diff_url: Default::default(),
-            html_url: Default::default(),
-            patch_url: Default::default(),
-            url: Default::default(),
-        }
-    }
 }
 #[doc = "State of the issue; either 'open' or 'closed'"]
 #[doc = r""]
@@ -41814,21 +41441,13 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesEditedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub body: ::std::option::Option<IssuesEditedChangesBody>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<IssuesEditedChangesTitle>,
-}
-impl ::std::default::Default for IssuesEditedChanges {
-    fn default() -> Self {
-        Self {
-            body: Default::default(),
-            title: Default::default(),
-        }
-    }
 }
 #[doc = "`IssuesEditedChangesBody`"]
 #[doc = r""]
@@ -42492,7 +42111,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesLockedIssueActiveL
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesLockedIssuePullRequest {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -42503,16 +42122,6 @@ pub struct IssuesLockedIssuePullRequest {
     pub patch_url: ::std::option::Option<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub url: ::std::option::Option<::std::string::String>,
-}
-impl ::std::default::Default for IssuesLockedIssuePullRequest {
-    fn default() -> Self {
-        Self {
-            diff_url: Default::default(),
-            html_url: Default::default(),
-            patch_url: Default::default(),
-            url: Default::default(),
-        }
-    }
 }
 #[doc = "State of the issue; either 'open' or 'closed'"]
 #[doc = r""]
@@ -43080,7 +42689,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesMilestonedIssueMil
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesMilestonedIssuePullRequest {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -43091,16 +42700,6 @@ pub struct IssuesMilestonedIssuePullRequest {
     pub patch_url: ::std::option::Option<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub url: ::std::option::Option<::std::string::String>,
-}
-impl ::std::default::Default for IssuesMilestonedIssuePullRequest {
-    fn default() -> Self {
-        Self {
-            diff_url: Default::default(),
-            html_url: Default::default(),
-            patch_url: Default::default(),
-            url: Default::default(),
-        }
-    }
 }
 #[doc = "State of the issue; either 'open' or 'closed'"]
 #[doc = r""]
@@ -43524,7 +43123,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesOpenedIssueActiveL
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesOpenedIssuePullRequest {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -43535,16 +43134,6 @@ pub struct IssuesOpenedIssuePullRequest {
     pub patch_url: ::std::option::Option<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub url: ::std::option::Option<::std::string::String>,
-}
-impl ::std::default::Default for IssuesOpenedIssuePullRequest {
-    fn default() -> Self {
-        Self {
-            diff_url: Default::default(),
-            html_url: Default::default(),
-            patch_url: Default::default(),
-            url: Default::default(),
-        }
-    }
 }
 #[doc = "`IssuesOpenedIssueState`"]
 #[doc = r""]
@@ -44020,7 +43609,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesReopenedIssueActiv
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesReopenedIssuePullRequest {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -44031,16 +43620,6 @@ pub struct IssuesReopenedIssuePullRequest {
     pub patch_url: ::std::option::Option<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub url: ::std::option::Option<::std::string::String>,
-}
-impl ::std::default::Default for IssuesReopenedIssuePullRequest {
-    fn default() -> Self {
-        Self {
-            diff_url: Default::default(),
-            html_url: Default::default(),
-            patch_url: Default::default(),
-            url: Default::default(),
-        }
-    }
 }
 #[doc = "`IssuesReopenedIssueState`"]
 #[doc = r""]
@@ -44794,7 +44373,7 @@ impl<'de> ::serde::Deserialize<'de> for IssuesUnlockedIssueActiveLockReason {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesUnlockedIssuePullRequest {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -44805,16 +44384,6 @@ pub struct IssuesUnlockedIssuePullRequest {
     pub patch_url: ::std::option::Option<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub url: ::std::option::Option<::std::string::String>,
-}
-impl ::std::default::Default for IssuesUnlockedIssuePullRequest {
-    fn default() -> Self {
-        Self {
-            diff_url: Default::default(),
-            html_url: Default::default(),
-            patch_url: Default::default(),
-            url: Default::default(),
-        }
-    }
 }
 #[doc = "State of the issue; either 'open' or 'closed'"]
 #[doc = r""]
@@ -45506,7 +45075,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LabelEditedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct LabelEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -45515,15 +45084,6 @@ pub struct LabelEditedChanges {
     pub description: ::std::option::Option<LabelEditedChangesDescription>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<LabelEditedChangesName>,
-}
-impl ::std::default::Default for LabelEditedChanges {
-    fn default() -> Self {
-        Self {
-            color: Default::default(),
-            description: Default::default(),
-            name: Default::default(),
-        }
-    }
 }
 #[doc = "`LabelEditedChangesColor`"]
 #[doc = r""]
@@ -48626,18 +48186,11 @@ impl ::std::convert::TryFrom<::std::string::String> for MemberAddedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct MemberAddedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub permission: ::std::option::Option<MemberAddedChangesPermission>,
-}
-impl ::std::default::Default for MemberAddedChanges {
-    fn default() -> Self {
-        Self {
-            permission: Default::default(),
-        }
-    }
 }
 #[doc = "`MemberAddedChangesPermission`"]
 #[doc = r""]
@@ -50958,7 +50511,7 @@ impl ::std::convert::TryFrom<::std::string::String> for MilestoneEditedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct MilestoneEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -50967,15 +50520,6 @@ pub struct MilestoneEditedChanges {
     pub due_on: ::std::option::Option<MilestoneEditedChangesDueOn>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<MilestoneEditedChangesTitle>,
-}
-impl ::std::default::Default for MilestoneEditedChanges {
-    fn default() -> Self {
-        Self {
-            description: Default::default(),
-            due_on: Default::default(),
-            title: Default::default(),
-        }
-    }
 }
 #[doc = "`MilestoneEditedChangesDescription`"]
 #[doc = r""]
@@ -57217,18 +56761,11 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectColumnEditedActio
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectColumnEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<ProjectColumnEditedChangesName>,
-}
-impl ::std::default::Default for ProjectColumnEditedChanges {
-    fn default() -> Self {
-        Self {
-            name: Default::default(),
-        }
-    }
 }
 #[doc = "`ProjectColumnEditedChangesName`"]
 #[doc = r""]
@@ -57832,21 +57369,13 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectEditedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub body: ::std::option::Option<ProjectEditedChangesBody>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<ProjectEditedChangesName>,
-}
-impl ::std::default::Default for ProjectEditedChanges {
-    fn default() -> Self {
-        Self {
-            body: Default::default(),
-            name: Default::default(),
-        }
-    }
 }
 #[doc = "`ProjectEditedChangesBody`"]
 #[doc = r""]
@@ -60776,21 +60305,13 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestEditedAction 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub body: ::std::option::Option<PullRequestEditedChangesBody>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<PullRequestEditedChangesTitle>,
-}
-impl ::std::default::Default for PullRequestEditedChanges {
-    fn default() -> Self {
-        Self {
-            body: Default::default(),
-            title: Default::default(),
-        }
-    }
 }
 #[doc = "`PullRequestEditedChangesBody`"]
 #[doc = r""]
@@ -66029,18 +65550,11 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReviewComment
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub body: ::std::option::Option<PullRequestReviewCommentEditedChangesBody>,
-}
-impl ::std::default::Default for PullRequestReviewCommentEditedChanges {
-    fn default() -> Self {
-        Self {
-            body: Default::default(),
-        }
-    }
 }
 #[doc = "`PullRequestReviewCommentEditedChangesBody`"]
 #[doc = r""]
@@ -67582,18 +67096,11 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReviewEditedA
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub body: ::std::option::Option<PullRequestReviewEditedChangesBody>,
-}
-impl ::std::default::Default for PullRequestReviewEditedChanges {
-    fn default() -> Self {
-        Self {
-            body: Default::default(),
-        }
-    }
 }
 #[doc = "`PullRequestReviewEditedChangesBody`"]
 #[doc = r""]
@@ -70006,21 +69513,13 @@ impl ::std::convert::TryFrom<::std::string::String> for ReleaseEditedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct ReleaseEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub body: ::std::option::Option<ReleaseEditedChangesBody>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<ReleaseEditedChangesName>,
-}
-impl ::std::default::Default for ReleaseEditedChanges {
-    fn default() -> Self {
-        Self {
-            body: Default::default(),
-            name: Default::default(),
-        }
-    }
 }
 #[doc = "`ReleaseEditedChangesBody`"]
 #[doc = r""]
@@ -72520,7 +72019,7 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryEditedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -72529,15 +72028,6 @@ pub struct RepositoryEditedChanges {
     pub description: ::std::option::Option<RepositoryEditedChangesDescription>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub homepage: ::std::option::Option<RepositoryEditedChangesHomepage>,
-}
-impl ::std::default::Default for RepositoryEditedChanges {
-    fn default() -> Self {
-        Self {
-            default_branch: Default::default(),
-            description: Default::default(),
-            homepage: Default::default(),
-        }
-    }
 }
 #[doc = "`RepositoryEditedChangesDefaultBranch`"]
 #[doc = r""]
@@ -74528,18 +74018,11 @@ pub struct RepositoryTransferredChangesOwner {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryTransferredChangesOwnerFrom {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub user: ::std::option::Option<User>,
-}
-impl ::std::default::Default for RepositoryTransferredChangesOwnerFrom {
-    fn default() -> Self {
-        Self {
-            user: Default::default(),
-        }
-    }
 }
 #[doc = "`RepositoryUnarchived`"]
 #[doc = r""]
@@ -80413,18 +79896,11 @@ impl ::std::convert::TryFrom<::std::string::String> for SponsorshipEditedAction 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub privacy_level: ::std::option::Option<SponsorshipEditedChangesPrivacyLevel>,
-}
-impl ::std::default::Default for SponsorshipEditedChanges {
-    fn default() -> Self {
-        Self {
-            privacy_level: Default::default(),
-        }
-    }
 }
 #[doc = "`SponsorshipEditedChangesPrivacyLevel`"]
 #[doc = r""]
@@ -83646,7 +83122,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TeamEditedAction {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct TeamEditedChanges {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -83657,16 +83133,6 @@ pub struct TeamEditedChanges {
     pub privacy: ::std::option::Option<TeamEditedChangesPrivacy>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub repository: ::std::option::Option<TeamEditedChangesRepository>,
-}
-impl ::std::default::Default for TeamEditedChanges {
-    fn default() -> Self {
-        Self {
-            description: Default::default(),
-            name: Default::default(),
-            privacy: Default::default(),
-            repository: Default::default(),
-        }
-    }
 }
 #[doc = "`TeamEditedChangesDescription`"]
 #[doc = r""]
@@ -83858,7 +83324,7 @@ pub struct TeamEditedChangesRepositoryPermissions {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct TeamEditedChangesRepositoryPermissionsFrom {
     #[doc = "The previous version of the team member's `admin` permission on a repository, if the action was `edited`."]
@@ -83870,15 +83336,6 @@ pub struct TeamEditedChangesRepositoryPermissionsFrom {
     #[doc = "The previous version of the team member's `push` permission on a repository, if the action was `edited`."]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub push: ::std::option::Option<bool>,
-}
-impl ::std::default::Default for TeamEditedChangesRepositoryPermissionsFrom {
-    fn default() -> Self {
-        Self {
-            admin: Default::default(),
-            pull: Default::default(),
-            push: Default::default(),
-        }
-    }
 }
 #[doc = "`TeamEvent`"]
 #[doc = r""]

--- a/typify-impl/tests/vega.out
+++ b/typify-impl/tests/vega.out
@@ -8066,7 +8066,7 @@ impl ::std::convert::From<NumberValue> for AxisDomainWidth {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct AxisEncode {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -8081,18 +8081,6 @@ pub struct AxisEncode {
     pub ticks: ::std::option::Option<GuideEncode>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
-}
-impl ::std::default::Default for AxisEncode {
-    fn default() -> Self {
-        Self {
-            axis: Default::default(),
-            domain: Default::default(),
-            grid: Default::default(),
-            labels: Default::default(),
-            ticks: Default::default(),
-            title: Default::default(),
-        }
-    }
 }
 #[doc = "`AxisFormat`"]
 #[doc = r""]
@@ -20264,7 +20252,7 @@ impl ::std::convert::From<SignalRef> for DataVariant2Format {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct DataVariant2FormatVariant0Subtype0 {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub parse: ::std::option::Option<DataVariant2FormatVariant0Subtype0Parse>,
@@ -20274,14 +20262,6 @@ pub struct DataVariant2FormatVariant0Subtype0 {
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub type_: ::std::option::Option<StringOrSignal>,
-}
-impl ::std::default::Default for DataVariant2FormatVariant0Subtype0 {
-    fn default() -> Self {
-        Self {
-            parse: Default::default(),
-            type_: Default::default(),
-        }
-    }
 }
 #[doc = "`DataVariant2FormatVariant0Subtype0Parse`"]
 #[doc = r""]
@@ -20703,7 +20683,7 @@ impl<'de> ::serde::Deserialize<'de>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct DataVariant2FormatVariant0Subtype1 {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -20718,16 +20698,6 @@ pub struct DataVariant2FormatVariant0Subtype1 {
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub type_: ::std::option::Option<DataVariant2FormatVariant0Subtype1Type>,
-}
-impl ::std::default::Default for DataVariant2FormatVariant0Subtype1 {
-    fn default() -> Self {
-        Self {
-            copy: Default::default(),
-            parse: Default::default(),
-            property: Default::default(),
-            type_: Default::default(),
-        }
-    }
 }
 #[doc = "`DataVariant2FormatVariant0Subtype1Parse`"]
 #[doc = r""]
@@ -22764,7 +22734,7 @@ impl ::std::convert::From<SignalRef> for DataVariant3Format {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct DataVariant3FormatVariant0Subtype0 {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub parse: ::std::option::Option<DataVariant3FormatVariant0Subtype0Parse>,
@@ -22774,14 +22744,6 @@ pub struct DataVariant3FormatVariant0Subtype0 {
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub type_: ::std::option::Option<StringOrSignal>,
-}
-impl ::std::default::Default for DataVariant3FormatVariant0Subtype0 {
-    fn default() -> Self {
-        Self {
-            parse: Default::default(),
-            type_: Default::default(),
-        }
-    }
 }
 #[doc = "`DataVariant3FormatVariant0Subtype0Parse`"]
 #[doc = r""]
@@ -23203,7 +23165,7 @@ impl<'de> ::serde::Deserialize<'de>
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct DataVariant3FormatVariant0Subtype1 {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -23218,16 +23180,6 @@ pub struct DataVariant3FormatVariant0Subtype1 {
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub type_: ::std::option::Option<DataVariant3FormatVariant0Subtype1Type>,
-}
-impl ::std::default::Default for DataVariant3FormatVariant0Subtype1 {
-    fn default() -> Self {
-        Self {
-            copy: Default::default(),
-            parse: Default::default(),
-            property: Default::default(),
-            type_: Default::default(),
-        }
-    }
 }
 #[doc = "`DataVariant3FormatVariant0Subtype1Parse`"]
 #[doc = r""]
@@ -28306,7 +28258,7 @@ impl ::std::convert::From<::std::collections::HashMap<EncodeKey, EncodeEntry>> f
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct EncodeEntry {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub align: ::std::option::Option<AlignValue>,
@@ -28563,81 +28515,6 @@ pub struct EncodeEntry {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub zindex: ::std::option::Option<NumberValue>,
 }
-impl ::std::default::Default for EncodeEntry {
-    fn default() -> Self {
-        Self {
-            align: Default::default(),
-            angle: Default::default(),
-            aria: Default::default(),
-            aria_role: Default::default(),
-            aria_role_description: Default::default(),
-            aspect: Default::default(),
-            baseline: Default::default(),
-            blend: Default::default(),
-            clip: Default::default(),
-            corner_radius: Default::default(),
-            corner_radius_bottom_left: Default::default(),
-            corner_radius_bottom_right: Default::default(),
-            corner_radius_top_left: Default::default(),
-            corner_radius_top_right: Default::default(),
-            cursor: Default::default(),
-            defined: Default::default(),
-            description: Default::default(),
-            dir: Default::default(),
-            dx: Default::default(),
-            dy: Default::default(),
-            ellipsis: Default::default(),
-            end_angle: Default::default(),
-            fill: Default::default(),
-            fill_opacity: Default::default(),
-            font: Default::default(),
-            font_size: Default::default(),
-            font_style: Default::default(),
-            font_weight: Default::default(),
-            height: Default::default(),
-            inner_radius: Default::default(),
-            interpolate: Default::default(),
-            limit: Default::default(),
-            line_break: Default::default(),
-            line_height: Default::default(),
-            opacity: Default::default(),
-            orient: Default::default(),
-            outer_radius: Default::default(),
-            pad_angle: Default::default(),
-            path: Default::default(),
-            radius: Default::default(),
-            scale_x: Default::default(),
-            scale_y: Default::default(),
-            shape: Default::default(),
-            size: Default::default(),
-            smooth: Default::default(),
-            start_angle: Default::default(),
-            stroke: Default::default(),
-            stroke_cap: Default::default(),
-            stroke_dash: Default::default(),
-            stroke_dash_offset: Default::default(),
-            stroke_foreground: Default::default(),
-            stroke_join: Default::default(),
-            stroke_miter_limit: Default::default(),
-            stroke_offset: Default::default(),
-            stroke_opacity: Default::default(),
-            stroke_width: Default::default(),
-            tension: Default::default(),
-            text: Default::default(),
-            theta: Default::default(),
-            tooltip: Default::default(),
-            url: Default::default(),
-            width: Default::default(),
-            x: Default::default(),
-            x2: Default::default(),
-            xc: Default::default(),
-            y: Default::default(),
-            y2: Default::default(),
-            yc: Default::default(),
-            zindex: Default::default(),
-        }
-    }
-}
 #[doc = "`EncodeKey`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -28748,7 +28625,7 @@ impl<'de> ::serde::Deserialize<'de> for EncodeKey {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct Everything {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub autosize: ::std::option::Option<Autosize>,
@@ -28794,32 +28671,6 @@ pub struct Everything {
     pub usermeta: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub width: ::std::option::Option<NumberOrSignal>,
-}
-impl ::std::default::Default for Everything {
-    fn default() -> Self {
-        Self {
-            autosize: Default::default(),
-            axes: Default::default(),
-            background: Default::default(),
-            config: Default::default(),
-            data: Default::default(),
-            description: Default::default(),
-            encode: Default::default(),
-            height: Default::default(),
-            layout: Default::default(),
-            legends: Default::default(),
-            marks: Default::default(),
-            padding: Default::default(),
-            projections: Default::default(),
-            scales: Default::default(),
-            schema: Default::default(),
-            signals: Default::default(),
-            style: Default::default(),
-            title: Default::default(),
-            usermeta: Default::default(),
-            width: Default::default(),
-        }
-    }
 }
 #[doc = "`EverythingMarksItem`"]
 #[doc = r""]
@@ -29327,7 +29178,7 @@ pub enum FacetFacet {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct FacetFacetVariant1Aggregate {
     #[serde(
@@ -29342,16 +29193,6 @@ pub struct FacetFacetVariant1Aggregate {
     pub fields: ::std::vec::Vec<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub ops: ::std::vec::Vec<::std::string::String>,
-}
-impl ::std::default::Default for FacetFacetVariant1Aggregate {
-    fn default() -> Self {
-        Self {
-            as_: Default::default(),
-            cross: Default::default(),
-            fields: Default::default(),
-            ops: Default::default(),
-        }
-    }
 }
 #[doc = "`FacetFacetVariant1Groupby`"]
 #[doc = r""]
@@ -33523,18 +33364,11 @@ impl ::std::convert::TryFrom<::std::string::String> for FormulaTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct From {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub data: ::std::option::Option<::std::string::String>,
-}
-impl ::std::default::Default for From {
-    fn default() -> Self {
-        Self {
-            data: Default::default(),
-        }
-    }
 }
 #[doc = "`GeojsonTransform`"]
 #[doc = r""]
@@ -35429,7 +35263,7 @@ impl ::std::convert::TryFrom<::std::string::String> for GraticuleTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct GuideEncode {
     #[serde(default)]
@@ -35438,15 +35272,6 @@ pub struct GuideEncode {
     pub name: ::std::option::Option<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub style: ::std::option::Option<Style>,
-}
-impl ::std::default::Default for GuideEncode {
-    fn default() -> Self {
-        Self {
-            interactive: Default::default(),
-            name: Default::default(),
-            style: Default::default(),
-        }
-    }
 }
 #[doc = "`HeatmapTransform`"]
 #[doc = r""]
@@ -45634,7 +45459,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant0Direction 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct LegendVariant0Encode {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -45649,18 +45474,6 @@ pub struct LegendVariant0Encode {
     pub symbols: ::std::option::Option<GuideEncode>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
-}
-impl ::std::default::Default for LegendVariant0Encode {
-    fn default() -> Self {
-        Self {
-            entries: Default::default(),
-            gradient: Default::default(),
-            labels: Default::default(),
-            legend: Default::default(),
-            symbols: Default::default(),
-            title: Default::default(),
-        }
-    }
 }
 #[doc = "`LegendVariant0FillColor`"]
 #[doc = r""]
@@ -48141,7 +47954,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant1Direction 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct LegendVariant1Encode {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -48156,18 +47969,6 @@ pub struct LegendVariant1Encode {
     pub symbols: ::std::option::Option<GuideEncode>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
-}
-impl ::std::default::Default for LegendVariant1Encode {
-    fn default() -> Self {
-        Self {
-            entries: Default::default(),
-            gradient: Default::default(),
-            labels: Default::default(),
-            legend: Default::default(),
-            symbols: Default::default(),
-            title: Default::default(),
-        }
-    }
 }
 #[doc = "`LegendVariant1FillColor`"]
 #[doc = r""]
@@ -50648,7 +50449,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant2Direction 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct LegendVariant2Encode {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -50663,18 +50464,6 @@ pub struct LegendVariant2Encode {
     pub symbols: ::std::option::Option<GuideEncode>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
-}
-impl ::std::default::Default for LegendVariant2Encode {
-    fn default() -> Self {
-        Self {
-            entries: Default::default(),
-            gradient: Default::default(),
-            labels: Default::default(),
-            legend: Default::default(),
-            symbols: Default::default(),
-            title: Default::default(),
-        }
-    }
 }
 #[doc = "`LegendVariant2FillColor`"]
 #[doc = r""]
@@ -53155,7 +52944,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant3Direction 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct LegendVariant3Encode {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -53170,18 +52959,6 @@ pub struct LegendVariant3Encode {
     pub symbols: ::std::option::Option<GuideEncode>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
-}
-impl ::std::default::Default for LegendVariant3Encode {
-    fn default() -> Self {
-        Self {
-            entries: Default::default(),
-            gradient: Default::default(),
-            labels: Default::default(),
-            legend: Default::default(),
-            symbols: Default::default(),
-            title: Default::default(),
-        }
-    }
 }
 #[doc = "`LegendVariant3FillColor`"]
 #[doc = r""]
@@ -55662,7 +55439,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant4Direction 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct LegendVariant4Encode {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -55677,18 +55454,6 @@ pub struct LegendVariant4Encode {
     pub symbols: ::std::option::Option<GuideEncode>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
-}
-impl ::std::default::Default for LegendVariant4Encode {
-    fn default() -> Self {
-        Self {
-            entries: Default::default(),
-            gradient: Default::default(),
-            labels: Default::default(),
-            legend: Default::default(),
-            symbols: Default::default(),
-            title: Default::default(),
-        }
-    }
 }
 #[doc = "`LegendVariant4FillColor`"]
 #[doc = r""]
@@ -58169,7 +57934,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant5Direction 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct LegendVariant5Encode {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -58184,18 +57949,6 @@ pub struct LegendVariant5Encode {
     pub symbols: ::std::option::Option<GuideEncode>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
-}
-impl ::std::default::Default for LegendVariant5Encode {
-    fn default() -> Self {
-        Self {
-            entries: Default::default(),
-            gradient: Default::default(),
-            labels: Default::default(),
-            legend: Default::default(),
-            symbols: Default::default(),
-            title: Default::default(),
-        }
-    }
 }
 #[doc = "`LegendVariant5FillColor`"]
 #[doc = r""]
@@ -60676,7 +60429,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant6Direction 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct LegendVariant6Encode {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -60691,18 +60444,6 @@ pub struct LegendVariant6Encode {
     pub symbols: ::std::option::Option<GuideEncode>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
-}
-impl ::std::default::Default for LegendVariant6Encode {
-    fn default() -> Self {
-        Self {
-            entries: Default::default(),
-            gradient: Default::default(),
-            labels: Default::default(),
-            legend: Default::default(),
-            symbols: Default::default(),
-            title: Default::default(),
-        }
-    }
 }
 #[doc = "`LegendVariant6FillColor`"]
 #[doc = r""]
@@ -65613,7 +65354,7 @@ impl ::std::convert::TryFrom<::std::string::String> for NestTransformType {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct NumberModifiers {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub band: ::std::option::Option<NumberModifiersBand>,
@@ -65629,19 +65370,6 @@ pub struct NumberModifiers {
     pub round: bool,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub scale: ::std::option::Option<Field>,
-}
-impl ::std::default::Default for NumberModifiers {
-    fn default() -> Self {
-        Self {
-            band: Default::default(),
-            exponent: Default::default(),
-            extra: Default::default(),
-            mult: Default::default(),
-            offset: Default::default(),
-            round: Default::default(),
-            scale: Default::default(),
-        }
-    }
 }
 #[doc = "`NumberModifiersBand`"]
 #[doc = r""]
@@ -75584,17 +75312,10 @@ impl ::std::convert::TryFrom<::std::string::String> for ResolvefilterTransformTy
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct Rule {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub test: ::std::option::Option<::std::string::String>,
-}
-impl ::std::default::Default for Rule {
-    fn default() -> Self {
-        Self {
-            test: Default::default(),
-        }
-    }
 }
 #[doc = "`SampleTransform`"]
 #[doc = r""]
@@ -88107,7 +87828,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant9Type {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct Scope {
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub axes: ::std::vec::Vec<Axis>,
@@ -88131,23 +87852,6 @@ pub struct Scope {
     pub title: ::std::option::Option<Title>,
     #[serde(default, skip_serializing_if = "::serde_json::Map::is_empty")]
     pub usermeta: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-}
-impl ::std::default::Default for Scope {
-    fn default() -> Self {
-        Self {
-            axes: Default::default(),
-            data: Default::default(),
-            encode: Default::default(),
-            layout: Default::default(),
-            legends: Default::default(),
-            marks: Default::default(),
-            projections: Default::default(),
-            scales: Default::default(),
-            signals: Default::default(),
-            title: Default::default(),
-            usermeta: Default::default(),
-        }
-    }
 }
 #[doc = "`ScopeMarksItem`"]
 #[doc = r""]
@@ -89873,17 +89577,10 @@ impl ::std::convert::From<::std::vec::Vec<ExprString>> for StreamVariant2Filter 
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct StringModifiers {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub scale: ::std::option::Option<Field>,
-}
-impl ::std::default::Default for StringModifiers {
-    fn default() -> Self {
-        Self {
-            scale: Default::default(),
-        }
-    }
 }
 #[doc = "`StringOrSignal`"]
 #[doc = r""]
@@ -97745,7 +97442,7 @@ impl ::std::convert::From<NumberValue> for TitleObjectDy {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct TitleObjectEncode {
     #[serde(
         flatten,
@@ -97761,14 +97458,6 @@ pub struct TitleObjectEncode {
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub subtype_1: ::std::option::Option<TitleObjectEncodeSubtype1>,
-}
-impl ::std::default::Default for TitleObjectEncode {
-    fn default() -> Self {
-        Self {
-            subtype_0: Default::default(),
-            subtype_1: Default::default(),
-        }
-    }
 }
 #[doc = "`TitleObjectEncodeSubtype0Key`"]
 #[doc = r""]
@@ -97856,7 +97545,7 @@ impl<'de> ::serde::Deserialize<'de> for TitleObjectEncodeSubtype0Key {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct TitleObjectEncodeSubtype1 {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -97865,15 +97554,6 @@ pub struct TitleObjectEncodeSubtype1 {
     pub subtitle: ::std::option::Option<GuideEncode>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
-}
-impl ::std::default::Default for TitleObjectEncodeSubtype1 {
-    fn default() -> Self {
-        Self {
-            group: Default::default(),
-            subtitle: Default::default(),
-            title: Default::default(),
-        }
-    }
 }
 #[doc = "`TitleObjectFont`"]
 #[doc = r""]

--- a/typify/tests/schemas/extraneous-enum.rs
+++ b/typify/tests/schemas/extraneous-enum.rs
@@ -47,17 +47,10 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct LetterBox {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub letter: ::std::option::Option<LetterBoxLetter>,
-}
-impl ::std::default::Default for LetterBox {
-    fn default() -> Self {
-        Self {
-            letter: Default::default(),
-        }
-    }
 }
 impl LetterBox {
     pub fn builder() -> builder::LetterBox {

--- a/typify/tests/schemas/merged-schemas.rs
+++ b/typify/tests/schemas/merged-schemas.rs
@@ -39,17 +39,10 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct BarProp {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub bar: ::std::option::Option<::serde_json::Value>,
-}
-impl ::std::default::Default for BarProp {
-    fn default() -> Self {
-        Self {
-            bar: Default::default(),
-        }
-    }
 }
 impl BarProp {
     pub fn builder() -> builder::BarProp {
@@ -75,17 +68,10 @@ impl BarProp {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct ButNotThat {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub this: ::std::option::Option<::serde_json::Value>,
-}
-impl ::std::default::Default for ButNotThat {
-    fn default() -> Self {
-        Self {
-            this: Default::default(),
-        }
-    }
 }
 impl ButNotThat {
     pub fn builder() -> builder::ButNotThat {
@@ -114,20 +100,12 @@ impl ButNotThat {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct CommentedTypeMerged {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub x: ::std::option::Option<::serde_json::Value>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub y: ::std::option::Option<::serde_json::Value>,
-}
-impl ::std::default::Default for CommentedTypeMerged {
-    fn default() -> Self {
-        Self {
-            x: Default::default(),
-            y: Default::default(),
-        }
-    }
 }
 impl CommentedTypeMerged {
     pub fn builder() -> builder::CommentedTypeMerged {
@@ -202,17 +180,10 @@ pub enum HereAndThere {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct JsonResponseBase {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub result: ::std::option::Option<::std::string::String>,
-}
-impl ::std::default::Default for JsonResponseBase {
-    fn default() -> Self {
-        Self {
-            result: Default::default(),
-        }
-    }
 }
 impl JsonResponseBase {
     pub fn builder() -> builder::JsonResponseBase {
@@ -452,14 +423,9 @@ impl ::std::convert::TryFrom<::std::string::String> for JsonSuccessResult {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct MergeEmpty {}
-impl ::std::default::Default for MergeEmpty {
-    fn default() -> Self {
-        Self {}
-    }
-}
 impl MergeEmpty {
     pub fn builder() -> builder::MergeEmpty {
         Default::default()
@@ -754,17 +720,10 @@ impl Pickingone {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct PickingoneInstallation {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub suspended_by: ::std::option::Option<PickingoneUser>,
-}
-impl ::std::default::Default for PickingoneInstallation {
-    fn default() -> Self {
-        Self {
-            suspended_by: Default::default(),
-        }
-    }
 }
 impl PickingoneInstallation {
     pub fn builder() -> builder::PickingoneInstallation {
@@ -801,17 +760,10 @@ impl PickingoneInstallation {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct PickingoneSuspendedBy {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub email: ::std::option::Option<::std::string::String>,
-}
-impl ::std::default::Default for PickingoneSuspendedBy {
-    fn default() -> Self {
-        Self {
-            email: Default::default(),
-        }
-    }
 }
 impl PickingoneSuspendedBy {
     pub fn builder() -> builder::PickingoneSuspendedBy {
@@ -836,17 +788,10 @@ impl PickingoneSuspendedBy {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct PickingoneUser {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub email: ::std::option::Option<::std::string::String>,
-}
-impl ::std::default::Default for PickingoneUser {
-    fn default() -> Self {
-        Self {
-            email: Default::default(),
-        }
-    }
 }
 impl PickingoneUser {
     pub fn builder() -> builder::PickingoneUser {
@@ -1289,17 +1234,10 @@ pub enum Unsatisfiable3 {}
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct Unsatisfiable3A {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub action: ::std::option::Option<Unsatisfiable3C>,
-}
-impl ::std::default::Default for Unsatisfiable3A {
-    fn default() -> Self {
-        Self {
-            action: Default::default(),
-        }
-    }
 }
 impl Unsatisfiable3A {
     pub fn builder() -> builder::Unsatisfiable3A {

--- a/typify/tests/schemas/noisy-types.rs
+++ b/typify/tests/schemas/noisy-types.rs
@@ -143,17 +143,10 @@ impl ::std::fmt::Display for IntegerBs {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct ObjectBs {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub ok: ::std::option::Option<bool>,
-}
-impl ::std::default::Default for ObjectBs {
-    fn default() -> Self {
-        Self {
-            ok: Default::default(),
-        }
-    }
 }
 impl ObjectBs {
     pub fn builder() -> builder::ObjectBs {

--- a/typify/tests/schemas/reflexive.rs
+++ b/typify/tests/schemas/reflexive.rs
@@ -48,20 +48,12 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct Node {
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub children: ::std::vec::Vec<Node>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub value: ::std::option::Option<i64>,
-}
-impl ::std::default::Default for Node {
-    fn default() -> Self {
-        Self {
-            children: Default::default(),
-            value: Default::default(),
-        }
-    }
 }
 impl Node {
     pub fn builder() -> builder::Node {

--- a/typify/tests/schemas/rust-collisions.rs
+++ b/typify/tests/schemas/rust-collisions.rs
@@ -105,17 +105,10 @@ impl Copy {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct DoubleOptionCollision {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub option: ::std::option::Option<DoubleOptionCollisionOption>,
-}
-impl ::std::default::Default for DoubleOptionCollision {
-    fn default() -> Self {
-        Self {
-            option: Default::default(),
-        }
-    }
 }
 impl DoubleOptionCollision {
     pub fn builder() -> builder::DoubleOptionCollision {
@@ -140,17 +133,10 @@ impl DoubleOptionCollision {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct DoubleOptionCollisionOption {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub option: ::std::option::Option<::std::string::String>,
-}
-impl ::std::default::Default for DoubleOptionCollisionOption {
-    fn default() -> Self {
-        Self {
-            option: Default::default(),
-        }
-    }
 }
 impl DoubleOptionCollisionOption {
     pub fn builder() -> builder::DoubleOptionCollisionOption {
@@ -592,7 +578,7 @@ impl NestedTypeCollisions {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct NestedTypeCollisionsOptionType {
     #[serde(
         rename = "type",
@@ -600,13 +586,6 @@ pub struct NestedTypeCollisionsOptionType {
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub type_: ::std::option::Option<::std::string::String>,
-}
-impl ::std::default::Default for NestedTypeCollisionsOptionType {
-    fn default() -> Self {
-        Self {
-            type_: Default::default(),
-        }
-    }
 }
 impl NestedTypeCollisionsOptionType {
     pub fn builder() -> builder::NestedTypeCollisionsOptionType {

--- a/typify/tests/schemas/simple-types.rs
+++ b/typify/tests/schemas/simple-types.rs
@@ -63,17 +63,10 @@ impl AnythingWorks {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct FloatsArentTerribleImTold {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub flush_timeout: ::std::option::Option<f32>,
-}
-impl ::std::default::Default for FloatsArentTerribleImTold {
-    fn default() -> Self {
-        Self {
-            flush_timeout: Default::default(),
-        }
-    }
 }
 impl FloatsArentTerribleImTold {
     pub fn builder() -> builder::FloatsArentTerribleImTold {

--- a/typify/tests/schemas/types-with-defaults.rs
+++ b/typify/tests/schemas/types-with-defaults.rs
@@ -143,17 +143,10 @@ impl MrDefaultNumbers {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct OuterThing {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub thing: ::std::option::Option<ThingWithDefaults>,
-}
-impl ::std::default::Default for OuterThing {
-    fn default() -> Self {
-        Self {
-            thing: Default::default(),
-        }
-    }
 }
 impl OuterThing {
     pub fn builder() -> builder::OuterThing {

--- a/typify/tests/schemas/various-enums-json-schema.rs
+++ b/typify/tests/schemas/various-enums-json-schema.rs
@@ -426,17 +426,12 @@ impl ::std::default::Default for DiskAttachmentState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, schemars :: JsonSchema)]
+#[derive(
+    :: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default, schemars :: JsonSchema,
+)]
 pub struct EmptyObject {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub prop: ::std::option::Option<EmptyObjectProp>,
-}
-impl ::std::default::Default for EmptyObject {
-    fn default() -> Self {
-        Self {
-            prop: Default::default(),
-        }
-    }
 }
 impl EmptyObject {
     pub fn builder() -> builder::EmptyObject {

--- a/typify/tests/schemas/various-enums.rs
+++ b/typify/tests/schemas/various-enums.rs
@@ -403,17 +403,10 @@ impl ::std::default::Default for DiskAttachmentState {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct EmptyObject {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub prop: ::std::option::Option<EmptyObjectProp>,
-}
-impl ::std::default::Default for EmptyObject {
-    fn default() -> Self {
-        Self {
-            prop: Default::default(),
-        }
-    }
 }
 impl EmptyObject {
     pub fn builder() -> builder::EmptyObject {

--- a/typify/tests/schemas/x-rust-type.rs
+++ b/typify/tests/schemas/x-rust-type.rs
@@ -43,20 +43,12 @@ pub mod error {
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct AllTheThings {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub option_marker: ::std::option::Option<::std::option::Option<Marker>>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub path: ::std::option::Option<::std::path::PathBuf>,
-}
-impl ::std::default::Default for AllTheThings {
-    fn default() -> Self {
-        Self {
-            option_marker: Default::default(),
-            path: Default::default(),
-        }
-    }
 }
 impl AllTheThings {
     pub fn builder() -> builder::AllTheThings {


### PR DESCRIPTION
## Problem

When every property of a struct has a default and none of them are custom, the generated code emits a hand-written `impl Default` whose every field initializer is `Default::default()`. That impl is exactly what `#[derive(Default)]` produces, so clippy's warn-by-default `derivable_impls` lint fires on it in consuming code — roughly 50 times on the output for a large schema like the `github.json` test fixture. It also bloats the generated output.

## Fix

In `output_struct`, when there is no whole-type default value and every property's default is the intrinsic `Default::default()`, add `Default` to the struct's derive set instead of emitting the manual impl.

Hand-written impls are kept where they carry real information:
- structs with a whole-type `default` value,
- structs where any property has a custom default function,
- builder-module `Default` impls (which initialize fields to `Ok(..)`/`Err(..)`).

## Trade-offs

None behavioral — the derived impl produces identical values to the removed manual one. The golden-file diff is large but mechanical: every removed impl had all-`Default::default()` initializers, and its struct gains `Default` in the derive list.