### PR TITLE
Fix StringValidator counting bytes instead of code points for minLength/maxLength

### DIFF
--- a/typify-impl/src/util.rs
+++ b/typify-impl/src/util.rs
@@ -919,13 +919,15 @@ impl StringValidator {
     }
 
     pub fn is_valid<S: AsRef<str>>(&self, s: S) -> bool {
+        // Per the JSON Schema spec (and RFC 8259), minLength/maxLength count
+        // Unicode code points, not UTF-8 bytes, so we must not use `len()`.
         self.max_length
             .as_ref()
-            .is_none_or(|max| s.as_ref().len() as u32 <= *max)
+            .is_none_or(|max| s.as_ref().chars().count() as u32 <= *max)
             && self
                 .min_length
                 .as_ref()
-                .is_none_or(|min| s.as_ref().len() as u32 >= *min)
+                .is_none_or(|min| s.as_ref().chars().count() as u32 >= *min)
             && self
                 .pattern
                 .as_ref()
@@ -1177,6 +1179,61 @@ mod tests {
         assert!(ach.is_valid("Shadrach"));
         assert!(ach.is_valid("Meshach"));
         assert!(!ach.is_valid("Abednego"));
+    }
+
+    #[test]
+    fn test_string_validation_multi_byte() {
+        // minLength/maxLength count Unicode code points, not UTF-8 bytes.
+        // "héllo" is 5 code points but 6 bytes (the "é" is 2 bytes).
+        let five = StringValidator::new(
+            &Name::Unknown,
+            Some(&StringValidation {
+                max_length: Some(5),
+                min_length: Some(5),
+                pattern: None,
+            }),
+        )
+        .unwrap();
+        assert!(five.is_valid("héllo"));
+        assert!(five.is_valid("hello"));
+        // 6 bytes but only 5 code points -- should still be valid.
+        assert_eq!("héllo".len(), 6);
+        assert_eq!("héllo".chars().count(), 5);
+
+        // A single 4-byte emoji is one code point, so it satisfies a
+        // minLength/maxLength of 1 even though it is 4 bytes long.
+        let one = StringValidator::new(
+            &Name::Unknown,
+            Some(&StringValidation {
+                max_length: Some(1),
+                min_length: Some(1),
+                pattern: None,
+            }),
+        )
+        .unwrap();
+        assert!(one.is_valid("🍔"));
+        assert_eq!("🍔".len(), 4);
+        assert_eq!("🍔".chars().count(), 1);
+        // Two code points should now be rejected by maxLength: 1.
+        assert!(!one.is_valid("🍔🍔"));
+
+        // A string of exactly 8 code points, each multi-byte, should pass
+        // an exact-length-8 validator even though its byte length is 24.
+        let eight = StringValidator::new(
+            &Name::Unknown,
+            Some(&StringValidation {
+                max_length: Some(8),
+                min_length: Some(8),
+                pattern: None,
+            }),
+        )
+        .unwrap();
+        let emoji8 = "🍔".repeat(8);
+        assert_eq!(emoji8.len(), 32);
+        assert_eq!(emoji8.chars().count(), 8);
+        assert!(eight.is_valid(&emoji8));
+        assert!(!eight.is_valid("🍔".repeat(7)));
+        assert!(!eight.is_valid("🍔".repeat(9)));
     }
 
     #[test]


### PR DESCRIPTION
## Bug

JSON Schema's `minLength`/`maxLength` (validation spec §6.3, and consistent with RFC 8259's treatment of JSON strings) are defined to count Unicode **code points**, not bytes.

`StringValidator::is_valid` in `typify-impl/src/util.rs` compared against `s.len()`, which in Rust is the *byte* length of a `&str`. This meant a string like `"héllo"` (5 code points, 6 UTF-8 bytes) could be wrongly rejected by a `maxLength: 5` constraint, and multi-byte strings could wrongly pass a `minLength` check they shouldn't.

`StringValidator` is used at schema-processing time (e.g. matching string constants/enum variants against string constraints in `convert.rs`), separately from the generated Rust validation code.

Note: the generated `FromStr`/`TryFrom` validation code in `type_entry.rs` already uses `value.chars().count()` for this, fixed previously in #776 for issue #775. That fix didn't touch `StringValidator`, which has the same class of bug.

## Fix

Switch both the `max_length` and `min_length` comparisons in `StringValidator::is_valid` from `s.as_ref().len()` to `s.as_ref().chars().count()`, matching the approach already used in the generated code.

## Trade-off

`chars().count()` is O(n) versus O(1) for `len()`, but this is negligible on validation paths. Using code points (rather than grapheme clusters) matches what the JSON Schema spec actually specifies.

## Testing

Added unit tests in `typify-impl/src/util.rs` covering multi-byte characters (`"héllo"`) and 4-byte code points (emoji) at exact boundary lengths for both `minLength` and `maxLength`.

`cargo test --workspace --locked` and `cargo fmt --all -- --check` pass.