### PR TITLE
refactor!: remove remaining non-idiomatic TryFrom<&String> trait impls

### DIFF
--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -880,15 +880,6 @@ impl TypeEntry {
                             value.parse()
                         }
                     }
-                    impl ::std::convert::TryFrom<&::std::string::String> for #type_name {
-                        type Error = self::error::ConversionError;
-
-                        fn try_from(value: &::std::string::String) ->
-                            ::std::result::Result<Self, self::error::ConversionError>
-                        {
-                            value.parse()
-                        }
-                    }
                     impl ::std::convert::TryFrom<::std::string::String> for #type_name {
                         type Error = self::error::ConversionError;
 
@@ -941,15 +932,6 @@ impl TypeEntry {
                         type Error = self::error::ConversionError;
 
                         fn try_from(value: &str) ->
-                            ::std::result::Result<Self, self::error::ConversionError>
-                        {
-                            value.parse()
-                        }
-                    }
-                    impl ::std::convert::TryFrom<&::std::string::String> for #type_name {
-                        type Error = self::error::ConversionError;
-
-                        fn try_from(value: &::std::string::String) ->
                             ::std::result::Result<Self, self::error::ConversionError>
                         {
                             value.parse()
@@ -1649,15 +1631,6 @@ impl TypeEntry {
                         type Error = self::error::ConversionError;
 
                         fn try_from(value: &str) ->
-                            ::std::result::Result<Self, self::error::ConversionError>
-                        {
-                            value.parse()
-                        }
-                    }
-                    impl ::std::convert::TryFrom<&::std::string::String> for #type_name {
-                        type Error = self::error::ConversionError;
-
-                        fn try_from(value: &::std::string::String) ->
                             ::std::result::Result<Self, self::error::ConversionError>
                         {
                             value.parse()

--- a/typify-impl/tests/generator.out
+++ b/typify-impl/tests/generator.out
@@ -199,14 +199,6 @@ mod types {
             value.parse()
         }
     }
-    impl ::std::convert::TryFrom<&::std::string::String> for StringEnum {
-        type Error = self::error::ConversionError;
-        fn try_from(
-            value: &::std::string::String,
-        ) -> ::std::result::Result<Self, self::error::ConversionError> {
-            value.parse()
-        }
-    }
     impl ::std::convert::TryFrom<::std::string::String> for StringEnum {
         type Error = self::error::ConversionError;
         fn try_from(

--- a/typify-impl/tests/github.out
+++ b/typify-impl/tests/github.out
@@ -270,14 +270,6 @@ impl ::std::convert::TryFrom<&str> for AlertInstanceState {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AlertInstanceState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AlertInstanceState {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -940,14 +932,6 @@ impl ::std::convert::TryFrom<&str> for AppEventsItem {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AppEventsItem {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AppEventsItem {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -1378,14 +1362,6 @@ impl ::std::convert::TryFrom<&str> for AppPermissionsActions {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsActions {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsActions {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -1447,14 +1423,6 @@ impl ::std::str::FromStr for AppPermissionsAdministration {
 impl ::std::convert::TryFrom<&str> for AppPermissionsAdministration {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsAdministration {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1522,14 +1490,6 @@ impl ::std::convert::TryFrom<&str> for AppPermissionsChecks {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsChecks {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsChecks {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -1591,14 +1551,6 @@ impl ::std::str::FromStr for AppPermissionsContentReferences {
 impl ::std::convert::TryFrom<&str> for AppPermissionsContentReferences {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsContentReferences {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1666,14 +1618,6 @@ impl ::std::convert::TryFrom<&str> for AppPermissionsContents {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsContents {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsContents {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -1735,14 +1679,6 @@ impl ::std::str::FromStr for AppPermissionsDeployments {
 impl ::std::convert::TryFrom<&str> for AppPermissionsDeployments {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsDeployments {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1810,14 +1746,6 @@ impl ::std::convert::TryFrom<&str> for AppPermissionsDiscussions {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsDiscussions {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsDiscussions {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -1879,14 +1807,6 @@ impl ::std::str::FromStr for AppPermissionsEmails {
 impl ::std::convert::TryFrom<&str> for AppPermissionsEmails {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsEmails {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1954,14 +1874,6 @@ impl ::std::convert::TryFrom<&str> for AppPermissionsEnvironments {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsEnvironments {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsEnvironments {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -2023,14 +1935,6 @@ impl ::std::str::FromStr for AppPermissionsIssues {
 impl ::std::convert::TryFrom<&str> for AppPermissionsIssues {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsIssues {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2098,14 +2002,6 @@ impl ::std::convert::TryFrom<&str> for AppPermissionsMembers {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsMembers {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsMembers {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -2167,14 +2063,6 @@ impl ::std::str::FromStr for AppPermissionsMetadata {
 impl ::std::convert::TryFrom<&str> for AppPermissionsMetadata {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsMetadata {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2242,14 +2130,6 @@ impl ::std::convert::TryFrom<&str> for AppPermissionsOrganizationAdministration 
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsOrganizationAdministration {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsOrganizationAdministration {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -2311,14 +2191,6 @@ impl ::std::str::FromStr for AppPermissionsOrganizationHooks {
 impl ::std::convert::TryFrom<&str> for AppPermissionsOrganizationHooks {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsOrganizationHooks {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2386,14 +2258,6 @@ impl ::std::convert::TryFrom<&str> for AppPermissionsOrganizationPackages {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsOrganizationPackages {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsOrganizationPackages {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -2455,14 +2319,6 @@ impl ::std::str::FromStr for AppPermissionsOrganizationPlan {
 impl ::std::convert::TryFrom<&str> for AppPermissionsOrganizationPlan {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsOrganizationPlan {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2530,14 +2386,6 @@ impl ::std::convert::TryFrom<&str> for AppPermissionsOrganizationProjects {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsOrganizationProjects {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsOrganizationProjects {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -2602,14 +2450,6 @@ impl ::std::convert::TryFrom<&str> for AppPermissionsOrganizationSecrets {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsOrganizationSecrets {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsOrganizationSecrets {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -2671,16 +2511,6 @@ impl ::std::str::FromStr for AppPermissionsOrganizationSelfHostedRunners {
 impl ::std::convert::TryFrom<&str> for AppPermissionsOrganizationSelfHostedRunners {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for AppPermissionsOrganizationSelfHostedRunners
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2750,14 +2580,6 @@ impl ::std::convert::TryFrom<&str> for AppPermissionsOrganizationUserBlocking {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsOrganizationUserBlocking {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsOrganizationUserBlocking {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -2819,14 +2641,6 @@ impl ::std::str::FromStr for AppPermissionsPackages {
 impl ::std::convert::TryFrom<&str> for AppPermissionsPackages {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsPackages {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2894,14 +2708,6 @@ impl ::std::convert::TryFrom<&str> for AppPermissionsPages {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsPages {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsPages {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -2963,14 +2769,6 @@ impl ::std::str::FromStr for AppPermissionsPullRequests {
 impl ::std::convert::TryFrom<&str> for AppPermissionsPullRequests {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsPullRequests {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -3038,14 +2836,6 @@ impl ::std::convert::TryFrom<&str> for AppPermissionsRepositoryHooks {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsRepositoryHooks {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsRepositoryHooks {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -3107,14 +2897,6 @@ impl ::std::str::FromStr for AppPermissionsRepositoryProjects {
 impl ::std::convert::TryFrom<&str> for AppPermissionsRepositoryProjects {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsRepositoryProjects {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -3182,14 +2964,6 @@ impl ::std::convert::TryFrom<&str> for AppPermissionsSecretScanningAlerts {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsSecretScanningAlerts {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsSecretScanningAlerts {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -3251,14 +3025,6 @@ impl ::std::str::FromStr for AppPermissionsSecrets {
 impl ::std::convert::TryFrom<&str> for AppPermissionsSecrets {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsSecrets {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -3326,14 +3092,6 @@ impl ::std::convert::TryFrom<&str> for AppPermissionsSecurityEvents {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsSecurityEvents {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsSecurityEvents {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -3395,14 +3153,6 @@ impl ::std::str::FromStr for AppPermissionsSecurityScanningAlert {
 impl ::std::convert::TryFrom<&str> for AppPermissionsSecurityScanningAlert {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsSecurityScanningAlert {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -3470,14 +3220,6 @@ impl ::std::convert::TryFrom<&str> for AppPermissionsSingleFile {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsSingleFile {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsSingleFile {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -3539,14 +3281,6 @@ impl ::std::str::FromStr for AppPermissionsStatuses {
 impl ::std::convert::TryFrom<&str> for AppPermissionsStatuses {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsStatuses {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -3614,14 +3348,6 @@ impl ::std::convert::TryFrom<&str> for AppPermissionsTeamDiscussions {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsTeamDiscussions {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsTeamDiscussions {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -3686,14 +3412,6 @@ impl ::std::convert::TryFrom<&str> for AppPermissionsVulnerabilityAlerts {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsVulnerabilityAlerts {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AppPermissionsVulnerabilityAlerts {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -3755,14 +3473,6 @@ impl ::std::str::FromStr for AppPermissionsWorkflows {
 impl ::std::convert::TryFrom<&str> for AppPermissionsWorkflows {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for AppPermissionsWorkflows {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -3860,14 +3570,6 @@ impl ::std::str::FromStr for AuthorAssociation {
 impl ::std::convert::TryFrom<&str> for AuthorAssociation {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for AuthorAssociation {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -4141,16 +3843,6 @@ impl ::std::convert::TryFrom<&str> for BranchProtectionRuleAllowDeletionsEnforce
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for BranchProtectionRuleAllowDeletionsEnforcementLevel
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for BranchProtectionRuleAllowDeletionsEnforcementLevel
 {
@@ -4219,16 +3911,6 @@ impl ::std::str::FromStr for BranchProtectionRuleAllowForcePushesEnforcementLeve
 impl ::std::convert::TryFrom<&str> for BranchProtectionRuleAllowForcePushesEnforcementLevel {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for BranchProtectionRuleAllowForcePushesEnforcementLevel
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -4348,14 +4030,6 @@ impl ::std::convert::TryFrom<&str> for BranchProtectionRuleCreatedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for BranchProtectionRuleCreatedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for BranchProtectionRuleCreatedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -4467,14 +4141,6 @@ impl ::std::str::FromStr for BranchProtectionRuleDeletedAction {
 impl ::std::convert::TryFrom<&str> for BranchProtectionRuleDeletedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for BranchProtectionRuleDeletedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -4625,14 +4291,6 @@ impl ::std::str::FromStr for BranchProtectionRuleEditedAction {
 impl ::std::convert::TryFrom<&str> for BranchProtectionRuleEditedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for BranchProtectionRuleEditedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -4859,16 +4517,6 @@ impl ::std::convert::TryFrom<&str>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for BranchProtectionRuleLinearHistoryRequirementEnforcementLevel
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for BranchProtectionRuleLinearHistoryRequirementEnforcementLevel
 {
@@ -4937,16 +4585,6 @@ impl ::std::str::FromStr for BranchProtectionRuleMergeQueueEnforcementLevel {
 impl ::std::convert::TryFrom<&str> for BranchProtectionRuleMergeQueueEnforcementLevel {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for BranchProtectionRuleMergeQueueEnforcementLevel
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -5021,16 +4659,6 @@ impl ::std::convert::TryFrom<&str> for BranchProtectionRulePullRequestReviewsEnf
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for BranchProtectionRulePullRequestReviewsEnforcementLevel
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for BranchProtectionRulePullRequestReviewsEnforcementLevel
 {
@@ -5099,16 +4727,6 @@ impl ::std::str::FromStr for BranchProtectionRuleRequiredConversationResolutionL
 impl ::std::convert::TryFrom<&str> for BranchProtectionRuleRequiredConversationResolutionLevel {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for BranchProtectionRuleRequiredConversationResolutionLevel
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -5183,16 +4801,6 @@ impl ::std::convert::TryFrom<&str> for BranchProtectionRuleRequiredDeploymentsEn
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for BranchProtectionRuleRequiredDeploymentsEnforcementLevel
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for BranchProtectionRuleRequiredDeploymentsEnforcementLevel
 {
@@ -5264,16 +4872,6 @@ impl ::std::convert::TryFrom<&str> for BranchProtectionRuleRequiredStatusChecksE
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for BranchProtectionRuleRequiredStatusChecksEnforcementLevel
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for BranchProtectionRuleRequiredStatusChecksEnforcementLevel
 {
@@ -5342,16 +4940,6 @@ impl ::std::str::FromStr for BranchProtectionRuleSignatureRequirementEnforcement
 impl ::std::convert::TryFrom<&str> for BranchProtectionRuleSignatureRequirementEnforcementLevel {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for BranchProtectionRuleSignatureRequirementEnforcementLevel
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -5711,14 +5299,6 @@ impl ::std::str::FromStr for CheckRunCompletedAction {
 impl ::std::convert::TryFrom<&str> for CheckRunCompletedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CheckRunCompletedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -6205,16 +5785,6 @@ impl ::std::convert::TryFrom<&str> for CheckRunCompletedCheckRunCheckSuiteConclu
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for CheckRunCompletedCheckRunCheckSuiteConclusion
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for CheckRunCompletedCheckRunCheckSuiteConclusion
 {
@@ -6283,14 +5853,6 @@ impl ::std::str::FromStr for CheckRunCompletedCheckRunCheckSuiteStatus {
 impl ::std::convert::TryFrom<&str> for CheckRunCompletedCheckRunCheckSuiteStatus {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CheckRunCompletedCheckRunCheckSuiteStatus {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -6386,14 +5948,6 @@ impl ::std::str::FromStr for CheckRunCompletedCheckRunConclusion {
 impl ::std::convert::TryFrom<&str> for CheckRunCompletedCheckRunConclusion {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CheckRunCompletedCheckRunConclusion {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -6508,14 +6062,6 @@ impl ::std::str::FromStr for CheckRunCompletedCheckRunStatus {
 impl ::std::convert::TryFrom<&str> for CheckRunCompletedCheckRunStatus {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CheckRunCompletedCheckRunStatus {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -6910,14 +6456,6 @@ impl ::std::str::FromStr for CheckRunCreatedAction {
 impl ::std::convert::TryFrom<&str> for CheckRunCreatedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CheckRunCreatedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -7409,16 +6947,6 @@ impl ::std::convert::TryFrom<&str> for CheckRunCreatedCheckRunCheckSuiteConclusi
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for CheckRunCreatedCheckRunCheckSuiteConclusion
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for CheckRunCreatedCheckRunCheckSuiteConclusion
 {
@@ -7487,14 +7015,6 @@ impl ::std::str::FromStr for CheckRunCreatedCheckRunCheckSuiteStatus {
 impl ::std::convert::TryFrom<&str> for CheckRunCreatedCheckRunCheckSuiteStatus {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CheckRunCreatedCheckRunCheckSuiteStatus {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -7590,14 +7110,6 @@ impl ::std::str::FromStr for CheckRunCreatedCheckRunConclusion {
 impl ::std::convert::TryFrom<&str> for CheckRunCreatedCheckRunConclusion {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CheckRunCreatedCheckRunConclusion {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -7722,14 +7234,6 @@ impl ::std::str::FromStr for CheckRunCreatedCheckRunStatus {
 impl ::std::convert::TryFrom<&str> for CheckRunCreatedCheckRunStatus {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CheckRunCreatedCheckRunStatus {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -8410,14 +7914,6 @@ impl ::std::convert::TryFrom<&str> for CheckRunRequestedActionAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for CheckRunRequestedActionAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for CheckRunRequestedActionAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -8906,16 +8402,6 @@ impl ::std::convert::TryFrom<&str> for CheckRunRequestedActionCheckRunCheckSuite
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for CheckRunRequestedActionCheckRunCheckSuiteConclusion
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for CheckRunRequestedActionCheckRunCheckSuiteConclusion
 {
@@ -8984,16 +8470,6 @@ impl ::std::str::FromStr for CheckRunRequestedActionCheckRunCheckSuiteStatus {
 impl ::std::convert::TryFrom<&str> for CheckRunRequestedActionCheckRunCheckSuiteStatus {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for CheckRunRequestedActionCheckRunCheckSuiteStatus
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -9091,14 +8567,6 @@ impl ::std::str::FromStr for CheckRunRequestedActionCheckRunConclusion {
 impl ::std::convert::TryFrom<&str> for CheckRunRequestedActionCheckRunConclusion {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CheckRunRequestedActionCheckRunConclusion {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -9223,14 +8691,6 @@ impl ::std::str::FromStr for CheckRunRequestedActionCheckRunStatus {
 impl ::std::convert::TryFrom<&str> for CheckRunRequestedActionCheckRunStatus {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CheckRunRequestedActionCheckRunStatus {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -9614,14 +9074,6 @@ impl ::std::str::FromStr for CheckRunRerequestedAction {
 impl ::std::convert::TryFrom<&str> for CheckRunRerequestedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CheckRunRerequestedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -10096,16 +9548,6 @@ impl ::std::convert::TryFrom<&str> for CheckRunRerequestedCheckRunCheckSuiteConc
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for CheckRunRerequestedCheckRunCheckSuiteConclusion
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for CheckRunRerequestedCheckRunCheckSuiteConclusion
 {
@@ -10164,16 +9606,6 @@ impl ::std::str::FromStr for CheckRunRerequestedCheckRunCheckSuiteStatus {
 impl ::std::convert::TryFrom<&str> for CheckRunRerequestedCheckRunCheckSuiteStatus {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for CheckRunRerequestedCheckRunCheckSuiteStatus
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -10271,14 +9703,6 @@ impl ::std::str::FromStr for CheckRunRerequestedCheckRunConclusion {
 impl ::std::convert::TryFrom<&str> for CheckRunRerequestedCheckRunConclusion {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CheckRunRerequestedCheckRunConclusion {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -10393,14 +9817,6 @@ impl ::std::str::FromStr for CheckRunRerequestedCheckRunStatus {
 impl ::std::convert::TryFrom<&str> for CheckRunRerequestedCheckRunStatus {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CheckRunRerequestedCheckRunStatus {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -10661,14 +10077,6 @@ impl ::std::convert::TryFrom<&str> for CheckSuiteCompletedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for CheckSuiteCompletedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for CheckSuiteCompletedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -10907,14 +10315,6 @@ impl ::std::convert::TryFrom<&str> for CheckSuiteCompletedCheckSuiteConclusion {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for CheckSuiteCompletedCheckSuiteConclusion {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for CheckSuiteCompletedCheckSuiteConclusion {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -10987,14 +10387,6 @@ impl ::std::str::FromStr for CheckSuiteCompletedCheckSuiteStatus {
 impl ::std::convert::TryFrom<&str> for CheckSuiteCompletedCheckSuiteStatus {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CheckSuiteCompletedCheckSuiteStatus {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -11265,14 +10657,6 @@ impl ::std::convert::TryFrom<&str> for CheckSuiteRequestedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for CheckSuiteRequestedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for CheckSuiteRequestedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -11511,14 +10895,6 @@ impl ::std::convert::TryFrom<&str> for CheckSuiteRequestedCheckSuiteConclusion {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for CheckSuiteRequestedCheckSuiteConclusion {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for CheckSuiteRequestedCheckSuiteConclusion {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -11591,14 +10967,6 @@ impl ::std::str::FromStr for CheckSuiteRequestedCheckSuiteStatus {
 impl ::std::convert::TryFrom<&str> for CheckSuiteRequestedCheckSuiteStatus {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CheckSuiteRequestedCheckSuiteStatus {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -11824,14 +11192,6 @@ impl ::std::str::FromStr for CheckSuiteRerequestedAction {
 impl ::std::convert::TryFrom<&str> for CheckSuiteRerequestedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CheckSuiteRerequestedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -12073,14 +11433,6 @@ impl ::std::convert::TryFrom<&str> for CheckSuiteRerequestedCheckSuiteConclusion
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for CheckSuiteRerequestedCheckSuiteConclusion {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for CheckSuiteRerequestedCheckSuiteConclusion {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -12153,14 +11505,6 @@ impl ::std::str::FromStr for CheckSuiteRerequestedCheckSuiteStatus {
 impl ::std::convert::TryFrom<&str> for CheckSuiteRerequestedCheckSuiteStatus {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CheckSuiteRerequestedCheckSuiteStatus {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -12430,14 +11774,6 @@ impl ::std::convert::TryFrom<&str> for CodeScanningAlertAppearedInBranchAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for CodeScanningAlertAppearedInBranchAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for CodeScanningAlertAppearedInBranchAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -12680,16 +12016,6 @@ impl ::std::convert::TryFrom<&str> for CodeScanningAlertAppearedInBranchAlertDis
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for CodeScanningAlertAppearedInBranchAlertDismissedReason
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for CodeScanningAlertAppearedInBranchAlertDismissedReason
 {
@@ -12817,16 +12143,6 @@ impl ::std::convert::TryFrom<&str> for CodeScanningAlertAppearedInBranchAlertRul
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for CodeScanningAlertAppearedInBranchAlertRuleSeverity
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for CodeScanningAlertAppearedInBranchAlertRuleSeverity
 {
@@ -12896,16 +12212,6 @@ impl ::std::str::FromStr for CodeScanningAlertAppearedInBranchAlertState {
 impl ::std::convert::TryFrom<&str> for CodeScanningAlertAppearedInBranchAlertState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for CodeScanningAlertAppearedInBranchAlertState
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -13235,14 +12541,6 @@ impl ::std::convert::TryFrom<&str> for CodeScanningAlertClosedByUserAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for CodeScanningAlertClosedByUserAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for CodeScanningAlertClosedByUserAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -13507,16 +12805,6 @@ impl ::std::convert::TryFrom<&str> for CodeScanningAlertClosedByUserAlertDismiss
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for CodeScanningAlertClosedByUserAlertDismissedReason
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for CodeScanningAlertClosedByUserAlertDismissedReason
 {
@@ -13709,16 +12997,6 @@ impl ::std::convert::TryFrom<&str> for CodeScanningAlertClosedByUserAlertInstanc
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for CodeScanningAlertClosedByUserAlertInstancesItemState
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for CodeScanningAlertClosedByUserAlertInstancesItemState
 {
@@ -13866,16 +13144,6 @@ impl ::std::convert::TryFrom<&str> for CodeScanningAlertClosedByUserAlertRuleSev
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for CodeScanningAlertClosedByUserAlertRuleSeverity
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for CodeScanningAlertClosedByUserAlertRuleSeverity
 {
@@ -13935,14 +13203,6 @@ impl ::std::str::FromStr for CodeScanningAlertClosedByUserAlertState {
 impl ::std::convert::TryFrom<&str> for CodeScanningAlertClosedByUserAlertState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CodeScanningAlertClosedByUserAlertState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -14270,14 +13530,6 @@ impl ::std::str::FromStr for CodeScanningAlertCreatedAction {
 impl ::std::convert::TryFrom<&str> for CodeScanningAlertCreatedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CodeScanningAlertCreatedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -14665,16 +13917,6 @@ impl ::std::convert::TryFrom<&str> for CodeScanningAlertCreatedAlertInstancesIte
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for CodeScanningAlertCreatedAlertInstancesItemState
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for CodeScanningAlertCreatedAlertInstancesItemState
 {
@@ -14822,14 +14064,6 @@ impl ::std::convert::TryFrom<&str> for CodeScanningAlertCreatedAlertRuleSeverity
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for CodeScanningAlertCreatedAlertRuleSeverity {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for CodeScanningAlertCreatedAlertRuleSeverity {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -14892,14 +14126,6 @@ impl ::std::str::FromStr for CodeScanningAlertCreatedAlertState {
 impl ::std::convert::TryFrom<&str> for CodeScanningAlertCreatedAlertState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CodeScanningAlertCreatedAlertState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -15321,14 +14547,6 @@ impl ::std::convert::TryFrom<&str> for CodeScanningAlertFixedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for CodeScanningAlertFixedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for CodeScanningAlertFixedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -15611,16 +14829,6 @@ impl ::std::convert::TryFrom<&str> for CodeScanningAlertFixedAlertDismissedReaso
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for CodeScanningAlertFixedAlertDismissedReason
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for CodeScanningAlertFixedAlertDismissedReason {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -15811,16 +15019,6 @@ impl ::std::convert::TryFrom<&str> for CodeScanningAlertFixedAlertInstancesItemS
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for CodeScanningAlertFixedAlertInstancesItemState
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for CodeScanningAlertFixedAlertInstancesItemState
 {
@@ -15968,14 +15166,6 @@ impl ::std::convert::TryFrom<&str> for CodeScanningAlertFixedAlertRuleSeverity {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for CodeScanningAlertFixedAlertRuleSeverity {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for CodeScanningAlertFixedAlertRuleSeverity {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -16033,14 +15223,6 @@ impl ::std::str::FromStr for CodeScanningAlertFixedAlertState {
 impl ::std::convert::TryFrom<&str> for CodeScanningAlertFixedAlertState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CodeScanningAlertFixedAlertState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -16368,14 +15550,6 @@ impl ::std::str::FromStr for CodeScanningAlertReopenedAction {
 impl ::std::convert::TryFrom<&str> for CodeScanningAlertReopenedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CodeScanningAlertReopenedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -16757,16 +15931,6 @@ impl ::std::convert::TryFrom<&str> for CodeScanningAlertReopenedAlertInstancesIt
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for CodeScanningAlertReopenedAlertInstancesItemState
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for CodeScanningAlertReopenedAlertInstancesItemState
 {
@@ -16914,16 +16078,6 @@ impl ::std::convert::TryFrom<&str> for CodeScanningAlertReopenedAlertRuleSeverit
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for CodeScanningAlertReopenedAlertRuleSeverity
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for CodeScanningAlertReopenedAlertRuleSeverity {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -16991,14 +16145,6 @@ impl ::std::str::FromStr for CodeScanningAlertReopenedAlertState {
 impl ::std::convert::TryFrom<&str> for CodeScanningAlertReopenedAlertState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CodeScanningAlertReopenedAlertState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -17306,14 +16452,6 @@ impl ::std::str::FromStr for CodeScanningAlertReopenedByUserAction {
 impl ::std::convert::TryFrom<&str> for CodeScanningAlertReopenedByUserAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CodeScanningAlertReopenedByUserAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -17675,16 +16813,6 @@ impl ::std::convert::TryFrom<&str> for CodeScanningAlertReopenedByUserAlertInsta
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for CodeScanningAlertReopenedByUserAlertInstancesItemState
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for CodeScanningAlertReopenedByUserAlertInstancesItemState
 {
@@ -17812,16 +16940,6 @@ impl ::std::convert::TryFrom<&str> for CodeScanningAlertReopenedByUserAlertRuleS
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for CodeScanningAlertReopenedByUserAlertRuleSeverity
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for CodeScanningAlertReopenedByUserAlertRuleSeverity
 {
@@ -17881,14 +16999,6 @@ impl ::std::str::FromStr for CodeScanningAlertReopenedByUserAlertState {
 impl ::std::convert::TryFrom<&str> for CodeScanningAlertReopenedByUserAlertState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CodeScanningAlertReopenedByUserAlertState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -18218,14 +17328,6 @@ impl ::std::str::FromStr for CommitCommentCreatedAction {
 impl ::std::convert::TryFrom<&str> for CommitCommentCreatedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CommitCommentCreatedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -18609,14 +17711,6 @@ impl ::std::convert::TryFrom<&str> for ContentReferenceCreatedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ContentReferenceCreatedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ContentReferenceCreatedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -18835,14 +17929,6 @@ impl ::std::convert::TryFrom<&str> for CreateEventRefType {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for CreateEventRefType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for CreateEventRefType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -18973,14 +18059,6 @@ impl ::std::str::FromStr for DeleteEventRefType {
 impl ::std::convert::TryFrom<&str> for DeleteEventRefType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for DeleteEventRefType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -19129,14 +18207,6 @@ impl ::std::str::FromStr for DeployKeyCreatedAction {
 impl ::std::convert::TryFrom<&str> for DeployKeyCreatedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for DeployKeyCreatedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -19341,14 +18411,6 @@ impl ::std::str::FromStr for DeployKeyDeletedAction {
 impl ::std::convert::TryFrom<&str> for DeployKeyDeletedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for DeployKeyDeletedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -19641,14 +18703,6 @@ impl ::std::str::FromStr for DeploymentCreatedAction {
 impl ::std::convert::TryFrom<&str> for DeploymentCreatedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for DeploymentCreatedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -20082,14 +19136,6 @@ impl ::std::str::FromStr for DeploymentStatusCreatedAction {
 impl ::std::convert::TryFrom<&str> for DeploymentStatusCreatedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for DeploymentStatusCreatedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -20754,14 +19800,6 @@ impl ::std::convert::TryFrom<&str> for DiscussionAnsweredAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for DiscussionAnsweredAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for DiscussionAnsweredAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -21136,16 +20174,6 @@ impl ::std::convert::TryFrom<&str> for DiscussionAnsweredDiscussionAnswerChosenB
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DiscussionAnsweredDiscussionAnswerChosenByType
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for DiscussionAnsweredDiscussionAnswerChosenByType
 {
@@ -21282,14 +20310,6 @@ impl ::std::str::FromStr for DiscussionAnsweredDiscussionState {
 impl ::std::convert::TryFrom<&str> for DiscussionAnsweredDiscussionState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for DiscussionAnsweredDiscussionState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -21533,14 +20553,6 @@ impl ::std::str::FromStr for DiscussionCategoryChangedAction {
 impl ::std::convert::TryFrom<&str> for DiscussionCategoryChangedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for DiscussionCategoryChangedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -21924,14 +20936,6 @@ impl ::std::convert::TryFrom<&str> for DiscussionCommentCreatedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for DiscussionCommentCreatedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for DiscussionCommentCreatedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -22185,14 +21189,6 @@ impl ::std::str::FromStr for DiscussionCommentDeletedAction {
 impl ::std::convert::TryFrom<&str> for DiscussionCommentDeletedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for DiscussionCommentDeletedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -22472,14 +21468,6 @@ impl ::std::str::FromStr for DiscussionCommentEditedAction {
 impl ::std::convert::TryFrom<&str> for DiscussionCommentEditedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for DiscussionCommentEditedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -22816,14 +21804,6 @@ impl ::std::convert::TryFrom<&str> for DiscussionCreatedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for DiscussionCreatedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for DiscussionCreatedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -23025,14 +22005,6 @@ impl ::std::convert::TryFrom<&str> for DiscussionCreatedDiscussionState {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for DiscussionCreatedDiscussionState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for DiscussionCreatedDiscussionState {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -23143,14 +22115,6 @@ impl ::std::str::FromStr for DiscussionDeletedAction {
 impl ::std::convert::TryFrom<&str> for DiscussionDeletedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for DiscussionDeletedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -23296,14 +22260,6 @@ impl ::std::str::FromStr for DiscussionEditedAction {
 impl ::std::convert::TryFrom<&str> for DiscussionEditedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for DiscussionEditedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -23658,14 +22614,6 @@ impl ::std::convert::TryFrom<&str> for DiscussionLabeledAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for DiscussionLabeledAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for DiscussionLabeledAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -23802,14 +22750,6 @@ impl ::std::str::FromStr for DiscussionLockedAction {
 impl ::std::convert::TryFrom<&str> for DiscussionLockedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for DiscussionLockedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -23996,14 +22936,6 @@ impl ::std::convert::TryFrom<&str> for DiscussionLockedDiscussionState {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for DiscussionLockedDiscussionState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for DiscussionLockedDiscussionState {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -24117,14 +23049,6 @@ impl ::std::convert::TryFrom<&str> for DiscussionPinnedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for DiscussionPinnedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for DiscussionPinnedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -24191,14 +23115,6 @@ impl ::std::str::FromStr for DiscussionState {
 impl ::std::convert::TryFrom<&str> for DiscussionState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for DiscussionState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -24330,14 +23246,6 @@ impl ::std::str::FromStr for DiscussionTransferredAction {
 impl ::std::convert::TryFrom<&str> for DiscussionTransferredAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for DiscussionTransferredAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -24583,14 +23491,6 @@ impl ::std::convert::TryFrom<&str> for DiscussionUnansweredAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for DiscussionUnansweredAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for DiscussionUnansweredAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -24801,14 +23701,6 @@ impl ::std::convert::TryFrom<&str> for DiscussionUnansweredDiscussionState {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for DiscussionUnansweredDiscussionState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for DiscussionUnansweredDiscussionState {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -25008,14 +23900,6 @@ impl ::std::convert::TryFrom<&str> for DiscussionUnlabeledAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for DiscussionUnlabeledAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for DiscussionUnlabeledAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -25152,14 +24036,6 @@ impl ::std::str::FromStr for DiscussionUnlockedAction {
 impl ::std::convert::TryFrom<&str> for DiscussionUnlockedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for DiscussionUnlockedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -25346,14 +24222,6 @@ impl ::std::convert::TryFrom<&str> for DiscussionUnlockedDiscussionState {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for DiscussionUnlockedDiscussionState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for DiscussionUnlockedDiscussionState {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -25464,14 +24332,6 @@ impl ::std::str::FromStr for DiscussionUnpinnedAction {
 impl ::std::convert::TryFrom<&str> for DiscussionUnpinnedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for DiscussionUnpinnedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -26241,14 +25101,6 @@ impl ::std::convert::TryFrom<&str> for ForkEventForkeeCreatedAt {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ForkEventForkeeCreatedAt {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ForkEventForkeeCreatedAt {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -26472,14 +25324,6 @@ impl ::std::str::FromStr for GithubAppAuthorizationRevokedAction {
 impl ::std::convert::TryFrom<&str> for GithubAppAuthorizationRevokedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for GithubAppAuthorizationRevokedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -26853,14 +25697,6 @@ impl ::std::str::FromStr for GollumEventPagesItemAction {
 impl ::std::convert::TryFrom<&str> for GollumEventPagesItemAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for GollumEventPagesItemAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -27470,14 +26306,6 @@ impl ::std::convert::TryFrom<&str> for InstallationCreatedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationCreatedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for InstallationCreatedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -27525,14 +26353,6 @@ impl ::std::str::FromStr for InstallationCreatedAt {
 impl ::std::convert::TryFrom<&str> for InstallationCreatedAt {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationCreatedAt {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -27742,14 +26562,6 @@ impl ::std::str::FromStr for InstallationDeletedAction {
 impl ::std::convert::TryFrom<&str> for InstallationDeletedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationDeletedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -28142,14 +26954,6 @@ impl ::std::convert::TryFrom<&str> for InstallationEventsItem {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationEventsItem {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for InstallationEventsItem {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -28322,14 +27126,6 @@ impl ::std::str::FromStr for InstallationNewPermissionsAcceptedAction {
 impl ::std::convert::TryFrom<&str> for InstallationNewPermissionsAcceptedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationNewPermissionsAcceptedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -28824,14 +27620,6 @@ impl ::std::convert::TryFrom<&str> for InstallationPermissionsActions {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationPermissionsActions {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsActions {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -28893,14 +27681,6 @@ impl ::std::str::FromStr for InstallationPermissionsAdministration {
 impl ::std::convert::TryFrom<&str> for InstallationPermissionsAdministration {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationPermissionsAdministration {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -28968,14 +27748,6 @@ impl ::std::convert::TryFrom<&str> for InstallationPermissionsChecks {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationPermissionsChecks {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsChecks {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -29037,14 +27809,6 @@ impl ::std::str::FromStr for InstallationPermissionsContentReferences {
 impl ::std::convert::TryFrom<&str> for InstallationPermissionsContentReferences {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationPermissionsContentReferences {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -29112,14 +27876,6 @@ impl ::std::convert::TryFrom<&str> for InstallationPermissionsContents {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationPermissionsContents {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsContents {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -29181,14 +27937,6 @@ impl ::std::str::FromStr for InstallationPermissionsDeployments {
 impl ::std::convert::TryFrom<&str> for InstallationPermissionsDeployments {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationPermissionsDeployments {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -29256,14 +28004,6 @@ impl ::std::convert::TryFrom<&str> for InstallationPermissionsDiscussions {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationPermissionsDiscussions {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsDiscussions {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -29325,14 +28065,6 @@ impl ::std::str::FromStr for InstallationPermissionsEmails {
 impl ::std::convert::TryFrom<&str> for InstallationPermissionsEmails {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationPermissionsEmails {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -29400,14 +28132,6 @@ impl ::std::convert::TryFrom<&str> for InstallationPermissionsEnvironments {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationPermissionsEnvironments {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsEnvironments {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -29469,14 +28193,6 @@ impl ::std::str::FromStr for InstallationPermissionsIssues {
 impl ::std::convert::TryFrom<&str> for InstallationPermissionsIssues {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationPermissionsIssues {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -29544,14 +28260,6 @@ impl ::std::convert::TryFrom<&str> for InstallationPermissionsMembers {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationPermissionsMembers {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsMembers {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -29616,14 +28324,6 @@ impl ::std::convert::TryFrom<&str> for InstallationPermissionsMetadata {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationPermissionsMetadata {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsMetadata {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -29685,16 +28385,6 @@ impl ::std::str::FromStr for InstallationPermissionsOrganizationAdministration {
 impl ::std::convert::TryFrom<&str> for InstallationPermissionsOrganizationAdministration {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationPermissionsOrganizationAdministration
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -29764,14 +28454,6 @@ impl ::std::convert::TryFrom<&str> for InstallationPermissionsOrganizationEvents
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationPermissionsOrganizationEvents {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsOrganizationEvents {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -29836,14 +28518,6 @@ impl ::std::convert::TryFrom<&str> for InstallationPermissionsOrganizationHooks 
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationPermissionsOrganizationHooks {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsOrganizationHooks {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -29905,16 +28579,6 @@ impl ::std::str::FromStr for InstallationPermissionsOrganizationPackages {
 impl ::std::convert::TryFrom<&str> for InstallationPermissionsOrganizationPackages {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationPermissionsOrganizationPackages
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -29984,14 +28648,6 @@ impl ::std::convert::TryFrom<&str> for InstallationPermissionsOrganizationPlan {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationPermissionsOrganizationPlan {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsOrganizationPlan {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -30053,16 +28709,6 @@ impl ::std::str::FromStr for InstallationPermissionsOrganizationProjects {
 impl ::std::convert::TryFrom<&str> for InstallationPermissionsOrganizationProjects {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationPermissionsOrganizationProjects
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -30132,16 +28778,6 @@ impl ::std::convert::TryFrom<&str> for InstallationPermissionsOrganizationSecret
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationPermissionsOrganizationSecrets
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsOrganizationSecrets {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -30203,16 +28839,6 @@ impl ::std::str::FromStr for InstallationPermissionsOrganizationSelfHostedRunner
 impl ::std::convert::TryFrom<&str> for InstallationPermissionsOrganizationSelfHostedRunners {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationPermissionsOrganizationSelfHostedRunners
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -30282,16 +28908,6 @@ impl ::std::convert::TryFrom<&str> for InstallationPermissionsOrganizationUserBl
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationPermissionsOrganizationUserBlocking
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationPermissionsOrganizationUserBlocking
 {
@@ -30355,14 +28971,6 @@ impl ::std::str::FromStr for InstallationPermissionsPackages {
 impl ::std::convert::TryFrom<&str> for InstallationPermissionsPackages {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationPermissionsPackages {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -30430,14 +29038,6 @@ impl ::std::convert::TryFrom<&str> for InstallationPermissionsPages {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationPermissionsPages {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsPages {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -30499,14 +29099,6 @@ impl ::std::str::FromStr for InstallationPermissionsPullRequests {
 impl ::std::convert::TryFrom<&str> for InstallationPermissionsPullRequests {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationPermissionsPullRequests {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -30574,14 +29166,6 @@ impl ::std::convert::TryFrom<&str> for InstallationPermissionsRepositoryHooks {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationPermissionsRepositoryHooks {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsRepositoryHooks {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -30646,14 +29230,6 @@ impl ::std::convert::TryFrom<&str> for InstallationPermissionsRepositoryProjects
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationPermissionsRepositoryProjects {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsRepositoryProjects {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -30715,16 +29291,6 @@ impl ::std::str::FromStr for InstallationPermissionsSecretScanningAlerts {
 impl ::std::convert::TryFrom<&str> for InstallationPermissionsSecretScanningAlerts {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationPermissionsSecretScanningAlerts
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -30794,14 +29360,6 @@ impl ::std::convert::TryFrom<&str> for InstallationPermissionsSecrets {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationPermissionsSecrets {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsSecrets {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -30866,14 +29424,6 @@ impl ::std::convert::TryFrom<&str> for InstallationPermissionsSecurityEvents {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationPermissionsSecurityEvents {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsSecurityEvents {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -30935,16 +29485,6 @@ impl ::std::str::FromStr for InstallationPermissionsSecurityScanningAlert {
 impl ::std::convert::TryFrom<&str> for InstallationPermissionsSecurityScanningAlert {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationPermissionsSecurityScanningAlert
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -31014,14 +29554,6 @@ impl ::std::convert::TryFrom<&str> for InstallationPermissionsSingleFile {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationPermissionsSingleFile {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsSingleFile {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -31083,14 +29615,6 @@ impl ::std::str::FromStr for InstallationPermissionsStatuses {
 impl ::std::convert::TryFrom<&str> for InstallationPermissionsStatuses {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationPermissionsStatuses {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -31158,14 +29682,6 @@ impl ::std::convert::TryFrom<&str> for InstallationPermissionsTeamDiscussions {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationPermissionsTeamDiscussions {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsTeamDiscussions {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -31230,16 +29746,6 @@ impl ::std::convert::TryFrom<&str> for InstallationPermissionsVulnerabilityAlert
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationPermissionsVulnerabilityAlerts
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for InstallationPermissionsVulnerabilityAlerts {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -31301,14 +29807,6 @@ impl ::std::str::FromStr for InstallationPermissionsWorkflows {
 impl ::std::convert::TryFrom<&str> for InstallationPermissionsWorkflows {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationPermissionsWorkflows {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -31503,14 +30001,6 @@ impl ::std::convert::TryFrom<&str> for InstallationRepositoriesAddedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationRepositoriesAddedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for InstallationRepositoriesAddedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -31682,16 +30172,6 @@ impl ::std::str::FromStr for InstallationRepositoriesAddedRepositorySelection {
 impl ::std::convert::TryFrom<&str> for InstallationRepositoriesAddedRepositorySelection {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationRepositoriesAddedRepositorySelection
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -31929,14 +30409,6 @@ impl ::std::convert::TryFrom<&str> for InstallationRepositoriesRemovedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationRepositoriesRemovedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for InstallationRepositoriesRemovedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -32102,16 +30574,6 @@ impl ::std::convert::TryFrom<&str> for InstallationRepositoriesRemovedRepository
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationRepositoriesRemovedRepositorySelection
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationRepositoriesRemovedRepositorySelection
 {
@@ -32176,14 +30638,6 @@ impl ::std::str::FromStr for InstallationRepositorySelection {
 impl ::std::convert::TryFrom<&str> for InstallationRepositorySelection {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationRepositorySelection {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -32349,14 +30803,6 @@ impl ::std::convert::TryFrom<&str> for InstallationSuspendAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationSuspendAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for InstallationSuspendAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -32464,14 +30910,6 @@ impl ::std::str::FromStr for InstallationSuspendInstallationCreatedAt {
 impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationCreatedAt {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationSuspendInstallationCreatedAt {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -32771,14 +31209,6 @@ impl ::std::str::FromStr for InstallationSuspendInstallationEventsItem {
 impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationEventsItem {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationSuspendInstallationEventsItem {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -33239,16 +31669,6 @@ impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationPermission
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsActions
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationSuspendInstallationPermissionsActions
 {
@@ -33312,16 +31732,6 @@ impl ::std::str::FromStr for InstallationSuspendInstallationPermissionsAdministr
 impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsAdministration {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsAdministration
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -33391,16 +31801,6 @@ impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationPermission
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsChecks
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationSuspendInstallationPermissionsChecks
 {
@@ -33464,16 +31864,6 @@ impl ::std::str::FromStr for InstallationSuspendInstallationPermissionsContentRe
 impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsContentReferences {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsContentReferences
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -33543,16 +31933,6 @@ impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationPermission
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsContents
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationSuspendInstallationPermissionsContents
 {
@@ -33616,16 +31996,6 @@ impl ::std::str::FromStr for InstallationSuspendInstallationPermissionsDeploymen
 impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsDeployments {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsDeployments
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -33695,16 +32065,6 @@ impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationPermission
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsDiscussions
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationSuspendInstallationPermissionsDiscussions
 {
@@ -33768,16 +32128,6 @@ impl ::std::str::FromStr for InstallationSuspendInstallationPermissionsEmails {
 impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsEmails {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsEmails
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -33847,16 +32197,6 @@ impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationPermission
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsEnvironments
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationSuspendInstallationPermissionsEnvironments
 {
@@ -33920,16 +32260,6 @@ impl ::std::str::FromStr for InstallationSuspendInstallationPermissionsIssues {
 impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsIssues {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsIssues
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -33999,16 +32329,6 @@ impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationPermission
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsMembers
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationSuspendInstallationPermissionsMembers
 {
@@ -34072,16 +32392,6 @@ impl ::std::str::FromStr for InstallationSuspendInstallationPermissionsMetadata 
 impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsMetadata {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsMetadata
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -34153,16 +32463,6 @@ impl ::std::convert::TryFrom<&str>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsOrganizationAdministration
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationSuspendInstallationPermissionsOrganizationAdministration
 {
@@ -34231,16 +32531,6 @@ impl ::std::convert::TryFrom<&str>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsOrganizationEvents
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationSuspendInstallationPermissionsOrganizationEvents
 {
@@ -34304,16 +32594,6 @@ impl ::std::str::FromStr for InstallationSuspendInstallationPermissionsOrganizat
 impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsOrganizationHooks {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsOrganizationHooks
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -34385,16 +32665,6 @@ impl ::std::convert::TryFrom<&str>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsOrganizationPackages
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationSuspendInstallationPermissionsOrganizationPackages
 {
@@ -34458,16 +32728,6 @@ impl ::std::str::FromStr for InstallationSuspendInstallationPermissionsOrganizat
 impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsOrganizationPlan {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsOrganizationPlan
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -34539,16 +32799,6 @@ impl ::std::convert::TryFrom<&str>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsOrganizationProjects
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationSuspendInstallationPermissionsOrganizationProjects
 {
@@ -34614,16 +32864,6 @@ impl ::std::convert::TryFrom<&str>
 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsOrganizationSecrets
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -34699,16 +32939,6 @@ impl ::std::convert::TryFrom<&str>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunners
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunners
 {
@@ -34774,16 +33004,6 @@ impl ::std::convert::TryFrom<&str>
 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsOrganizationUserBlocking
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -34853,16 +33073,6 @@ impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationPermission
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsPackages
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationSuspendInstallationPermissionsPackages
 {
@@ -34926,16 +33136,6 @@ impl ::std::str::FromStr for InstallationSuspendInstallationPermissionsPages {
 impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsPages {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsPages
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -35005,16 +33205,6 @@ impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationPermission
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsPullRequests
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationSuspendInstallationPermissionsPullRequests
 {
@@ -35078,16 +33268,6 @@ impl ::std::str::FromStr for InstallationSuspendInstallationPermissionsRepositor
 impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsRepositoryHooks {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsRepositoryHooks
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -35159,16 +33339,6 @@ impl ::std::convert::TryFrom<&str>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsRepositoryProjects
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationSuspendInstallationPermissionsRepositoryProjects
 {
@@ -35234,16 +33404,6 @@ impl ::std::convert::TryFrom<&str>
 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsSecretScanningAlerts
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -35313,16 +33473,6 @@ impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationPermission
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsSecrets
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationSuspendInstallationPermissionsSecrets
 {
@@ -35386,16 +33536,6 @@ impl ::std::str::FromStr for InstallationSuspendInstallationPermissionsSecurityE
 impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsSecurityEvents {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsSecurityEvents
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -35467,16 +33607,6 @@ impl ::std::convert::TryFrom<&str>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsSecurityScanningAlert
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationSuspendInstallationPermissionsSecurityScanningAlert
 {
@@ -35540,16 +33670,6 @@ impl ::std::str::FromStr for InstallationSuspendInstallationPermissionsSingleFil
 impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsSingleFile {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsSingleFile
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -35619,16 +33739,6 @@ impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationPermission
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsStatuses
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationSuspendInstallationPermissionsStatuses
 {
@@ -35692,16 +33802,6 @@ impl ::std::str::FromStr for InstallationSuspendInstallationPermissionsTeamDiscu
 impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsTeamDiscussions {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsTeamDiscussions
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -35773,16 +33873,6 @@ impl ::std::convert::TryFrom<&str>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsVulnerabilityAlerts
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationSuspendInstallationPermissionsVulnerabilityAlerts
 {
@@ -35846,16 +33936,6 @@ impl ::std::str::FromStr for InstallationSuspendInstallationPermissionsWorkflows
 impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationPermissionsWorkflows {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationPermissionsWorkflows
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -35923,16 +34003,6 @@ impl ::std::str::FromStr for InstallationSuspendInstallationRepositorySelection 
 impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationRepositorySelection {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationRepositorySelection
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -36156,16 +34226,6 @@ impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationSuspendedB
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationSuspendInstallationSuspendedByType
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationSuspendInstallationSuspendedByType
 {
@@ -36230,14 +34290,6 @@ impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationTargetType
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationSuspendInstallationTargetType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for InstallationSuspendInstallationTargetType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -36285,14 +34337,6 @@ impl ::std::str::FromStr for InstallationSuspendInstallationUpdatedAt {
 impl ::std::convert::TryFrom<&str> for InstallationSuspendInstallationUpdatedAt {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationSuspendInstallationUpdatedAt {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -36425,14 +34469,6 @@ impl ::std::str::FromStr for InstallationTargetType {
 impl ::std::convert::TryFrom<&str> for InstallationTargetType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationTargetType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -36597,14 +34633,6 @@ impl ::std::convert::TryFrom<&str> for InstallationUnsuspendAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationUnsuspendAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for InstallationUnsuspendAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -36711,16 +34739,6 @@ impl ::std::str::FromStr for InstallationUnsuspendInstallationCreatedAt {
 impl ::std::convert::TryFrom<&str> for InstallationUnsuspendInstallationCreatedAt {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationCreatedAt
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -37020,16 +35038,6 @@ impl ::std::str::FromStr for InstallationUnsuspendInstallationEventsItem {
 impl ::std::convert::TryFrom<&str> for InstallationUnsuspendInstallationEventsItem {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationEventsItem
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -37494,16 +35502,6 @@ impl ::std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissi
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsActions
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationUnsuspendInstallationPermissionsActions
 {
@@ -37570,16 +35568,6 @@ impl ::std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissi
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsAdministration
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationUnsuspendInstallationPermissionsAdministration
 {
@@ -37643,16 +35631,6 @@ impl ::std::str::FromStr for InstallationUnsuspendInstallationPermissionsChecks 
 impl ::std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsChecks {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsChecks
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -37724,16 +35702,6 @@ impl ::std::convert::TryFrom<&str>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsContentReferences
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationUnsuspendInstallationPermissionsContentReferences
 {
@@ -37797,16 +35765,6 @@ impl ::std::str::FromStr for InstallationUnsuspendInstallationPermissionsContent
 impl ::std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsContents {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsContents
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -37876,16 +35834,6 @@ impl ::std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissi
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsDeployments
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationUnsuspendInstallationPermissionsDeployments
 {
@@ -37949,16 +35897,6 @@ impl ::std::str::FromStr for InstallationUnsuspendInstallationPermissionsDiscuss
 impl ::std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsDiscussions {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsDiscussions
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -38028,16 +35966,6 @@ impl ::std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissi
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsEmails
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationUnsuspendInstallationPermissionsEmails
 {
@@ -38101,16 +36029,6 @@ impl ::std::str::FromStr for InstallationUnsuspendInstallationPermissionsEnviron
 impl ::std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsEnvironments {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsEnvironments
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -38180,16 +36098,6 @@ impl ::std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissi
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsIssues
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationUnsuspendInstallationPermissionsIssues
 {
@@ -38256,16 +36164,6 @@ impl ::std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissi
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsMembers
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationUnsuspendInstallationPermissionsMembers
 {
@@ -38329,16 +36227,6 @@ impl ::std::str::FromStr for InstallationUnsuspendInstallationPermissionsMetadat
 impl ::std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsMetadata {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsMetadata
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -38414,16 +36302,6 @@ impl ::std::convert::TryFrom<&str>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsOrganizationAdministration
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationUnsuspendInstallationPermissionsOrganizationAdministration
 {
@@ -38489,16 +36367,6 @@ impl ::std::convert::TryFrom<&str>
 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsOrganizationEvents
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -38570,16 +36438,6 @@ impl ::std::convert::TryFrom<&str>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsOrganizationHooks
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationUnsuspendInstallationPermissionsOrganizationHooks
 {
@@ -38645,16 +36503,6 @@ impl ::std::convert::TryFrom<&str>
 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsOrganizationPackages
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -38726,16 +36574,6 @@ impl ::std::convert::TryFrom<&str>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsOrganizationPlan
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationUnsuspendInstallationPermissionsOrganizationPlan
 {
@@ -38804,16 +36642,6 @@ impl ::std::convert::TryFrom<&str>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsOrganizationProjects
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationUnsuspendInstallationPermissionsOrganizationProjects
 {
@@ -38879,16 +36707,6 @@ impl ::std::convert::TryFrom<&str>
 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsOrganizationSecrets
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -38964,16 +36782,6 @@ impl ::std::convert::TryFrom<&str>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRunners
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRunners
 {
@@ -39039,16 +36847,6 @@ impl ::std::convert::TryFrom<&str>
 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -39118,16 +36916,6 @@ impl ::std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissi
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsPackages
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationUnsuspendInstallationPermissionsPackages
 {
@@ -39191,16 +36979,6 @@ impl ::std::str::FromStr for InstallationUnsuspendInstallationPermissionsPages {
 impl ::std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsPages {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsPages
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -39270,16 +37048,6 @@ impl ::std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissi
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsPullRequests
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationUnsuspendInstallationPermissionsPullRequests
 {
@@ -39343,16 +37111,6 @@ impl ::std::str::FromStr for InstallationUnsuspendInstallationPermissionsReposit
 impl ::std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsRepositoryHooks {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsRepositoryHooks
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -39424,16 +37182,6 @@ impl ::std::convert::TryFrom<&str>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsRepositoryProjects
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationUnsuspendInstallationPermissionsRepositoryProjects
 {
@@ -39499,16 +37247,6 @@ impl ::std::convert::TryFrom<&str>
 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsSecretScanningAlerts
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -39578,16 +37316,6 @@ impl ::std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissi
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsSecrets
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationUnsuspendInstallationPermissionsSecrets
 {
@@ -39651,16 +37379,6 @@ impl ::std::str::FromStr for InstallationUnsuspendInstallationPermissionsSecurit
 impl ::std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsSecurityEvents {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsSecurityEvents
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -39732,16 +37450,6 @@ impl ::std::convert::TryFrom<&str>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsSecurityScanningAlert
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationUnsuspendInstallationPermissionsSecurityScanningAlert
 {
@@ -39805,16 +37513,6 @@ impl ::std::str::FromStr for InstallationUnsuspendInstallationPermissionsSingleF
 impl ::std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsSingleFile {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsSingleFile
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -39884,16 +37582,6 @@ impl ::std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissi
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsStatuses
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationUnsuspendInstallationPermissionsStatuses
 {
@@ -39957,16 +37645,6 @@ impl ::std::str::FromStr for InstallationUnsuspendInstallationPermissionsTeamDis
 impl ::std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsTeamDiscussions {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsTeamDiscussions
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -40038,16 +37716,6 @@ impl ::std::convert::TryFrom<&str>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts
 {
@@ -40111,16 +37779,6 @@ impl ::std::str::FromStr for InstallationUnsuspendInstallationPermissionsWorkflo
 impl ::std::convert::TryFrom<&str> for InstallationUnsuspendInstallationPermissionsWorkflows {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationPermissionsWorkflows
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -40191,16 +37849,6 @@ impl ::std::convert::TryFrom<&str> for InstallationUnsuspendInstallationReposito
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationRepositorySelection
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationUnsuspendInstallationRepositorySelection
 {
@@ -40265,16 +37913,6 @@ impl ::std::convert::TryFrom<&str> for InstallationUnsuspendInstallationTargetTy
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationTargetType
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for InstallationUnsuspendInstallationTargetType
 {
@@ -40324,16 +37962,6 @@ impl ::std::str::FromStr for InstallationUnsuspendInstallationUpdatedAt {
 impl ::std::convert::TryFrom<&str> for InstallationUnsuspendInstallationUpdatedAt {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for InstallationUnsuspendInstallationUpdatedAt
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -40454,14 +38082,6 @@ impl ::std::str::FromStr for InstallationUpdatedAt {
 impl ::std::convert::TryFrom<&str> for InstallationUpdatedAt {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for InstallationUpdatedAt {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -40792,14 +38412,6 @@ impl ::std::convert::TryFrom<&str> for IssueActiveLockReason {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for IssueActiveLockReason {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for IssueActiveLockReason {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -41085,14 +38697,6 @@ impl ::std::convert::TryFrom<&str> for IssueCommentCreatedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for IssueCommentCreatedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for IssueCommentCreatedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -41284,14 +38888,6 @@ impl ::std::convert::TryFrom<&str> for IssueCommentCreatedIssueActiveLockReason 
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for IssueCommentCreatedIssueActiveLockReason {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for IssueCommentCreatedIssueActiveLockReason {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -41414,14 +39010,6 @@ impl ::std::convert::TryFrom<&str> for IssueCommentCreatedIssueAssigneeType {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for IssueCommentCreatedIssueAssigneeType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for IssueCommentCreatedIssueAssigneeType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -41526,14 +39114,6 @@ impl ::std::str::FromStr for IssueCommentCreatedIssueState {
 impl ::std::convert::TryFrom<&str> for IssueCommentCreatedIssueState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IssueCommentCreatedIssueState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -41724,14 +39304,6 @@ impl ::std::str::FromStr for IssueCommentDeletedAction {
 impl ::std::convert::TryFrom<&str> for IssueCommentDeletedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IssueCommentDeletedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -41926,14 +39498,6 @@ impl ::std::convert::TryFrom<&str> for IssueCommentDeletedIssueActiveLockReason 
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for IssueCommentDeletedIssueActiveLockReason {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for IssueCommentDeletedIssueActiveLockReason {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -42056,14 +39620,6 @@ impl ::std::convert::TryFrom<&str> for IssueCommentDeletedIssueAssigneeType {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for IssueCommentDeletedIssueAssigneeType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for IssueCommentDeletedIssueAssigneeType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -42168,14 +39724,6 @@ impl ::std::str::FromStr for IssueCommentDeletedIssueState {
 impl ::std::convert::TryFrom<&str> for IssueCommentDeletedIssueState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IssueCommentDeletedIssueState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -42388,14 +39936,6 @@ impl ::std::str::FromStr for IssueCommentEditedAction {
 impl ::std::convert::TryFrom<&str> for IssueCommentEditedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IssueCommentEditedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -42656,14 +40196,6 @@ impl ::std::convert::TryFrom<&str> for IssueCommentEditedIssueActiveLockReason {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for IssueCommentEditedIssueActiveLockReason {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for IssueCommentEditedIssueActiveLockReason {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -42786,14 +40318,6 @@ impl ::std::convert::TryFrom<&str> for IssueCommentEditedIssueAssigneeType {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for IssueCommentEditedIssueAssigneeType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for IssueCommentEditedIssueAssigneeType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -42898,14 +40422,6 @@ impl ::std::str::FromStr for IssueCommentEditedIssueState {
 impl ::std::convert::TryFrom<&str> for IssueCommentEditedIssueState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IssueCommentEditedIssueState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -43067,14 +40583,6 @@ impl ::std::convert::TryFrom<&str> for IssueState {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for IssueState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for IssueState {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -43203,14 +40711,6 @@ impl ::std::str::FromStr for IssuesAssignedAction {
 impl ::std::convert::TryFrom<&str> for IssuesAssignedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesAssignedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -43351,14 +40851,6 @@ impl ::std::str::FromStr for IssuesClosedAction {
 impl ::std::convert::TryFrom<&str> for IssuesClosedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesClosedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -43508,14 +41000,6 @@ impl ::std::convert::TryFrom<&str> for IssuesClosedIssueActiveLockReason {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesClosedIssueActiveLockReason {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for IssuesClosedIssueActiveLockReason {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -43623,14 +41107,6 @@ impl ::std::str::FromStr for IssuesClosedIssueState {
 impl ::std::convert::TryFrom<&str> for IssuesClosedIssueState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesClosedIssueState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -43744,14 +41220,6 @@ impl ::std::str::FromStr for IssuesDeletedAction {
 impl ::std::convert::TryFrom<&str> for IssuesDeletedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesDeletedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -43886,14 +41354,6 @@ impl ::std::str::FromStr for IssuesDemilestonedAction {
 impl ::std::convert::TryFrom<&str> for IssuesDemilestonedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesDemilestonedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -44037,14 +41497,6 @@ impl ::std::convert::TryFrom<&str> for IssuesDemilestonedIssueActiveLockReason {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesDemilestonedIssueActiveLockReason {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for IssuesDemilestonedIssueActiveLockReason {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -44158,14 +41610,6 @@ impl ::std::str::FromStr for IssuesDemilestonedIssueState {
 impl ::std::convert::TryFrom<&str> for IssuesDemilestonedIssueState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesDemilestonedIssueState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -44319,14 +41763,6 @@ impl ::std::str::FromStr for IssuesEditedAction {
 impl ::std::convert::TryFrom<&str> for IssuesEditedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesEditedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -44717,14 +42153,6 @@ impl ::std::convert::TryFrom<&str> for IssuesLabeledAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesLabeledAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for IssuesLabeledAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -44868,14 +42296,6 @@ impl ::std::str::FromStr for IssuesLockedAction {
 impl ::std::convert::TryFrom<&str> for IssuesLockedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesLockedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -45035,14 +42455,6 @@ impl ::std::convert::TryFrom<&str> for IssuesLockedIssueActiveLockReason {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesLockedIssueActiveLockReason {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for IssuesLockedIssueActiveLockReason {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -45156,14 +42568,6 @@ impl ::std::str::FromStr for IssuesLockedIssueState {
 impl ::std::convert::TryFrom<&str> for IssuesLockedIssueState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesLockedIssueState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -45298,14 +42702,6 @@ impl ::std::str::FromStr for IssuesMilestonedAction {
 impl ::std::convert::TryFrom<&str> for IssuesMilestonedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesMilestonedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -45446,14 +42842,6 @@ impl ::std::str::FromStr for IssuesMilestonedIssueActiveLockReason {
 impl ::std::convert::TryFrom<&str> for IssuesMilestonedIssueActiveLockReason {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesMilestonedIssueActiveLockReason {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -45655,14 +43043,6 @@ impl ::std::convert::TryFrom<&str> for IssuesMilestonedIssueMilestoneState {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesMilestonedIssueMilestoneState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for IssuesMilestonedIssueMilestoneState {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -45776,14 +43156,6 @@ impl ::std::str::FromStr for IssuesMilestonedIssueState {
 impl ::std::convert::TryFrom<&str> for IssuesMilestonedIssueState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesMilestonedIssueState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -45938,14 +43310,6 @@ impl ::std::str::FromStr for IssuesOpenedAction {
 impl ::std::convert::TryFrom<&str> for IssuesOpenedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesOpenedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -46123,14 +43487,6 @@ impl ::std::convert::TryFrom<&str> for IssuesOpenedIssueActiveLockReason {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesOpenedIssueActiveLockReason {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for IssuesOpenedIssueActiveLockReason {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -46238,14 +43594,6 @@ impl ::std::str::FromStr for IssuesOpenedIssueState {
 impl ::std::convert::TryFrom<&str> for IssuesOpenedIssueState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesOpenedIssueState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -46359,14 +43707,6 @@ impl ::std::str::FromStr for IssuesPinnedAction {
 impl ::std::convert::TryFrom<&str> for IssuesPinnedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesPinnedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -46499,14 +43839,6 @@ impl ::std::str::FromStr for IssuesReopenedAction {
 impl ::std::convert::TryFrom<&str> for IssuesReopenedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesReopenedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -46651,14 +43983,6 @@ impl ::std::convert::TryFrom<&str> for IssuesReopenedIssueActiveLockReason {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesReopenedIssueActiveLockReason {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for IssuesReopenedIssueActiveLockReason {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -46766,14 +44090,6 @@ impl ::std::str::FromStr for IssuesReopenedIssueState {
 impl ::std::convert::TryFrom<&str> for IssuesReopenedIssueState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesReopenedIssueState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -46905,14 +44221,6 @@ impl ::std::str::FromStr for IssuesTransferredAction {
 impl ::std::convert::TryFrom<&str> for IssuesTransferredAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesTransferredAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -47075,14 +44383,6 @@ impl ::std::convert::TryFrom<&str> for IssuesUnassignedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesUnassignedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for IssuesUnassignedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -47200,14 +44500,6 @@ impl ::std::str::FromStr for IssuesUnlabeledAction {
 impl ::std::convert::TryFrom<&str> for IssuesUnlabeledAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesUnlabeledAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -47344,14 +44636,6 @@ impl ::std::str::FromStr for IssuesUnlockedAction {
 impl ::std::convert::TryFrom<&str> for IssuesUnlockedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesUnlockedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -47589,14 +44873,6 @@ impl ::std::convert::TryFrom<&str> for IssuesUnlockedIssueState {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesUnlockedIssueState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for IssuesUnlockedIssueState {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -47707,14 +44983,6 @@ impl ::std::str::FromStr for IssuesUnpinnedAction {
 impl ::std::convert::TryFrom<&str> for IssuesUnpinnedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IssuesUnpinnedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -47899,14 +45167,6 @@ impl ::std::convert::TryFrom<&str> for LabelCreatedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LabelCreatedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LabelCreatedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -48019,14 +45279,6 @@ impl ::std::str::FromStr for LabelDeletedAction {
 impl ::std::convert::TryFrom<&str> for LabelDeletedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LabelDeletedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -48190,14 +45442,6 @@ impl ::std::str::FromStr for LabelEditedAction {
 impl ::std::convert::TryFrom<&str> for LabelEditedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LabelEditedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -48856,14 +46100,6 @@ impl ::std::convert::TryFrom<&str> for MarketplacePurchaseCancelledAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for MarketplacePurchaseCancelledAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for MarketplacePurchaseCancelledAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -49348,14 +46584,6 @@ impl ::std::str::FromStr for MarketplacePurchaseChangedAction {
 impl ::std::convert::TryFrom<&str> for MarketplacePurchaseChangedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for MarketplacePurchaseChangedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -49906,14 +47134,6 @@ impl ::std::convert::TryFrom<&str> for MarketplacePurchasePendingChangeAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for MarketplacePurchasePendingChangeAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for MarketplacePurchasePendingChangeAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -50124,16 +47344,6 @@ impl ::std::str::FromStr for MarketplacePurchasePendingChangeCancelledAction {
 impl ::std::convert::TryFrom<&str> for MarketplacePurchasePendingChangeCancelledAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for MarketplacePurchasePendingChangeCancelledAction
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -50970,14 +48180,6 @@ impl ::std::convert::TryFrom<&str> for MarketplacePurchasePurchasedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for MarketplacePurchasePurchasedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for MarketplacePurchasePurchasedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -51387,14 +48589,6 @@ impl ::std::convert::TryFrom<&str> for MemberAddedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for MemberAddedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for MemberAddedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -51526,14 +48720,6 @@ impl ::std::str::FromStr for MemberAddedChangesPermissionTo {
 impl ::std::convert::TryFrom<&str> for MemberAddedChangesPermissionTo {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for MemberAddedChangesPermissionTo {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -51669,14 +48855,6 @@ impl ::std::str::FromStr for MemberEditedAction {
 impl ::std::convert::TryFrom<&str> for MemberEditedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for MemberEditedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -51893,14 +49071,6 @@ impl ::std::convert::TryFrom<&str> for MemberRemovedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for MemberRemovedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for MemberRemovedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -52077,14 +49247,6 @@ impl ::std::convert::TryFrom<&str> for MembershipAddedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for MembershipAddedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for MembershipAddedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -52142,14 +49304,6 @@ impl ::std::str::FromStr for MembershipAddedScope {
 impl ::std::convert::TryFrom<&str> for MembershipAddedScope {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for MembershipAddedScope {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -52337,14 +49491,6 @@ impl ::std::convert::TryFrom<&str> for MembershipRemovedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for MembershipRemovedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for MembershipRemovedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -52407,14 +49553,6 @@ impl ::std::str::FromStr for MembershipRemovedScope {
 impl ::std::convert::TryFrom<&str> for MembershipRemovedScope {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for MembershipRemovedScope {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -52638,14 +49776,6 @@ impl ::std::convert::TryFrom<&str> for MetaDeletedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for MetaDeletedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for MetaDeletedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -52829,14 +49959,6 @@ impl ::std::str::FromStr for MetaDeletedHookConfigContentType {
 impl ::std::convert::TryFrom<&str> for MetaDeletedHookConfigContentType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for MetaDeletedHookConfigContentType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -53137,14 +50259,6 @@ impl ::std::convert::TryFrom<&str> for MilestoneClosedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for MilestoneClosedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for MilestoneClosedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -53256,14 +50370,6 @@ impl ::std::str::FromStr for MilestoneClosedMilestoneState {
 impl ::std::convert::TryFrom<&str> for MilestoneClosedMilestoneState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for MilestoneClosedMilestoneState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -53403,14 +50509,6 @@ impl ::std::convert::TryFrom<&str> for MilestoneCreatedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for MilestoneCreatedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for MilestoneCreatedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -53525,14 +50623,6 @@ impl ::std::convert::TryFrom<&str> for MilestoneCreatedMilestoneState {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for MilestoneCreatedMilestoneState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for MilestoneCreatedMilestoneState {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -53643,14 +50733,6 @@ impl ::std::str::FromStr for MilestoneDeletedAction {
 impl ::std::convert::TryFrom<&str> for MilestoneDeletedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for MilestoneDeletedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -53812,14 +50894,6 @@ impl ::std::str::FromStr for MilestoneEditedAction {
 impl ::std::convert::TryFrom<&str> for MilestoneEditedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for MilestoneEditedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -54169,14 +51243,6 @@ impl ::std::convert::TryFrom<&str> for MilestoneOpenedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for MilestoneOpenedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for MilestoneOpenedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -54291,14 +51357,6 @@ impl ::std::convert::TryFrom<&str> for MilestoneOpenedMilestoneState {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for MilestoneOpenedMilestoneState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for MilestoneOpenedMilestoneState {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -54361,14 +51419,6 @@ impl ::std::str::FromStr for MilestoneState {
 impl ::std::convert::TryFrom<&str> for MilestoneState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for MilestoneState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -54479,14 +51529,6 @@ impl ::std::str::FromStr for OrgBlockBlockedAction {
 impl ::std::convert::TryFrom<&str> for OrgBlockBlockedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for OrgBlockBlockedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -54630,14 +51672,6 @@ impl ::std::str::FromStr for OrgBlockUnblockedAction {
 impl ::std::convert::TryFrom<&str> for OrgBlockUnblockedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for OrgBlockUnblockedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -54847,14 +51881,6 @@ impl ::std::convert::TryFrom<&str> for OrganizationDeletedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for OrganizationDeletedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for OrganizationDeletedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -55020,14 +52046,6 @@ impl ::std::str::FromStr for OrganizationMemberAddedAction {
 impl ::std::convert::TryFrom<&str> for OrganizationMemberAddedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for OrganizationMemberAddedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -55207,14 +52225,6 @@ impl ::std::str::FromStr for OrganizationMemberInvitedAction {
 impl ::std::convert::TryFrom<&str> for OrganizationMemberInvitedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for OrganizationMemberInvitedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -55417,14 +52427,6 @@ impl ::std::convert::TryFrom<&str> for OrganizationMemberRemovedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for OrganizationMemberRemovedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for OrganizationMemberRemovedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -55530,14 +52532,6 @@ impl ::std::str::FromStr for OrganizationRenamedAction {
 impl ::std::convert::TryFrom<&str> for OrganizationRenamedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for OrganizationRenamedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -55968,14 +52962,6 @@ impl ::std::str::FromStr for PackagePublishedAction {
 impl ::std::convert::TryFrom<&str> for PackagePublishedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for PackagePublishedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -57128,14 +54114,6 @@ impl ::std::str::FromStr for PackageUpdatedAction {
 impl ::std::convert::TryFrom<&str> for PackageUpdatedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for PackageUpdatedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -58493,14 +55471,6 @@ impl ::std::convert::TryFrom<&str> for PingEventHookConfigContentType {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for PingEventHookConfigContentType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for PingEventHookConfigContentType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -58875,14 +55845,6 @@ impl ::std::convert::TryFrom<&str> for ProjectCardConvertedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ProjectCardConvertedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ProjectCardConvertedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -59053,14 +56015,6 @@ impl ::std::convert::TryFrom<&str> for ProjectCardCreatedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ProjectCardCreatedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ProjectCardCreatedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -59171,14 +56125,6 @@ impl ::std::str::FromStr for ProjectCardDeletedAction {
 impl ::std::convert::TryFrom<&str> for ProjectCardDeletedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ProjectCardDeletedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -59315,14 +56261,6 @@ impl ::std::str::FromStr for ProjectCardEditedAction {
 impl ::std::convert::TryFrom<&str> for ProjectCardEditedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ProjectCardEditedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -59598,14 +56536,6 @@ impl ::std::convert::TryFrom<&str> for ProjectCardMovedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ProjectCardMovedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ProjectCardMovedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -59825,14 +56755,6 @@ impl ::std::convert::TryFrom<&str> for ProjectClosedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ProjectClosedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ProjectClosedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -60016,14 +56938,6 @@ impl ::std::convert::TryFrom<&str> for ProjectColumnCreatedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ProjectColumnCreatedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ProjectColumnCreatedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -60134,14 +57048,6 @@ impl ::std::str::FromStr for ProjectColumnDeletedAction {
 impl ::std::convert::TryFrom<&str> for ProjectColumnDeletedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ProjectColumnDeletedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -60275,14 +57181,6 @@ impl ::std::str::FromStr for ProjectColumnEditedAction {
 impl ::std::convert::TryFrom<&str> for ProjectColumnEditedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ProjectColumnEditedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -60512,14 +57410,6 @@ impl ::std::convert::TryFrom<&str> for ProjectColumnMovedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ProjectColumnMovedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ProjectColumnMovedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -60633,14 +57523,6 @@ impl ::std::convert::TryFrom<&str> for ProjectCreatedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ProjectCreatedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ProjectCreatedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -60751,14 +57633,6 @@ impl ::std::str::FromStr for ProjectDeletedAction {
 impl ::std::convert::TryFrom<&str> for ProjectDeletedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ProjectDeletedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -60907,14 +57781,6 @@ impl ::std::str::FromStr for ProjectEditedAction {
 impl ::std::convert::TryFrom<&str> for ProjectEditedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ProjectEditedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -61199,14 +58065,6 @@ impl ::std::convert::TryFrom<&str> for ProjectReopenedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ProjectReopenedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ProjectReopenedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -61269,14 +58127,6 @@ impl ::std::str::FromStr for ProjectState {
 impl ::std::convert::TryFrom<&str> for ProjectState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ProjectState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -61532,14 +58382,6 @@ impl ::std::str::FromStr for PublicEventRepositoryCreatedAt {
 impl ::std::convert::TryFrom<&str> for PublicEventRepositoryCreatedAt {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for PublicEventRepositoryCreatedAt {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -62169,14 +59011,6 @@ impl ::std::convert::TryFrom<&str> for PullRequestActiveLockReason {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestActiveLockReason {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for PullRequestActiveLockReason {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -62302,14 +59136,6 @@ impl ::std::convert::TryFrom<&str> for PullRequestAssignedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestAssignedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for PullRequestAssignedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -62428,14 +59254,6 @@ impl ::std::convert::TryFrom<&str> for PullRequestAutoMergeDisabledAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestAutoMergeDisabledAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for PullRequestAutoMergeDisabledAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -62551,14 +59369,6 @@ impl ::std::str::FromStr for PullRequestAutoMergeEnabledAction {
 impl ::std::convert::TryFrom<&str> for PullRequestAutoMergeEnabledAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestAutoMergeEnabledAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -62756,14 +59566,6 @@ impl ::std::convert::TryFrom<&str> for PullRequestClosedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestClosedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for PullRequestClosedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -62931,16 +59733,6 @@ impl ::std::str::FromStr for PullRequestClosedPullRequestActiveLockReason {
 impl ::std::convert::TryFrom<&str> for PullRequestClosedPullRequestActiveLockReason {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for PullRequestClosedPullRequestActiveLockReason
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -63188,14 +59980,6 @@ impl ::std::convert::TryFrom<&str> for PullRequestClosedPullRequestState {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestClosedPullRequestState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for PullRequestClosedPullRequestState {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -63352,14 +60136,6 @@ impl ::std::str::FromStr for PullRequestConvertedToDraftAction {
 impl ::std::convert::TryFrom<&str> for PullRequestConvertedToDraftAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestConvertedToDraftAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -63542,16 +60318,6 @@ impl ::std::str::FromStr for PullRequestConvertedToDraftPullRequestActiveLockRea
 impl ::std::convert::TryFrom<&str> for PullRequestConvertedToDraftPullRequestActiveLockReason {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for PullRequestConvertedToDraftPullRequestActiveLockReason
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -63805,16 +60571,6 @@ impl ::std::convert::TryFrom<&str> for PullRequestConvertedToDraftPullRequestSta
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for PullRequestConvertedToDraftPullRequestState
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for PullRequestConvertedToDraftPullRequestState
 {
@@ -63969,14 +60725,6 @@ impl ::std::str::FromStr for PullRequestEditedAction {
 impl ::std::convert::TryFrom<&str> for PullRequestEditedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestEditedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -64426,14 +61174,6 @@ impl ::std::convert::TryFrom<&str> for PullRequestLabeledAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestLabeledAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for PullRequestLabeledAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -64614,14 +61354,6 @@ impl ::std::convert::TryFrom<&str> for PullRequestLockedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestLockedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for PullRequestLockedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -64778,14 +61510,6 @@ impl ::std::str::FromStr for PullRequestOpenedAction {
 impl ::std::convert::TryFrom<&str> for PullRequestOpenedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestOpenedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -65183,14 +61907,6 @@ impl ::std::convert::TryFrom<&str> for PullRequestOpenedPullRequestState {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestOpenedPullRequestState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for PullRequestOpenedPullRequestState {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -65351,14 +62067,6 @@ impl ::std::str::FromStr for PullRequestReadyForReviewAction {
 impl ::std::convert::TryFrom<&str> for PullRequestReadyForReviewAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestReadyForReviewAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -65544,16 +62252,6 @@ impl ::std::str::FromStr for PullRequestReadyForReviewPullRequestActiveLockReaso
 impl ::std::convert::TryFrom<&str> for PullRequestReadyForReviewPullRequestActiveLockReason {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for PullRequestReadyForReviewPullRequestActiveLockReason
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -65801,14 +62499,6 @@ impl ::std::convert::TryFrom<&str> for PullRequestReadyForReviewPullRequestState
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestReadyForReviewPullRequestState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for PullRequestReadyForReviewPullRequestState {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -65965,14 +62655,6 @@ impl ::std::str::FromStr for PullRequestReopenedAction {
 impl ::std::convert::TryFrom<&str> for PullRequestReopenedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestReopenedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -66153,16 +62835,6 @@ impl ::std::str::FromStr for PullRequestReopenedPullRequestActiveLockReason {
 impl ::std::convert::TryFrom<&str> for PullRequestReopenedPullRequestActiveLockReason {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for PullRequestReopenedPullRequestActiveLockReason
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -66407,14 +63079,6 @@ impl ::std::str::FromStr for PullRequestReopenedPullRequestState {
 impl ::std::convert::TryFrom<&str> for PullRequestReopenedPullRequestState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestReopenedPullRequestState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -67104,14 +63768,6 @@ impl ::std::convert::TryFrom<&str> for PullRequestReviewCommentCreatedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestReviewCommentCreatedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for PullRequestReviewCommentCreatedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -67541,16 +64197,6 @@ impl ::std::convert::TryFrom<&str> for PullRequestReviewCommentCreatedPullReques
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for PullRequestReviewCommentCreatedPullRequestActiveLockReason
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for PullRequestReviewCommentCreatedPullRequestActiveLockReason
 {
@@ -67801,16 +64447,6 @@ impl ::std::str::FromStr for PullRequestReviewCommentCreatedPullRequestState {
 impl ::std::convert::TryFrom<&str> for PullRequestReviewCommentCreatedPullRequestState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for PullRequestReviewCommentCreatedPullRequestState
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -68231,14 +64867,6 @@ impl ::std::str::FromStr for PullRequestReviewCommentDeletedAction {
 impl ::std::convert::TryFrom<&str> for PullRequestReviewCommentDeletedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestReviewCommentDeletedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -68671,16 +65299,6 @@ impl ::std::convert::TryFrom<&str> for PullRequestReviewCommentDeletedPullReques
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for PullRequestReviewCommentDeletedPullRequestActiveLockReason
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for PullRequestReviewCommentDeletedPullRequestActiveLockReason
 {
@@ -68931,16 +65549,6 @@ impl ::std::str::FromStr for PullRequestReviewCommentDeletedPullRequestState {
 impl ::std::convert::TryFrom<&str> for PullRequestReviewCommentDeletedPullRequestState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for PullRequestReviewCommentDeletedPullRequestState
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -69383,14 +65991,6 @@ impl ::std::str::FromStr for PullRequestReviewCommentEditedAction {
 impl ::std::convert::TryFrom<&str> for PullRequestReviewCommentEditedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestReviewCommentEditedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -69889,16 +66489,6 @@ impl ::std::convert::TryFrom<&str> for PullRequestReviewCommentEditedPullRequest
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for PullRequestReviewCommentEditedPullRequestActiveLockReason
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for PullRequestReviewCommentEditedPullRequestActiveLockReason
 {
@@ -70152,16 +66742,6 @@ impl ::std::convert::TryFrom<&str> for PullRequestReviewCommentEditedPullRequest
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for PullRequestReviewCommentEditedPullRequestState
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for PullRequestReviewCommentEditedPullRequestState
 {
@@ -70306,14 +66886,6 @@ impl ::std::convert::TryFrom<&str> for PullRequestReviewCommentSide {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestReviewCommentSide {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for PullRequestReviewCommentSide {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -70377,14 +66949,6 @@ impl ::std::str::FromStr for PullRequestReviewCommentStartSide {
 impl ::std::convert::TryFrom<&str> for PullRequestReviewCommentStartSide {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestReviewCommentStartSide {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -70581,14 +67145,6 @@ impl ::std::convert::TryFrom<&str> for PullRequestReviewDismissedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestReviewDismissedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for PullRequestReviewDismissedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -70778,14 +67334,6 @@ impl ::std::str::FromStr for PullRequestReviewDismissedReviewState {
 impl ::std::convert::TryFrom<&str> for PullRequestReviewDismissedReviewState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestReviewDismissedReviewState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -70997,14 +67545,6 @@ impl ::std::str::FromStr for PullRequestReviewEditedAction {
 impl ::std::convert::TryFrom<&str> for PullRequestReviewEditedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestReviewEditedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -71431,16 +67971,6 @@ impl ::std::convert::TryFrom<&str> for PullRequestReviewRequestRemovedVariant0Ac
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for PullRequestReviewRequestRemovedVariant0Action
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for PullRequestReviewRequestRemovedVariant0Action
 {
@@ -71499,16 +68029,6 @@ impl ::std::str::FromStr for PullRequestReviewRequestRemovedVariant1Action {
 impl ::std::convert::TryFrom<&str> for PullRequestReviewRequestRemovedVariant1Action {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for PullRequestReviewRequestRemovedVariant1Action
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -71700,14 +68220,6 @@ impl ::std::convert::TryFrom<&str> for PullRequestReviewRequestedVariant0Action 
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestReviewRequestedVariant0Action {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for PullRequestReviewRequestedVariant0Action {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -71764,14 +68276,6 @@ impl ::std::str::FromStr for PullRequestReviewRequestedVariant1Action {
 impl ::std::convert::TryFrom<&str> for PullRequestReviewRequestedVariant1Action {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestReviewRequestedVariant1Action {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -71962,14 +68466,6 @@ impl ::std::str::FromStr for PullRequestReviewSubmittedAction {
 impl ::std::convert::TryFrom<&str> for PullRequestReviewSubmittedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestReviewSubmittedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -72168,14 +68664,6 @@ impl ::std::convert::TryFrom<&str> for PullRequestState {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for PullRequestState {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -72306,14 +68794,6 @@ impl ::std::convert::TryFrom<&str> for PullRequestSynchronizeAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestSynchronizeAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for PullRequestSynchronizeAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -72436,14 +68916,6 @@ impl ::std::str::FromStr for PullRequestUnassignedAction {
 impl ::std::convert::TryFrom<&str> for PullRequestUnassignedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestUnassignedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -72572,14 +69044,6 @@ impl ::std::convert::TryFrom<&str> for PullRequestUnlabeledAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestUnlabeledAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for PullRequestUnlabeledAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -72697,14 +69161,6 @@ impl ::std::str::FromStr for PullRequestUnlockedAction {
 impl ::std::convert::TryFrom<&str> for PullRequestUnlockedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for PullRequestUnlockedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -73130,14 +69586,6 @@ impl ::std::convert::TryFrom<&str> for ReleaseAssetState {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ReleaseAssetState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ReleaseAssetState {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -73251,14 +69699,6 @@ impl ::std::convert::TryFrom<&str> for ReleaseCreatedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ReleaseCreatedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ReleaseCreatedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -73369,14 +69809,6 @@ impl ::std::str::FromStr for ReleaseDeletedAction {
 impl ::std::convert::TryFrom<&str> for ReleaseDeletedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ReleaseDeletedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -73524,14 +69956,6 @@ impl ::std::str::FromStr for ReleaseEditedAction {
 impl ::std::convert::TryFrom<&str> for ReleaseEditedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ReleaseEditedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -73853,14 +70277,6 @@ impl ::std::convert::TryFrom<&str> for ReleasePrereleasedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ReleasePrereleasedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ReleasePrereleasedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -74046,14 +70462,6 @@ impl ::std::convert::TryFrom<&str> for ReleasePublishedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ReleasePublishedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ReleasePublishedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -74220,14 +70628,6 @@ impl ::std::convert::TryFrom<&str> for ReleaseReleasedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ReleaseReleasedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ReleaseReleasedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -74354,14 +70754,6 @@ impl ::std::str::FromStr for ReleaseUnpublishedAction {
 impl ::std::convert::TryFrom<&str> for ReleaseUnpublishedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ReleaseUnpublishedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -75171,14 +71563,6 @@ impl ::std::convert::TryFrom<&str> for RepositoryArchivedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for RepositoryArchivedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for RepositoryArchivedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -75372,14 +71756,6 @@ impl ::std::str::FromStr for RepositoryArchivedRepositoryCreatedAt {
 impl ::std::convert::TryFrom<&str> for RepositoryArchivedRepositoryCreatedAt {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for RepositoryArchivedRepositoryCreatedAt {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -75595,14 +71971,6 @@ impl ::std::convert::TryFrom<&str> for RepositoryCreatedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for RepositoryCreatedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for RepositoryCreatedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -75650,14 +72018,6 @@ impl ::std::str::FromStr for RepositoryCreatedAt {
 impl ::std::convert::TryFrom<&str> for RepositoryCreatedAt {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for RepositoryCreatedAt {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -75784,14 +72144,6 @@ impl ::std::str::FromStr for RepositoryDeletedAction {
 impl ::std::convert::TryFrom<&str> for RepositoryDeletedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for RepositoryDeletedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -75944,14 +72296,6 @@ impl ::std::str::FromStr for RepositoryDispatchOnDemandTestAction {
 impl ::std::convert::TryFrom<&str> for RepositoryDispatchOnDemandTestAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for RepositoryDispatchOnDemandTestAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -76110,14 +72454,6 @@ impl ::std::str::FromStr for RepositoryEditedAction {
 impl ::std::convert::TryFrom<&str> for RepositoryEditedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for RepositoryEditedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -76486,14 +72822,6 @@ impl ::std::str::FromStr for RepositoryImportEventStatus {
 impl ::std::convert::TryFrom<&str> for RepositoryImportEventStatus {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for RepositoryImportEventStatus {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -76967,14 +73295,6 @@ impl ::std::convert::TryFrom<&str> for RepositoryPrivatizedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for RepositoryPrivatizedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for RepositoryPrivatizedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -77167,14 +73487,6 @@ impl ::std::str::FromStr for RepositoryPrivatizedRepositoryCreatedAt {
 impl ::std::convert::TryFrom<&str> for RepositoryPrivatizedRepositoryCreatedAt {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for RepositoryPrivatizedRepositoryCreatedAt {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -77410,14 +73722,6 @@ impl ::std::convert::TryFrom<&str> for RepositoryPublicizedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for RepositoryPublicizedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for RepositoryPublicizedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -77610,14 +73914,6 @@ impl ::std::str::FromStr for RepositoryPublicizedRepositoryCreatedAt {
 impl ::std::convert::TryFrom<&str> for RepositoryPublicizedRepositoryCreatedAt {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for RepositoryPublicizedRepositoryCreatedAt {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -77903,14 +74199,6 @@ impl ::std::convert::TryFrom<&str> for RepositoryRenamedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for RepositoryRenamedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for RepositoryRenamedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -78147,14 +74435,6 @@ impl ::std::convert::TryFrom<&str> for RepositoryTransferredAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for RepositoryTransferredAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for RepositoryTransferredAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -78382,14 +74662,6 @@ impl ::std::convert::TryFrom<&str> for RepositoryUnarchivedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for RepositoryUnarchivedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for RepositoryUnarchivedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -78583,14 +74855,6 @@ impl ::std::str::FromStr for RepositoryUnarchivedRepositoryCreatedAt {
 impl ::std::convert::TryFrom<&str> for RepositoryUnarchivedRepositoryCreatedAt {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for RepositoryUnarchivedRepositoryCreatedAt {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -78855,14 +75119,6 @@ impl ::std::convert::TryFrom<&str> for RepositoryVulnerabilityAlertCreateAction 
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for RepositoryVulnerabilityAlertCreateAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for RepositoryVulnerabilityAlertCreateAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -79101,14 +75357,6 @@ impl ::std::str::FromStr for RepositoryVulnerabilityAlertDismissAction {
 impl ::std::convert::TryFrom<&str> for RepositoryVulnerabilityAlertDismissAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for RepositoryVulnerabilityAlertDismissAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -79398,14 +75646,6 @@ impl ::std::convert::TryFrom<&str> for RepositoryVulnerabilityAlertResolveAction
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for RepositoryVulnerabilityAlertResolveAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for RepositoryVulnerabilityAlertResolveAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -79618,14 +75858,6 @@ impl ::std::str::FromStr for SecretScanningAlertCreatedAction {
 impl ::std::convert::TryFrom<&str> for SecretScanningAlertCreatedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for SecretScanningAlertCreatedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -79855,14 +76087,6 @@ impl ::std::convert::TryFrom<&str> for SecretScanningAlertReopenedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for SecretScanningAlertReopenedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for SecretScanningAlertReopenedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -80053,14 +76277,6 @@ impl ::std::convert::TryFrom<&str> for SecretScanningAlertResolvedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for SecretScanningAlertResolvedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for SecretScanningAlertResolvedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -80183,16 +76399,6 @@ impl ::std::str::FromStr for SecretScanningAlertResolvedAlertResolution {
 impl ::std::convert::TryFrom<&str> for SecretScanningAlertResolvedAlertResolution {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for SecretScanningAlertResolvedAlertResolution
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -80504,14 +76710,6 @@ impl ::std::str::FromStr for SecurityAdvisoryPerformedAction {
 impl ::std::convert::TryFrom<&str> for SecurityAdvisoryPerformedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for SecurityAdvisoryPerformedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -81204,14 +77402,6 @@ impl ::std::convert::TryFrom<&str> for SecurityAdvisoryPublishedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for SecurityAdvisoryPublishedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for SecurityAdvisoryPublishedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -81901,14 +78091,6 @@ impl ::std::convert::TryFrom<&str> for SecurityAdvisoryUpdatedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for SecurityAdvisoryUpdatedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for SecurityAdvisoryUpdatedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -82592,14 +78774,6 @@ impl ::std::str::FromStr for SecurityAdvisoryWithdrawnAction {
 impl ::std::convert::TryFrom<&str> for SecurityAdvisoryWithdrawnAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for SecurityAdvisoryWithdrawnAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -83458,14 +79632,6 @@ impl ::std::convert::TryFrom<&str> for SimplePullRequestActiveLockReason {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for SimplePullRequestActiveLockReason {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for SimplePullRequestActiveLockReason {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -83713,14 +79879,6 @@ impl ::std::convert::TryFrom<&str> for SimplePullRequestState {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for SimplePullRequestState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for SimplePullRequestState {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -83845,14 +80003,6 @@ impl ::std::str::FromStr for SponsorshipCancelledAction {
 impl ::std::convert::TryFrom<&str> for SponsorshipCancelledAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for SponsorshipCancelledAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -84029,14 +80179,6 @@ impl ::std::str::FromStr for SponsorshipCreatedAction {
 impl ::std::convert::TryFrom<&str> for SponsorshipCreatedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for SponsorshipCreatedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -84234,14 +80376,6 @@ impl ::std::str::FromStr for SponsorshipEditedAction {
 impl ::std::convert::TryFrom<&str> for SponsorshipEditedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for SponsorshipEditedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -84562,14 +80696,6 @@ impl ::std::convert::TryFrom<&str> for SponsorshipPendingCancellationAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for SponsorshipPendingCancellationAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for SponsorshipPendingCancellationAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -84773,14 +80899,6 @@ impl ::std::str::FromStr for SponsorshipPendingTierChangeAction {
 impl ::std::convert::TryFrom<&str> for SponsorshipPendingTierChangeAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for SponsorshipPendingTierChangeAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -85102,14 +81220,6 @@ impl ::std::convert::TryFrom<&str> for SponsorshipTierChangedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for SponsorshipTierChangedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for SponsorshipTierChangedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -85331,14 +81441,6 @@ impl ::std::convert::TryFrom<&str> for StarCreatedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for StarCreatedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for StarCreatedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -85451,14 +81553,6 @@ impl ::std::str::FromStr for StarDeletedAction {
 impl ::std::convert::TryFrom<&str> for StarDeletedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for StarDeletedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -86589,14 +82683,6 @@ impl ::std::convert::TryFrom<&str> for StatusEventCommitCommitVerificationReason
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for StatusEventCommitCommitVerificationReason {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for StatusEventCommitCommitVerificationReason {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -86705,14 +82791,6 @@ impl ::std::str::FromStr for StatusEventState {
 impl ::std::convert::TryFrom<&str> for StatusEventState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for StatusEventState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -87048,14 +83126,6 @@ impl ::std::convert::TryFrom<&str> for TeamAddedToRepositoryAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for TeamAddedToRepositoryAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for TeamAddedToRepositoryAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -87169,14 +83239,6 @@ impl ::std::convert::TryFrom<&str> for TeamCreatedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for TeamCreatedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for TeamCreatedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -87287,14 +83349,6 @@ impl ::std::str::FromStr for TeamDeletedAction {
 impl ::std::convert::TryFrom<&str> for TeamDeletedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for TeamDeletedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -87492,14 +83546,6 @@ impl ::std::str::FromStr for TeamEditedAction {
 impl ::std::convert::TryFrom<&str> for TeamEditedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for TeamEditedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -88051,14 +84097,6 @@ impl ::std::convert::TryFrom<&str> for TeamParentPrivacy {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for TeamParentPrivacy {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for TeamParentPrivacy {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -88125,14 +84163,6 @@ impl ::std::str::FromStr for TeamPrivacy {
 impl ::std::convert::TryFrom<&str> for TeamPrivacy {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for TeamPrivacy {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -88246,14 +84276,6 @@ impl ::std::str::FromStr for TeamRemovedFromRepositoryAction {
 impl ::std::convert::TryFrom<&str> for TeamRemovedFromRepositoryAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for TeamRemovedFromRepositoryAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -88465,14 +84487,6 @@ impl ::std::convert::TryFrom<&str> for UserType {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for UserType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for UserType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -88611,14 +84625,6 @@ impl ::std::str::FromStr for WatchStartedAction {
 impl ::std::convert::TryFrom<&str> for WatchStartedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for WatchStartedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -89001,14 +85007,6 @@ impl ::std::str::FromStr for WebhookEventsVariant0Item {
 impl ::std::convert::TryFrom<&str> for WebhookEventsVariant0Item {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for WebhookEventsVariant0Item {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -89408,14 +85406,6 @@ impl ::std::convert::TryFrom<&str> for WorkflowJobCompletedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for WorkflowJobCompletedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for WorkflowJobCompletedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -89529,14 +85519,6 @@ impl ::std::convert::TryFrom<&str> for WorkflowJobCompletedWorkflowJobConclusion
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for WorkflowJobCompletedWorkflowJobConclusion {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for WorkflowJobCompletedWorkflowJobConclusion {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -89606,14 +85588,6 @@ impl ::std::convert::TryFrom<&str> for WorkflowJobCompletedWorkflowJobStatus {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for WorkflowJobCompletedWorkflowJobStatus {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for WorkflowJobCompletedWorkflowJobStatus {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -89675,14 +85649,6 @@ impl ::std::str::FromStr for WorkflowJobConclusion {
 impl ::std::convert::TryFrom<&str> for WorkflowJobConclusion {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for WorkflowJobConclusion {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -89920,14 +85886,6 @@ impl ::std::convert::TryFrom<&str> for WorkflowJobQueuedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for WorkflowJobQueuedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for WorkflowJobQueuedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -90095,14 +86053,6 @@ impl ::std::convert::TryFrom<&str> for WorkflowJobQueuedWorkflowJobStatus {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for WorkflowJobQueuedWorkflowJobStatus {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for WorkflowJobQueuedWorkflowJobStatus {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -90242,14 +86192,6 @@ impl ::std::str::FromStr for WorkflowJobStartedAction {
 impl ::std::convert::TryFrom<&str> for WorkflowJobStartedAction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for WorkflowJobStartedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -90426,14 +86368,6 @@ impl ::std::convert::TryFrom<&str> for WorkflowJobStartedWorkflowJobStatus {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for WorkflowJobStartedWorkflowJobStatus {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for WorkflowJobStartedWorkflowJobStatus {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -90500,14 +86434,6 @@ impl ::std::str::FromStr for WorkflowJobStatus {
 impl ::std::convert::TryFrom<&str> for WorkflowJobStatus {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for WorkflowJobStatus {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -90903,14 +86829,6 @@ impl ::std::convert::TryFrom<&str> for WorkflowRunCompletedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for WorkflowRunCompletedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for WorkflowRunCompletedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -91063,14 +86981,6 @@ impl ::std::str::FromStr for WorkflowRunCompletedWorkflowRunConclusion {
 impl ::std::convert::TryFrom<&str> for WorkflowRunCompletedWorkflowRunConclusion {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for WorkflowRunCompletedWorkflowRunConclusion {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -91297,14 +87207,6 @@ impl ::std::convert::TryFrom<&str> for WorkflowRunCompletedWorkflowRunStatus {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for WorkflowRunCompletedWorkflowRunStatus {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for WorkflowRunCompletedWorkflowRunStatus {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -91391,14 +87293,6 @@ impl ::std::str::FromStr for WorkflowRunConclusion {
 impl ::std::convert::TryFrom<&str> for WorkflowRunConclusion {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for WorkflowRunConclusion {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -91702,14 +87596,6 @@ impl ::std::convert::TryFrom<&str> for WorkflowRunRequestedAction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for WorkflowRunRequestedAction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for WorkflowRunRequestedAction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -91781,14 +87667,6 @@ impl ::std::str::FromStr for WorkflowRunStatus {
 impl ::std::convert::TryFrom<&str> for WorkflowRunStatus {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for WorkflowRunStatus {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -91956,14 +87834,6 @@ impl ::std::convert::TryFrom<&str> for WorkflowStepCompletedConclusion {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for WorkflowStepCompletedConclusion {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for WorkflowStepCompletedConclusion {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -92020,14 +87890,6 @@ impl ::std::str::FromStr for WorkflowStepCompletedStatus {
 impl ::std::convert::TryFrom<&str> for WorkflowStepCompletedStatus {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for WorkflowStepCompletedStatus {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -92141,14 +88003,6 @@ impl ::std::str::FromStr for WorkflowStepInProgressStatus {
 impl ::std::convert::TryFrom<&str> for WorkflowStepInProgressStatus {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for WorkflowStepInProgressStatus {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }

--- a/typify-impl/tests/vega.out
+++ b/typify-impl/tests/vega.out
@@ -899,14 +899,6 @@ impl ::std::convert::TryFrom<&str> for AggregateTransformOpsArrayItemVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AggregateTransformOpsArrayItemVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AggregateTransformOpsArrayItemVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -962,14 +954,6 @@ impl ::std::str::FromStr for AggregateTransformType {
 impl ::std::convert::TryFrom<&str> for AggregateTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for AggregateTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1496,16 +1480,6 @@ impl ::std::convert::TryFrom<&str> for AlignValueVariant0ItemVariant0Variant1Val
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for AlignValueVariant0ItemVariant0Variant1Value
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for AlignValueVariant0ItemVariant0Variant1Value
 {
@@ -1554,16 +1528,6 @@ impl ::std::str::FromStr for AlignValueVariant0ItemVariant0Variant3Range {
 impl ::std::convert::TryFrom<&str> for AlignValueVariant0ItemVariant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for AlignValueVariant0ItemVariant0Variant3Range
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2113,14 +2077,6 @@ impl ::std::convert::TryFrom<&str> for AlignValueVariant1Variant0Variant1Value {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AlignValueVariant1Variant0Variant1Value {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AlignValueVariant1Variant0Variant1Value {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -2167,14 +2123,6 @@ impl ::std::str::FromStr for AlignValueVariant1Variant0Variant3Range {
 impl ::std::convert::TryFrom<&str> for AlignValueVariant1Variant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for AlignValueVariant1Variant0Variant3Range {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -2939,16 +2887,6 @@ impl ::std::convert::TryFrom<&str> for AnchorValueVariant0ItemVariant0Variant1Va
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for AnchorValueVariant0ItemVariant0Variant1Value
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for AnchorValueVariant0ItemVariant0Variant1Value
 {
@@ -2997,16 +2935,6 @@ impl ::std::str::FromStr for AnchorValueVariant0ItemVariant0Variant3Range {
 impl ::std::convert::TryFrom<&str> for AnchorValueVariant0ItemVariant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for AnchorValueVariant0ItemVariant0Variant3Range
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -3556,14 +3484,6 @@ impl ::std::convert::TryFrom<&str> for AnchorValueVariant1Variant0Variant1Value 
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AnchorValueVariant1Variant0Variant1Value {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AnchorValueVariant1Variant0Variant1Value {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -3610,14 +3530,6 @@ impl ::std::str::FromStr for AnchorValueVariant1Variant0Variant3Range {
 impl ::std::convert::TryFrom<&str> for AnchorValueVariant1Variant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for AnchorValueVariant1Variant0Variant3Range {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -4339,14 +4251,6 @@ impl ::std::convert::TryFrom<&str> for AnyValueVariant0ItemVariant0Variant3Range
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AnyValueVariant0ItemVariant0Variant3Range {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AnyValueVariant0ItemVariant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -4845,14 +4749,6 @@ impl ::std::str::FromStr for AnyValueVariant1Variant0Variant3Range {
 impl ::std::convert::TryFrom<&str> for AnyValueVariant1Variant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for AnyValueVariant1Variant0Variant3Range {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -5603,16 +5499,6 @@ impl ::std::convert::TryFrom<&str> for ArrayValueVariant0ItemVariant0Variant3Ran
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for ArrayValueVariant0ItemVariant0Variant3Range
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for ArrayValueVariant0ItemVariant0Variant3Range
 {
@@ -6124,14 +6010,6 @@ impl ::std::convert::TryFrom<&str> for ArrayValueVariant1Variant0Variant3Range {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ArrayValueVariant1Variant0Variant3Range {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ArrayValueVariant1Variant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -6517,14 +6395,6 @@ impl ::std::convert::TryFrom<&str> for AutosizeVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AutosizeVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AutosizeVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -6585,14 +6455,6 @@ impl ::std::str::FromStr for AutosizeVariant1Contains {
 impl ::std::convert::TryFrom<&str> for AutosizeVariant1Contains {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for AutosizeVariant1Contains {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -6672,14 +6534,6 @@ impl ::std::str::FromStr for AutosizeVariant1Type {
 impl ::std::convert::TryFrom<&str> for AutosizeVariant1Type {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for AutosizeVariant1Type {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -8423,14 +8277,6 @@ impl ::std::convert::TryFrom<&str> for AxisFormatTypeVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AxisFormatTypeVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AxisFormatTypeVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -8731,14 +8577,6 @@ impl ::std::convert::TryFrom<&str> for AxisLabelAlignVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AxisLabelAlignVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AxisLabelAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -8892,14 +8730,6 @@ impl ::std::str::FromStr for AxisLabelBaselineVariant0 {
 impl ::std::convert::TryFrom<&str> for AxisLabelBaselineVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for AxisLabelBaselineVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -9540,14 +9370,6 @@ impl ::std::convert::TryFrom<&str> for AxisOrientVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AxisOrientVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AxisOrientVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -9980,14 +9802,6 @@ impl ::std::convert::TryFrom<&str> for AxisTitleAlignVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AxisTitleAlignVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AxisTitleAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -10092,14 +9906,6 @@ impl ::std::str::FromStr for AxisTitleAnchorVariant0 {
 impl ::std::convert::TryFrom<&str> for AxisTitleAnchorVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for AxisTitleAnchorVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -10256,14 +10062,6 @@ impl ::std::str::FromStr for AxisTitleBaselineVariant0 {
 impl ::std::convert::TryFrom<&str> for AxisTitleBaselineVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for AxisTitleBaselineVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -11196,16 +10994,6 @@ impl ::std::convert::TryFrom<&str> for BaseColorValueVariant0Variant0Variant3Ran
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for BaseColorValueVariant0Variant0Variant3Range
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for BaseColorValueVariant0Variant0Variant3Range
 {
@@ -12035,16 +11823,6 @@ impl ::std::convert::TryFrom<&str> for BaselineValueVariant0ItemVariant0Variant1
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for BaselineValueVariant0ItemVariant0Variant1Value
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for BaselineValueVariant0ItemVariant0Variant1Value
 {
@@ -12093,16 +11871,6 @@ impl ::std::str::FromStr for BaselineValueVariant0ItemVariant0Variant3Range {
 impl ::std::convert::TryFrom<&str> for BaselineValueVariant0ItemVariant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for BaselineValueVariant0ItemVariant0Variant3Range
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -12661,16 +12429,6 @@ impl ::std::convert::TryFrom<&str> for BaselineValueVariant1Variant0Variant1Valu
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for BaselineValueVariant1Variant0Variant1Value
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for BaselineValueVariant1Variant0Variant1Value {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -12717,16 +12475,6 @@ impl ::std::str::FromStr for BaselineValueVariant1Variant0Variant3Range {
 impl ::std::convert::TryFrom<&str> for BaselineValueVariant1Variant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for BaselineValueVariant1Variant0Variant3Range
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -13972,14 +13720,6 @@ impl ::std::convert::TryFrom<&str> for BinTransformType {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for BinTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for BinTransformType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -14240,14 +13980,6 @@ impl ::std::convert::TryFrom<&str> for BindVariant0Input {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for BindVariant0Input {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for BindVariant0Input {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -14311,14 +14043,6 @@ impl ::std::convert::TryFrom<&str> for BindVariant1Input {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for BindVariant1Input {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for BindVariant1Input {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -14374,14 +14098,6 @@ impl ::std::str::FromStr for BindVariant2Input {
 impl ::std::convert::TryFrom<&str> for BindVariant2Input {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for BindVariant2Input {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -15080,16 +14796,6 @@ impl ::std::convert::TryFrom<&str> for BlendValueVariant0ItemVariant0Variant1Val
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for BlendValueVariant0ItemVariant0Variant1Value
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for BlendValueVariant0ItemVariant0Variant1Value
 {
@@ -15138,16 +14844,6 @@ impl ::std::str::FromStr for BlendValueVariant0ItemVariant0Variant3Range {
 impl ::std::convert::TryFrom<&str> for BlendValueVariant0ItemVariant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for BlendValueVariant0ItemVariant0Variant3Range
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -15810,14 +15506,6 @@ impl ::std::convert::TryFrom<&str> for BlendValueVariant1Variant0Variant1Value {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for BlendValueVariant1Variant0Variant1Value {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for BlendValueVariant1Variant0Variant1Value {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -15864,14 +15552,6 @@ impl ::std::str::FromStr for BlendValueVariant1Variant0Variant3Range {
 impl ::std::convert::TryFrom<&str> for BlendValueVariant1Variant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for BlendValueVariant1Variant0Variant3Range {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -16660,16 +16340,6 @@ impl ::std::convert::TryFrom<&str> for BooleanValueVariant0ItemVariant0Variant3R
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for BooleanValueVariant0ItemVariant0Variant3Range
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for BooleanValueVariant0ItemVariant0Variant3Range
 {
@@ -17181,14 +16851,6 @@ impl ::std::convert::TryFrom<&str> for BooleanValueVariant1Variant0Variant3Range
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for BooleanValueVariant1Variant0Variant3Range {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for BooleanValueVariant1Variant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -17511,14 +17173,6 @@ impl ::std::str::FromStr for CollectTransformType {
 impl ::std::convert::TryFrom<&str> for CollectTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CollectTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -18382,14 +18036,6 @@ impl ::std::convert::TryFrom<&str> for ContourTransformType {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ContourTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ContourTransformType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -18907,14 +18553,6 @@ impl ::std::convert::TryFrom<&str> for CountpatternTransformCaseVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for CountpatternTransformCaseVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for CountpatternTransformCaseVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -19074,14 +18712,6 @@ impl ::std::str::FromStr for CountpatternTransformType {
 impl ::std::convert::TryFrom<&str> for CountpatternTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CountpatternTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -19290,14 +18920,6 @@ impl ::std::str::FromStr for CrossTransformType {
 impl ::std::convert::TryFrom<&str> for CrossTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CrossTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -19550,14 +19172,6 @@ impl ::std::str::FromStr for CrossfilterTransformType {
 impl ::std::convert::TryFrom<&str> for CrossfilterTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CrossfilterTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -20798,16 +20412,6 @@ impl ::std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype0ParseVa
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant2FormatVariant0Subtype0ParseVariant0
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for DataVariant2FormatVariant0Subtype0ParseVariant0
 {
@@ -20862,16 +20466,6 @@ impl ::std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant1Valu
 impl ::std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype0ParseVariant1Value {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant2FormatVariant0Subtype0ParseVariant1Value
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -20974,16 +20568,6 @@ impl ::std::convert::TryFrom<&str>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0
 {
@@ -21037,16 +20621,6 @@ impl ::std::convert::TryFrom<&str>
 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -21284,16 +20858,6 @@ impl ::std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype1ParseVa
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant2FormatVariant0Subtype1ParseVariant0
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for DataVariant2FormatVariant0Subtype1ParseVariant0
 {
@@ -21348,16 +20912,6 @@ impl ::std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant1Valu
 impl ::std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype1ParseVariant1Value {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant2FormatVariant0Subtype1ParseVariant1Value
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -21460,16 +21014,6 @@ impl ::std::convert::TryFrom<&str>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0
 {
@@ -21523,16 +21067,6 @@ impl ::std::convert::TryFrom<&str>
 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -21607,14 +21141,6 @@ impl ::std::str::FromStr for DataVariant2FormatVariant0Subtype1Type {
 impl ::std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype1Type {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for DataVariant2FormatVariant0Subtype1Type {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -21824,16 +21350,6 @@ impl ::std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype2ParseVa
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant2FormatVariant0Subtype2ParseVariant0
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for DataVariant2FormatVariant0Subtype2ParseVariant0
 {
@@ -21888,16 +21404,6 @@ impl ::std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant1Valu
 impl ::std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype2ParseVariant1Value {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant2FormatVariant0Subtype2ParseVariant1Value
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -22000,16 +21506,6 @@ impl ::std::convert::TryFrom<&str>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0
 {
@@ -22063,16 +21559,6 @@ impl ::std::convert::TryFrom<&str>
 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -22152,14 +21638,6 @@ impl ::std::str::FromStr for DataVariant2FormatVariant0Subtype2Type {
 impl ::std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype2Type {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for DataVariant2FormatVariant0Subtype2Type {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -22373,16 +21851,6 @@ impl ::std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype3ParseVa
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant2FormatVariant0Subtype3ParseVariant0
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for DataVariant2FormatVariant0Subtype3ParseVariant0
 {
@@ -22437,16 +21905,6 @@ impl ::std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant1Valu
 impl ::std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype3ParseVariant1Value {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant2FormatVariant0Subtype3ParseVariant1Value
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -22549,16 +22007,6 @@ impl ::std::convert::TryFrom<&str>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0
 {
@@ -22612,16 +22060,6 @@ impl ::std::convert::TryFrom<&str>
 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -22696,14 +22134,6 @@ impl ::std::str::FromStr for DataVariant2FormatVariant0Subtype3Type {
 impl ::std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype3Type {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for DataVariant2FormatVariant0Subtype3Type {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -22845,16 +22275,6 @@ impl ::std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype4Variant
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant2FormatVariant0Subtype4Variant0Type
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for DataVariant2FormatVariant0Subtype4Variant0Type
 {
@@ -22921,16 +22341,6 @@ impl ::std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype4Variant
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant2FormatVariant0Subtype4Variant1Filter
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for DataVariant2FormatVariant0Subtype4Variant1Filter
 {
@@ -22988,16 +22398,6 @@ impl ::std::str::FromStr for DataVariant2FormatVariant0Subtype4Variant1Type {
 impl ::std::convert::TryFrom<&str> for DataVariant2FormatVariant0Subtype4Variant1Type {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant2FormatVariant0Subtype4Variant1Type
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -23512,16 +22912,6 @@ impl ::std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype0ParseVa
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant3FormatVariant0Subtype0ParseVariant0
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for DataVariant3FormatVariant0Subtype0ParseVariant0
 {
@@ -23576,16 +22966,6 @@ impl ::std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant1Valu
 impl ::std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype0ParseVariant1Value {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant3FormatVariant0Subtype0ParseVariant1Value
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -23688,16 +23068,6 @@ impl ::std::convert::TryFrom<&str>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0
 {
@@ -23751,16 +23121,6 @@ impl ::std::convert::TryFrom<&str>
 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -23998,16 +23358,6 @@ impl ::std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype1ParseVa
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant3FormatVariant0Subtype1ParseVariant0
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for DataVariant3FormatVariant0Subtype1ParseVariant0
 {
@@ -24062,16 +23412,6 @@ impl ::std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant1Valu
 impl ::std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype1ParseVariant1Value {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant3FormatVariant0Subtype1ParseVariant1Value
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -24174,16 +23514,6 @@ impl ::std::convert::TryFrom<&str>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0
 {
@@ -24237,16 +23567,6 @@ impl ::std::convert::TryFrom<&str>
 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -24321,14 +23641,6 @@ impl ::std::str::FromStr for DataVariant3FormatVariant0Subtype1Type {
 impl ::std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype1Type {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for DataVariant3FormatVariant0Subtype1Type {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -24538,16 +23850,6 @@ impl ::std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype2ParseVa
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant3FormatVariant0Subtype2ParseVariant0
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for DataVariant3FormatVariant0Subtype2ParseVariant0
 {
@@ -24602,16 +23904,6 @@ impl ::std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant1Valu
 impl ::std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype2ParseVariant1Value {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant3FormatVariant0Subtype2ParseVariant1Value
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -24714,16 +24006,6 @@ impl ::std::convert::TryFrom<&str>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0
 {
@@ -24777,16 +24059,6 @@ impl ::std::convert::TryFrom<&str>
 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -24866,14 +24138,6 @@ impl ::std::str::FromStr for DataVariant3FormatVariant0Subtype2Type {
 impl ::std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype2Type {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for DataVariant3FormatVariant0Subtype2Type {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -25087,16 +24351,6 @@ impl ::std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype3ParseVa
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant3FormatVariant0Subtype3ParseVariant0
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for DataVariant3FormatVariant0Subtype3ParseVariant0
 {
@@ -25151,16 +24405,6 @@ impl ::std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant1Valu
 impl ::std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype3ParseVariant1Value {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant3FormatVariant0Subtype3ParseVariant1Value
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -25263,16 +24507,6 @@ impl ::std::convert::TryFrom<&str>
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0
 {
@@ -25326,16 +24560,6 @@ impl ::std::convert::TryFrom<&str>
 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -25410,14 +24634,6 @@ impl ::std::str::FromStr for DataVariant3FormatVariant0Subtype3Type {
 impl ::std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype3Type {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for DataVariant3FormatVariant0Subtype3Type {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -25559,16 +24775,6 @@ impl ::std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype4Variant
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant3FormatVariant0Subtype4Variant0Type
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for DataVariant3FormatVariant0Subtype4Variant0Type
 {
@@ -25635,16 +24841,6 @@ impl ::std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype4Variant
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant3FormatVariant0Subtype4Variant1Filter
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for DataVariant3FormatVariant0Subtype4Variant1Filter
 {
@@ -25702,16 +24898,6 @@ impl ::std::str::FromStr for DataVariant3FormatVariant0Subtype4Variant1Type {
 impl ::std::convert::TryFrom<&str> for DataVariant3FormatVariant0Subtype4Variant1Type {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DataVariant3FormatVariant0Subtype4Variant1Type
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -27017,14 +26203,6 @@ impl ::std::convert::TryFrom<&str> for DensityTransformType {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for DensityTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for DensityTransformType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -27539,16 +26717,6 @@ impl ::std::convert::TryFrom<&str> for DirectionValueVariant0ItemVariant0Variant
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DirectionValueVariant0ItemVariant0Variant1Value
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for DirectionValueVariant0ItemVariant0Variant1Value
 {
@@ -27597,16 +26765,6 @@ impl ::std::str::FromStr for DirectionValueVariant0ItemVariant0Variant3Range {
 impl ::std::convert::TryFrom<&str> for DirectionValueVariant0ItemVariant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DirectionValueVariant0ItemVariant0Variant3Range
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -28147,16 +27305,6 @@ impl ::std::convert::TryFrom<&str> for DirectionValueVariant1Variant0Variant1Val
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DirectionValueVariant1Variant0Variant1Value
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for DirectionValueVariant1Variant0Variant1Value
 {
@@ -28205,16 +27353,6 @@ impl ::std::str::FromStr for DirectionValueVariant1Variant0Variant3Range {
 impl ::std::convert::TryFrom<&str> for DirectionValueVariant1Variant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for DirectionValueVariant1Variant0Variant3Range
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -28852,14 +27990,6 @@ impl ::std::str::FromStr for DotbinTransformType {
 impl ::std::convert::TryFrom<&str> for DotbinTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for DotbinTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -29550,14 +28680,6 @@ impl ::std::convert::TryFrom<&str> for EncodeKey {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for EncodeKey {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for EncodeKey {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -29949,14 +29071,6 @@ impl ::std::str::FromStr for ExtentTransformType {
 impl ::std::convert::TryFrom<&str> for ExtentTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ExtentTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -30440,14 +29554,6 @@ impl ::std::convert::TryFrom<&str> for FilterTransformType {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for FilterTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for FilterTransformType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -30790,14 +29896,6 @@ impl ::std::convert::TryFrom<&str> for FlattenTransformType {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for FlattenTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for FlattenTransformType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -31111,14 +30209,6 @@ impl ::std::str::FromStr for FoldTransformType {
 impl ::std::convert::TryFrom<&str> for FoldTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for FoldTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -31703,16 +30793,6 @@ impl ::std::str::FromStr for FontWeightValueVariant0ItemVariant0Variant3Range {
 impl ::std::convert::TryFrom<&str> for FontWeightValueVariant0ItemVariant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for FontWeightValueVariant0ItemVariant0Variant3Range
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -32320,16 +31400,6 @@ impl ::std::str::FromStr for FontWeightValueVariant1Variant0Variant3Range {
 impl ::std::convert::TryFrom<&str> for FontWeightValueVariant1Variant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for FontWeightValueVariant1Variant0Variant3Range
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -34209,14 +33279,6 @@ impl ::std::convert::TryFrom<&str> for ForceTransformType {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ForceTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ForceTransformType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -34434,14 +33496,6 @@ impl ::std::str::FromStr for FormulaTransformType {
 impl ::std::convert::TryFrom<&str> for FormulaTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for FormulaTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -34738,14 +33792,6 @@ impl ::std::convert::TryFrom<&str> for GeojsonTransformType {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for GeojsonTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for GeojsonTransformType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -35015,14 +34061,6 @@ impl ::std::str::FromStr for GeopathTransformType {
 impl ::std::convert::TryFrom<&str> for GeopathTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for GeopathTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -35351,14 +34389,6 @@ impl ::std::convert::TryFrom<&str> for GeopointTransformType {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for GeopointTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for GeopointTransformType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -35635,14 +34665,6 @@ impl ::std::str::FromStr for GeoshapeTransformType {
 impl ::std::convert::TryFrom<&str> for GeoshapeTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for GeoshapeTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -36371,14 +35393,6 @@ impl ::std::convert::TryFrom<&str> for GraticuleTransformType {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for GraticuleTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for GraticuleTransformType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -36816,14 +35830,6 @@ impl ::std::convert::TryFrom<&str> for HeatmapTransformResolveVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for HeatmapTransformResolveVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for HeatmapTransformResolveVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -36879,14 +35885,6 @@ impl ::std::str::FromStr for HeatmapTransformType {
 impl ::std::convert::TryFrom<&str> for HeatmapTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for HeatmapTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -37018,14 +36016,6 @@ impl ::std::str::FromStr for IdentifierTransformType {
 impl ::std::convert::TryFrom<&str> for IdentifierTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IdentifierTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -37482,14 +36472,6 @@ impl ::std::convert::TryFrom<&str> for ImputeTransformMethodVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ImputeTransformMethodVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ImputeTransformMethodVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -37545,14 +36527,6 @@ impl ::std::str::FromStr for ImputeTransformType {
 impl ::std::convert::TryFrom<&str> for ImputeTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ImputeTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -38004,14 +36978,6 @@ impl ::std::convert::TryFrom<&str> for IsocontourTransformResolveVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for IsocontourTransformResolveVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for IsocontourTransformResolveVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -38337,14 +37303,6 @@ impl ::std::str::FromStr for IsocontourTransformType {
 impl ::std::convert::TryFrom<&str> for IsocontourTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IsocontourTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -39175,16 +38133,6 @@ impl ::std::convert::TryFrom<&str> for JoinaggregateTransformOpsArrayItemVariant
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for JoinaggregateTransformOpsArrayItemVariant0
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for JoinaggregateTransformOpsArrayItemVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -39240,14 +38188,6 @@ impl ::std::str::FromStr for JoinaggregateTransformType {
 impl ::std::convert::TryFrom<&str> for JoinaggregateTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for JoinaggregateTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -39843,14 +38783,6 @@ impl ::std::str::FromStr for Kde2dTransformType {
 impl ::std::convert::TryFrom<&str> for Kde2dTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for Kde2dTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -40765,14 +39697,6 @@ impl ::std::convert::TryFrom<&str> for KdeTransformResolveVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for KdeTransformResolveVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for KdeTransformResolveVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -40861,14 +39785,6 @@ impl ::std::str::FromStr for KdeTransformType {
 impl ::std::convert::TryFrom<&str> for KdeTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for KdeTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -40977,14 +39893,6 @@ impl ::std::str::FromStr for LabelOverlapVariant1 {
 impl ::std::convert::TryFrom<&str> for LabelOverlapVariant1 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LabelOverlapVariant1 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -41851,14 +40759,6 @@ impl ::std::convert::TryFrom<&str> for LabelTransformType {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LabelTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LabelTransformType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -42368,14 +41268,6 @@ impl ::std::convert::TryFrom<&str> for LayoutObjectAlignVariant0Variant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LayoutObjectAlignVariant0Variant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LayoutObjectAlignVariant0Variant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -42480,14 +41372,6 @@ impl ::std::str::FromStr for LayoutObjectAlignVariant1ColumnVariant0 {
 impl ::std::convert::TryFrom<&str> for LayoutObjectAlignVariant1ColumnVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LayoutObjectAlignVariant1ColumnVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -42596,14 +41480,6 @@ impl ::std::convert::TryFrom<&str> for LayoutObjectAlignVariant1RowVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LayoutObjectAlignVariant1RowVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LayoutObjectAlignVariant1RowVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -42700,14 +41576,6 @@ impl ::std::str::FromStr for LayoutObjectBoundsVariant0 {
 impl ::std::convert::TryFrom<&str> for LayoutObjectBoundsVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LayoutObjectBoundsVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -43173,14 +42041,6 @@ impl ::std::convert::TryFrom<&str> for LayoutObjectTitleAnchorVariant0Variant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LayoutObjectTitleAnchorVariant0Variant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LayoutObjectTitleAnchorVariant0Variant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -43279,16 +42139,6 @@ impl ::std::str::FromStr for LayoutObjectTitleAnchorVariant1ColumnVariant0 {
 impl ::std::convert::TryFrom<&str> for LayoutObjectTitleAnchorVariant1ColumnVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for LayoutObjectTitleAnchorVariant1ColumnVariant0
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -43392,16 +42242,6 @@ impl ::std::str::FromStr for LayoutObjectTitleAnchorVariant1RowVariant0 {
 impl ::std::convert::TryFrom<&str> for LayoutObjectTitleAnchorVariant1RowVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for LayoutObjectTitleAnchorVariant1RowVariant0
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -46755,14 +45595,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant0Direction {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant0Direction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant0Direction {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -47045,14 +45877,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant0FormatTypeVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant0FormatTypeVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant0FormatTypeVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -47256,14 +46080,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant0GridAlignVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant0GridAlignVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant0GridAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -47366,14 +46182,6 @@ impl ::std::str::FromStr for LegendVariant0LabelAlignVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant0LabelAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant0LabelAlignVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -47497,14 +46305,6 @@ impl ::std::str::FromStr for LegendVariant0LabelBaselineVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant0LabelBaselineVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant0LabelBaselineVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -48027,14 +46827,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant0OrientVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant0OrientVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant0OrientVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -48498,14 +47290,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant0TitleAlignVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant0TitleAlignVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant0TitleAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -48612,14 +47396,6 @@ impl ::std::str::FromStr for LegendVariant0TitleAnchorVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant0TitleAnchorVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant0TitleAnchorVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -48743,14 +47519,6 @@ impl ::std::str::FromStr for LegendVariant0TitleBaselineVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant0TitleBaselineVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant0TitleBaselineVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -49142,14 +47910,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant0TitleOrientVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant0TitleOrientVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant0TitleOrientVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -49246,14 +48006,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant0Type {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant0Type {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant0Type {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -49347,14 +48099,6 @@ impl ::std::str::FromStr for LegendVariant1Direction {
 impl ::std::convert::TryFrom<&str> for LegendVariant1Direction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant1Direction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -49640,14 +48384,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant1FormatTypeVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant1FormatTypeVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant1FormatTypeVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -49851,14 +48587,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant1GridAlignVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant1GridAlignVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant1GridAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -49961,14 +48689,6 @@ impl ::std::str::FromStr for LegendVariant1LabelAlignVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant1LabelAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant1LabelAlignVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -50092,14 +48812,6 @@ impl ::std::str::FromStr for LegendVariant1LabelBaselineVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant1LabelBaselineVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant1LabelBaselineVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -50622,14 +49334,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant1OrientVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant1OrientVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant1OrientVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -51093,14 +49797,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant1TitleAlignVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant1TitleAlignVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant1TitleAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -51207,14 +49903,6 @@ impl ::std::str::FromStr for LegendVariant1TitleAnchorVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant1TitleAnchorVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant1TitleAnchorVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -51338,14 +50026,6 @@ impl ::std::str::FromStr for LegendVariant1TitleBaselineVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant1TitleBaselineVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant1TitleBaselineVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -51737,14 +50417,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant1TitleOrientVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant1TitleOrientVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant1TitleOrientVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -51841,14 +50513,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant1Type {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant1Type {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant1Type {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -51942,14 +50606,6 @@ impl ::std::str::FromStr for LegendVariant2Direction {
 impl ::std::convert::TryFrom<&str> for LegendVariant2Direction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant2Direction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -52235,14 +50891,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant2FormatTypeVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant2FormatTypeVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant2FormatTypeVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -52446,14 +51094,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant2GridAlignVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant2GridAlignVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant2GridAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -52556,14 +51196,6 @@ impl ::std::str::FromStr for LegendVariant2LabelAlignVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant2LabelAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant2LabelAlignVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -52687,14 +51319,6 @@ impl ::std::str::FromStr for LegendVariant2LabelBaselineVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant2LabelBaselineVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant2LabelBaselineVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -53217,14 +51841,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant2OrientVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant2OrientVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant2OrientVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -53688,14 +52304,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant2TitleAlignVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant2TitleAlignVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant2TitleAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -53802,14 +52410,6 @@ impl ::std::str::FromStr for LegendVariant2TitleAnchorVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant2TitleAnchorVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant2TitleAnchorVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -53933,14 +52533,6 @@ impl ::std::str::FromStr for LegendVariant2TitleBaselineVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant2TitleBaselineVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant2TitleBaselineVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -54332,14 +52924,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant2TitleOrientVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant2TitleOrientVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant2TitleOrientVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -54436,14 +53020,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant2Type {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant2Type {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant2Type {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -54537,14 +53113,6 @@ impl ::std::str::FromStr for LegendVariant3Direction {
 impl ::std::convert::TryFrom<&str> for LegendVariant3Direction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant3Direction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -54830,14 +53398,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant3FormatTypeVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant3FormatTypeVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant3FormatTypeVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -55041,14 +53601,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant3GridAlignVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant3GridAlignVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant3GridAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -55151,14 +53703,6 @@ impl ::std::str::FromStr for LegendVariant3LabelAlignVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant3LabelAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant3LabelAlignVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -55282,14 +53826,6 @@ impl ::std::str::FromStr for LegendVariant3LabelBaselineVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant3LabelBaselineVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant3LabelBaselineVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -55812,14 +54348,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant3OrientVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant3OrientVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant3OrientVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -56283,14 +54811,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant3TitleAlignVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant3TitleAlignVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant3TitleAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -56397,14 +54917,6 @@ impl ::std::str::FromStr for LegendVariant3TitleAnchorVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant3TitleAnchorVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant3TitleAnchorVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -56528,14 +55040,6 @@ impl ::std::str::FromStr for LegendVariant3TitleBaselineVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant3TitleBaselineVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant3TitleBaselineVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -56927,14 +55431,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant3TitleOrientVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant3TitleOrientVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant3TitleOrientVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -57031,14 +55527,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant3Type {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant3Type {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant3Type {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -57132,14 +55620,6 @@ impl ::std::str::FromStr for LegendVariant4Direction {
 impl ::std::convert::TryFrom<&str> for LegendVariant4Direction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant4Direction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -57425,14 +55905,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant4FormatTypeVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant4FormatTypeVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant4FormatTypeVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -57636,14 +56108,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant4GridAlignVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant4GridAlignVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant4GridAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -57746,14 +56210,6 @@ impl ::std::str::FromStr for LegendVariant4LabelAlignVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant4LabelAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant4LabelAlignVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -57877,14 +56333,6 @@ impl ::std::str::FromStr for LegendVariant4LabelBaselineVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant4LabelBaselineVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant4LabelBaselineVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -58407,14 +56855,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant4OrientVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant4OrientVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant4OrientVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -58878,14 +57318,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant4TitleAlignVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant4TitleAlignVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant4TitleAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -58992,14 +57424,6 @@ impl ::std::str::FromStr for LegendVariant4TitleAnchorVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant4TitleAnchorVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant4TitleAnchorVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -59123,14 +57547,6 @@ impl ::std::str::FromStr for LegendVariant4TitleBaselineVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant4TitleBaselineVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant4TitleBaselineVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -59522,14 +57938,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant4TitleOrientVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant4TitleOrientVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant4TitleOrientVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -59626,14 +58034,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant4Type {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant4Type {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant4Type {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -59727,14 +58127,6 @@ impl ::std::str::FromStr for LegendVariant5Direction {
 impl ::std::convert::TryFrom<&str> for LegendVariant5Direction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant5Direction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -60020,14 +58412,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant5FormatTypeVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant5FormatTypeVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant5FormatTypeVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -60231,14 +58615,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant5GridAlignVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant5GridAlignVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant5GridAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -60341,14 +58717,6 @@ impl ::std::str::FromStr for LegendVariant5LabelAlignVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant5LabelAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant5LabelAlignVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -60472,14 +58840,6 @@ impl ::std::str::FromStr for LegendVariant5LabelBaselineVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant5LabelBaselineVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant5LabelBaselineVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -61002,14 +59362,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant5OrientVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant5OrientVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant5OrientVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -61473,14 +59825,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant5TitleAlignVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant5TitleAlignVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant5TitleAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -61587,14 +59931,6 @@ impl ::std::str::FromStr for LegendVariant5TitleAnchorVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant5TitleAnchorVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant5TitleAnchorVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -61718,14 +60054,6 @@ impl ::std::str::FromStr for LegendVariant5TitleBaselineVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant5TitleBaselineVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant5TitleBaselineVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -62117,14 +60445,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant5TitleOrientVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant5TitleOrientVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant5TitleOrientVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -62221,14 +60541,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant5Type {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant5Type {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant5Type {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -62322,14 +60634,6 @@ impl ::std::str::FromStr for LegendVariant6Direction {
 impl ::std::convert::TryFrom<&str> for LegendVariant6Direction {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant6Direction {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -62615,14 +60919,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant6FormatTypeVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant6FormatTypeVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant6FormatTypeVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -62826,14 +61122,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant6GridAlignVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant6GridAlignVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant6GridAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -62936,14 +61224,6 @@ impl ::std::str::FromStr for LegendVariant6LabelAlignVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant6LabelAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant6LabelAlignVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -63067,14 +61347,6 @@ impl ::std::str::FromStr for LegendVariant6LabelBaselineVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant6LabelBaselineVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant6LabelBaselineVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -63597,14 +61869,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant6OrientVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant6OrientVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant6OrientVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -64068,14 +62332,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant6TitleAlignVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant6TitleAlignVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant6TitleAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -64182,14 +62438,6 @@ impl ::std::str::FromStr for LegendVariant6TitleAnchorVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant6TitleAnchorVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant6TitleAnchorVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -64313,14 +62561,6 @@ impl ::std::str::FromStr for LegendVariant6TitleBaselineVariant0 {
 impl ::std::convert::TryFrom<&str> for LegendVariant6TitleBaselineVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant6TitleBaselineVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -64712,14 +62952,6 @@ impl ::std::convert::TryFrom<&str> for LegendVariant6TitleOrientVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant6TitleOrientVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LegendVariant6TitleOrientVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -64813,14 +63045,6 @@ impl ::std::str::FromStr for LegendVariant6Type {
 impl ::std::convert::TryFrom<&str> for LegendVariant6Type {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LegendVariant6Type {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -64935,14 +63159,6 @@ impl ::std::str::FromStr for LinearGradientGradient {
 impl ::std::convert::TryFrom<&str> for LinearGradientGradient {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LinearGradientGradient {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -65241,14 +63457,6 @@ impl ::std::convert::TryFrom<&str> for LinkpathTransformOrientVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LinkpathTransformOrientVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LinkpathTransformOrientVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -65369,14 +63577,6 @@ impl ::std::str::FromStr for LinkpathTransformShapeVariant0 {
 impl ::std::convert::TryFrom<&str> for LinkpathTransformShapeVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LinkpathTransformShapeVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -65635,14 +63835,6 @@ impl ::std::str::FromStr for LinkpathTransformType {
 impl ::std::convert::TryFrom<&str> for LinkpathTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LinkpathTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -66072,14 +64264,6 @@ impl ::std::str::FromStr for LoessTransformType {
 impl ::std::convert::TryFrom<&str> for LoessTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for LoessTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -66559,14 +64743,6 @@ impl ::std::convert::TryFrom<&str> for LookupTransformType {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LookupTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LookupTransformType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -66956,14 +65132,6 @@ impl ::std::str::FromStr for MarkGroupType {
 impl ::std::convert::TryFrom<&str> for MarkGroupType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for MarkGroupType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -67375,14 +65543,6 @@ impl ::std::convert::TryFrom<&str> for NestTransformType {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for NestTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for NestTransformType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -67521,14 +65681,6 @@ impl ::std::str::FromStr for NumberModifiersBand {
 impl ::std::convert::TryFrom<&str> for NumberModifiersBand {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for NumberModifiersBand {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -68273,16 +66425,6 @@ impl ::std::convert::TryFrom<&str> for NumberValueVariant0ItemVariant0Variant0Ba
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for NumberValueVariant0ItemVariant0Variant0Band
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for NumberValueVariant0ItemVariant0Variant0Band
 {
@@ -68448,16 +66590,6 @@ impl ::std::str::FromStr for NumberValueVariant0ItemVariant0Variant1Band {
 impl ::std::convert::TryFrom<&str> for NumberValueVariant0ItemVariant0Variant1Band {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for NumberValueVariant0ItemVariant0Variant1Band
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -68629,16 +66761,6 @@ impl ::std::convert::TryFrom<&str> for NumberValueVariant0ItemVariant0Variant2Ba
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for NumberValueVariant0ItemVariant0Variant2Band
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for NumberValueVariant0ItemVariant0Variant2Band
 {
@@ -68807,16 +66929,6 @@ impl ::std::convert::TryFrom<&str> for NumberValueVariant0ItemVariant0Variant3Ba
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for NumberValueVariant0ItemVariant0Variant3Band
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for NumberValueVariant0ItemVariant0Variant3Band
 {
@@ -68982,16 +67094,6 @@ impl ::std::str::FromStr for NumberValueVariant0ItemVariant0Variant3Range {
 impl ::std::convert::TryFrom<&str> for NumberValueVariant0ItemVariant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for NumberValueVariant0ItemVariant0Variant3Range
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -69804,14 +67906,6 @@ impl ::std::convert::TryFrom<&str> for NumberValueVariant1Variant0Variant0Band {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for NumberValueVariant1Variant0Variant0Band {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for NumberValueVariant1Variant0Variant0Band {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -69981,14 +68075,6 @@ impl ::std::str::FromStr for NumberValueVariant1Variant0Variant1Band {
 impl ::std::convert::TryFrom<&str> for NumberValueVariant1Variant0Variant1Band {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for NumberValueVariant1Variant0Variant1Band {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -70164,14 +68250,6 @@ impl ::std::convert::TryFrom<&str> for NumberValueVariant1Variant0Variant2Band {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for NumberValueVariant1Variant0Variant2Band {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for NumberValueVariant1Variant0Variant2Band {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -70344,14 +68422,6 @@ impl ::std::convert::TryFrom<&str> for NumberValueVariant1Variant0Variant3Band {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for NumberValueVariant1Variant0Variant3Band {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for NumberValueVariant1Variant0Variant3Band {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -70521,14 +68591,6 @@ impl ::std::str::FromStr for NumberValueVariant1Variant0Variant3Range {
 impl ::std::convert::TryFrom<&str> for NumberValueVariant1Variant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for NumberValueVariant1Variant0Variant3Range {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -72078,16 +70140,6 @@ impl ::std::convert::TryFrom<&str> for OrientValueVariant0ItemVariant0Variant1Va
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for OrientValueVariant0ItemVariant0Variant1Value
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for OrientValueVariant0ItemVariant0Variant1Value
 {
@@ -72136,16 +70188,6 @@ impl ::std::str::FromStr for OrientValueVariant0ItemVariant0Variant3Range {
 impl ::std::convert::TryFrom<&str> for OrientValueVariant0ItemVariant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for OrientValueVariant0ItemVariant0Variant3Range
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -72704,14 +70746,6 @@ impl ::std::convert::TryFrom<&str> for OrientValueVariant1Variant0Variant1Value 
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for OrientValueVariant1Variant0Variant1Value {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for OrientValueVariant1Variant0Variant1Value {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -72758,14 +70792,6 @@ impl ::std::str::FromStr for OrientValueVariant1Variant0Variant3Range {
 impl ::std::convert::TryFrom<&str> for OrientValueVariant1Variant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for OrientValueVariant1Variant0Variant3Range {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -73487,14 +71513,6 @@ impl ::std::convert::TryFrom<&str> for PackTransformType {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for PackTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for PackTransformType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -74058,14 +72076,6 @@ impl ::std::convert::TryFrom<&str> for PartitionTransformType {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for PartitionTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for PartitionTransformType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -74469,14 +72479,6 @@ impl ::std::str::FromStr for PieTransformType {
 impl ::std::convert::TryFrom<&str> for PieTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for PieTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -75076,14 +73078,6 @@ impl ::std::convert::TryFrom<&str> for PivotTransformOpVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for PivotTransformOpVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for PivotTransformOpVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -75139,14 +73133,6 @@ impl ::std::str::FromStr for PivotTransformType {
 impl ::std::convert::TryFrom<&str> for PivotTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for PivotTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -75501,14 +73487,6 @@ impl ::std::str::FromStr for ProjectTransformType {
 impl ::std::convert::TryFrom<&str> for ProjectTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ProjectTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -76655,14 +74633,6 @@ impl ::std::convert::TryFrom<&str> for QuantileTransformType {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for QuantileTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for QuantileTransformType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -76784,14 +74754,6 @@ impl ::std::str::FromStr for RadialGradientGradient {
 impl ::std::convert::TryFrom<&str> for RadialGradientGradient {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for RadialGradientGradient {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -77377,14 +75339,6 @@ impl ::std::convert::TryFrom<&str> for RegressionTransformType {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for RegressionTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for RegressionTransformType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -77607,14 +75561,6 @@ impl ::std::convert::TryFrom<&str> for ResolvefilterTransformType {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ResolvefilterTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ResolvefilterTransformType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -77781,14 +75727,6 @@ impl ::std::str::FromStr for SampleTransformType {
 impl ::std::convert::TryFrom<&str> for SampleTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for SampleTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -81279,14 +79217,6 @@ impl ::std::convert::TryFrom<&str> for ScaleDataVariant1SortVariant1Op {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleDataVariant1SortVariant1Op {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ScaleDataVariant1SortVariant1Op {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -81352,14 +79282,6 @@ impl ::std::str::FromStr for ScaleDataVariant1SortVariant2Op {
 impl ::std::convert::TryFrom<&str> for ScaleDataVariant1SortVariant2Op {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleDataVariant1SortVariant2Op {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -81608,14 +79530,6 @@ impl ::std::convert::TryFrom<&str> for ScaleDataVariant2SortVariant1Op {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleDataVariant2SortVariant1Op {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ScaleDataVariant2SortVariant1Op {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -81681,14 +79595,6 @@ impl ::std::str::FromStr for ScaleDataVariant2SortVariant2Op {
 impl ::std::convert::TryFrom<&str> for ScaleDataVariant2SortVariant2Op {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleDataVariant2SortVariant2Op {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -81991,14 +79897,6 @@ impl ::std::str::FromStr for ScaleVariant0Type {
 impl ::std::convert::TryFrom<&str> for ScaleVariant0Type {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleVariant0Type {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -82438,14 +80336,6 @@ impl ::std::convert::TryFrom<&str> for ScaleVariant10RangeVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleVariant10RangeVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant10RangeVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -82678,14 +80568,6 @@ impl ::std::str::FromStr for ScaleVariant10Type {
 impl ::std::convert::TryFrom<&str> for ScaleVariant10Type {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleVariant10Type {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -83125,14 +81007,6 @@ impl ::std::convert::TryFrom<&str> for ScaleVariant11RangeVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleVariant11RangeVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant11RangeVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -83365,14 +81239,6 @@ impl ::std::str::FromStr for ScaleVariant11Type {
 impl ::std::convert::TryFrom<&str> for ScaleVariant11Type {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleVariant11Type {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -83976,14 +81842,6 @@ impl ::std::convert::TryFrom<&str> for ScaleVariant1RangeVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleVariant1RangeVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant1RangeVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -84569,16 +82427,6 @@ impl ::std::convert::TryFrom<&str> for ScaleVariant1RangeVariant3Variant1SortVar
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for ScaleVariant1RangeVariant3Variant1SortVariant1Op
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for ScaleVariant1RangeVariant3Variant1SortVariant1Op
 {
@@ -84646,16 +82494,6 @@ impl ::std::str::FromStr for ScaleVariant1RangeVariant3Variant1SortVariant2Op {
 impl ::std::convert::TryFrom<&str> for ScaleVariant1RangeVariant3Variant1SortVariant2Op {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for ScaleVariant1RangeVariant3Variant1SortVariant2Op
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -84906,16 +82744,6 @@ impl ::std::convert::TryFrom<&str> for ScaleVariant1RangeVariant3Variant2SortVar
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for ScaleVariant1RangeVariant3Variant2SortVariant1Op
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for ScaleVariant1RangeVariant3Variant2SortVariant1Op
 {
@@ -84986,16 +82814,6 @@ impl ::std::convert::TryFrom<&str> for ScaleVariant1RangeVariant3Variant2SortVar
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for ScaleVariant1RangeVariant3Variant2SortVariant2Op
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for ScaleVariant1RangeVariant3Variant2SortVariant2Op
 {
@@ -85053,14 +82871,6 @@ impl ::std::str::FromStr for ScaleVariant1Type {
 impl ::std::convert::TryFrom<&str> for ScaleVariant1Type {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleVariant1Type {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -85412,14 +83222,6 @@ impl ::std::convert::TryFrom<&str> for ScaleVariant2RangeVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleVariant2RangeVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant2RangeVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -85537,14 +83339,6 @@ impl ::std::str::FromStr for ScaleVariant2Type {
 impl ::std::convert::TryFrom<&str> for ScaleVariant2Type {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleVariant2Type {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -85896,14 +83690,6 @@ impl ::std::convert::TryFrom<&str> for ScaleVariant3RangeVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleVariant3RangeVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant3RangeVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -86021,14 +83807,6 @@ impl ::std::str::FromStr for ScaleVariant3Type {
 impl ::std::convert::TryFrom<&str> for ScaleVariant3Type {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleVariant3Type {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -86466,14 +84244,6 @@ impl ::std::convert::TryFrom<&str> for ScaleVariant4RangeVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleVariant4RangeVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant4RangeVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -86711,14 +84481,6 @@ impl ::std::str::FromStr for ScaleVariant4Type {
 impl ::std::convert::TryFrom<&str> for ScaleVariant4Type {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleVariant4Type {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -87114,14 +84876,6 @@ impl ::std::convert::TryFrom<&str> for ScaleVariant5RangeVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleVariant5RangeVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant5RangeVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -87354,14 +85108,6 @@ impl ::std::str::FromStr for ScaleVariant5Type {
 impl ::std::convert::TryFrom<&str> for ScaleVariant5Type {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleVariant5Type {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -87757,14 +85503,6 @@ impl ::std::convert::TryFrom<&str> for ScaleVariant6RangeVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleVariant6RangeVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant6RangeVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -87997,14 +85735,6 @@ impl ::std::str::FromStr for ScaleVariant6Type {
 impl ::std::convert::TryFrom<&str> for ScaleVariant6Type {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleVariant6Type {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -88345,14 +86075,6 @@ impl ::std::convert::TryFrom<&str> for ScaleVariant7NiceVariant1 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleVariant7NiceVariant1 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant7NiceVariant1 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -88487,14 +86209,6 @@ impl ::std::str::FromStr for ScaleVariant7NiceVariant2IntervalVariant0 {
 impl ::std::convert::TryFrom<&str> for ScaleVariant7NiceVariant2IntervalVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleVariant7NiceVariant2IntervalVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -88721,14 +86435,6 @@ impl ::std::str::FromStr for ScaleVariant7RangeVariant0 {
 impl ::std::convert::TryFrom<&str> for ScaleVariant7RangeVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleVariant7RangeVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -88969,14 +86675,6 @@ impl ::std::str::FromStr for ScaleVariant7Type {
 impl ::std::convert::TryFrom<&str> for ScaleVariant7Type {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleVariant7Type {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -89414,14 +87112,6 @@ impl ::std::convert::TryFrom<&str> for ScaleVariant8RangeVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleVariant8RangeVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant8RangeVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -89664,14 +87354,6 @@ impl ::std::str::FromStr for ScaleVariant8Type {
 impl ::std::convert::TryFrom<&str> for ScaleVariant8Type {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleVariant8Type {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -90109,14 +87791,6 @@ impl ::std::convert::TryFrom<&str> for ScaleVariant9RangeVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleVariant9RangeVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for ScaleVariant9RangeVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -90349,14 +88023,6 @@ impl ::std::str::FromStr for ScaleVariant9Type {
 impl ::std::convert::TryFrom<&str> for ScaleVariant9Type {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ScaleVariant9Type {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -90837,14 +88503,6 @@ impl ::std::convert::TryFrom<&str> for SequenceTransformType {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for SequenceTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for SequenceTransformType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -91114,14 +88772,6 @@ impl ::std::convert::TryFrom<&str> for SignalVariant0Push {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for SignalVariant0Push {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for SignalVariant0Push {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -91218,14 +88868,6 @@ impl ::std::str::FromStr for SortOrderVariant0 {
 impl ::std::convert::TryFrom<&str> for SortOrderVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for SortOrderVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -91679,14 +89321,6 @@ impl ::std::convert::TryFrom<&str> for StackTransformOffsetVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for StackTransformOffsetVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for StackTransformOffsetVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -91742,14 +89376,6 @@ impl ::std::str::FromStr for StackTransformType {
 impl ::std::convert::TryFrom<&str> for StackTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for StackTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -91955,14 +89581,6 @@ impl ::std::str::FromStr for StratifyTransformType {
 impl ::std::convert::TryFrom<&str> for StratifyTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for StratifyTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -92775,16 +90393,6 @@ impl ::std::convert::TryFrom<&str> for StringValueVariant0ItemVariant0Variant3Ra
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for StringValueVariant0ItemVariant0Variant3Range
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for StringValueVariant0ItemVariant0Variant3Range
 {
@@ -93293,14 +90901,6 @@ impl ::std::str::FromStr for StringValueVariant1Variant0Variant3Range {
 impl ::std::convert::TryFrom<&str> for StringValueVariant1Variant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for StringValueVariant1Variant0Variant3Range {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -94057,16 +91657,6 @@ impl ::std::convert::TryFrom<&str> for StrokeCapValueVariant0ItemVariant0Variant
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for StrokeCapValueVariant0ItemVariant0Variant1Value
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for StrokeCapValueVariant0ItemVariant0Variant1Value
 {
@@ -94115,16 +91705,6 @@ impl ::std::str::FromStr for StrokeCapValueVariant0ItemVariant0Variant3Range {
 impl ::std::convert::TryFrom<&str> for StrokeCapValueVariant0ItemVariant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for StrokeCapValueVariant0ItemVariant0Variant3Range
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -94674,16 +92254,6 @@ impl ::std::convert::TryFrom<&str> for StrokeCapValueVariant1Variant0Variant1Val
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for StrokeCapValueVariant1Variant0Variant1Value
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for StrokeCapValueVariant1Variant0Variant1Value
 {
@@ -94732,16 +92302,6 @@ impl ::std::str::FromStr for StrokeCapValueVariant1Variant0Variant3Range {
 impl ::std::convert::TryFrom<&str> for StrokeCapValueVariant1Variant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for StrokeCapValueVariant1Variant0Variant3Range
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -95508,16 +93068,6 @@ impl ::std::convert::TryFrom<&str> for StrokeJoinValueVariant0ItemVariant0Varian
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for StrokeJoinValueVariant0ItemVariant0Variant1Value
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for StrokeJoinValueVariant0ItemVariant0Variant1Value
 {
@@ -95566,16 +93116,6 @@ impl ::std::str::FromStr for StrokeJoinValueVariant0ItemVariant0Variant3Range {
 impl ::std::convert::TryFrom<&str> for StrokeJoinValueVariant0ItemVariant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for StrokeJoinValueVariant0ItemVariant0Variant3Range
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -96125,16 +93665,6 @@ impl ::std::convert::TryFrom<&str> for StrokeJoinValueVariant1Variant0Variant1Va
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for StrokeJoinValueVariant1Variant0Variant1Value
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String>
     for StrokeJoinValueVariant1Variant0Variant1Value
 {
@@ -96183,16 +93713,6 @@ impl ::std::str::FromStr for StrokeJoinValueVariant1Variant0Variant3Range {
 impl ::std::convert::TryFrom<&str> for StrokeJoinValueVariant1Variant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String>
-    for StrokeJoinValueVariant1Variant0Variant3Range
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -97102,16 +94622,6 @@ impl ::std::convert::TryFrom<&str> for TextValueVariant0ItemVariant0Variant3Rang
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String>
-    for TextValueVariant0ItemVariant0Variant3Range
-{
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for TextValueVariant0ItemVariant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -97694,14 +95204,6 @@ impl ::std::convert::TryFrom<&str> for TextValueVariant1Variant0Variant3Range {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for TextValueVariant1Variant0Variant3Range {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for TextValueVariant1Variant0Variant3Range {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -98051,14 +95553,6 @@ impl ::std::convert::TryFrom<&str> for TickBandVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for TickBandVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for TickBandVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -98239,14 +95733,6 @@ impl ::std::convert::TryFrom<&str> for TickCountVariant1 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for TickCountVariant1 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for TickCountVariant1 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -98379,14 +95865,6 @@ impl ::std::str::FromStr for TickCountVariant2IntervalVariant0 {
 impl ::std::convert::TryFrom<&str> for TickCountVariant2IntervalVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for TickCountVariant2IntervalVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -99003,14 +96481,6 @@ impl ::std::convert::TryFrom<&str> for TimeunitTransformTimezoneVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for TimeunitTransformTimezoneVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for TimeunitTransformTimezoneVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -99066,14 +96536,6 @@ impl ::std::str::FromStr for TimeunitTransformType {
 impl ::std::convert::TryFrom<&str> for TimeunitTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for TimeunitTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -99286,14 +96748,6 @@ impl ::std::str::FromStr for TimeunitTransformUnitsArrayItemVariant0 {
 impl ::std::convert::TryFrom<&str> for TimeunitTransformUnitsArrayItemVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for TimeunitTransformUnitsArrayItemVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -99887,14 +97341,6 @@ impl ::std::convert::TryFrom<&str> for TitleObjectAlignVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for TitleObjectAlignVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for TitleObjectAlignVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -99999,14 +97445,6 @@ impl ::std::str::FromStr for TitleObjectAnchorVariant0 {
 impl ::std::convert::TryFrom<&str> for TitleObjectAnchorVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for TitleObjectAnchorVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -100163,14 +97601,6 @@ impl ::std::str::FromStr for TitleObjectBaselineVariant0 {
 impl ::std::convert::TryFrom<&str> for TitleObjectBaselineVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for TitleObjectBaselineVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -100381,14 +97811,6 @@ impl ::std::str::FromStr for TitleObjectEncodeSubtype0Key {
 impl ::std::convert::TryFrom<&str> for TitleObjectEncodeSubtype0Key {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for TitleObjectEncodeSubtype0Key {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -100690,14 +98112,6 @@ impl ::std::convert::TryFrom<&str> for TitleObjectFrameVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for TitleObjectFrameVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for TitleObjectFrameVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -100913,14 +98327,6 @@ impl ::std::str::FromStr for TitleObjectOrientVariant0 {
 impl ::std::convert::TryFrom<&str> for TitleObjectOrientVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for TitleObjectOrientVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -102293,14 +99699,6 @@ impl ::std::convert::TryFrom<&str> for TreeTransformMethodVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for TreeTransformMethodVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for TreeTransformMethodVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -102554,14 +99952,6 @@ impl ::std::convert::TryFrom<&str> for TreeTransformType {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for TreeTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for TreeTransformType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -102649,14 +100039,6 @@ impl ::std::str::FromStr for TreelinksTransformType {
 impl ::std::convert::TryFrom<&str> for TreelinksTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for TreelinksTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -103185,14 +100567,6 @@ impl ::std::convert::TryFrom<&str> for TreemapTransformMethodVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for TreemapTransformMethodVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for TreemapTransformMethodVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -103632,14 +101006,6 @@ impl ::std::convert::TryFrom<&str> for TreemapTransformType {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for TreemapTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for TreemapTransformType {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -103985,14 +101351,6 @@ impl ::std::str::FromStr for VoronoiTransformType {
 impl ::std::convert::TryFrom<&str> for VoronoiTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for VoronoiTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -105116,14 +102474,6 @@ impl ::std::convert::TryFrom<&str> for WindowTransformOpsArrayItemVariant0 {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for WindowTransformOpsArrayItemVariant0 {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for WindowTransformOpsArrayItemVariant0 {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -105264,14 +102614,6 @@ impl ::std::str::FromStr for WindowTransformType {
 impl ::std::convert::TryFrom<&str> for WindowTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for WindowTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -106251,14 +103593,6 @@ impl ::std::str::FromStr for WordcloudTransformType {
 impl ::std::convert::TryFrom<&str> for WordcloudTransformType {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for WordcloudTransformType {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }

--- a/typify/tests/schemas/extraneous-enum.rs
+++ b/typify/tests/schemas/extraneous-enum.rs
@@ -122,14 +122,6 @@ impl ::std::convert::TryFrom<&str> for LetterBoxLetter {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for LetterBoxLetter {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for LetterBoxLetter {
     type Error = self::error::ConversionError;
     fn try_from(

--- a/typify/tests/schemas/id-or-name.rs
+++ b/typify/tests/schemas/id-or-name.rs
@@ -77,14 +77,6 @@ impl ::std::convert::TryFrom<&str> for IdOrName {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for IdOrName {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for IdOrName {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -152,14 +144,6 @@ impl ::std::str::FromStr for IdOrNameRedundant {
 impl ::std::convert::TryFrom<&str> for IdOrNameRedundant {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IdOrNameRedundant {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -242,14 +226,6 @@ impl ::std::convert::TryFrom<&str> for IdOrYolo {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for IdOrYolo {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for IdOrYolo {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -315,14 +291,6 @@ impl ::std::str::FromStr for IdOrYoloYolo {
 impl ::std::convert::TryFrom<&str> for IdOrYoloYolo {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for IdOrYoloYolo {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -394,14 +362,6 @@ impl ::std::str::FromStr for Name {
 impl ::std::convert::TryFrom<&str> for Name {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for Name {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }

--- a/typify/tests/schemas/merged-schemas.rs
+++ b/typify/tests/schemas/merged-schemas.rs
@@ -343,14 +343,6 @@ impl ::std::convert::TryFrom<&str> for JsonSuccessBaseResult {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for JsonSuccessBaseResult {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for JsonSuccessBaseResult {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -407,14 +399,6 @@ impl ::std::str::FromStr for JsonSuccessResult {
 impl ::std::convert::TryFrom<&str> for JsonSuccessResult {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for JsonSuccessResult {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -596,14 +580,6 @@ impl ::std::str::FromStr for MergeStringBounds {
 impl ::std::convert::TryFrom<&str> for MergeStringBounds {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for MergeStringBounds {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -975,14 +951,6 @@ impl ::std::convert::TryFrom<&str> for TriplePattern {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for TriplePattern {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for TriplePattern {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -1098,14 +1066,6 @@ impl ::std::str::FromStr for UnchangedByMergeTag {
 impl ::std::convert::TryFrom<&str> for UnchangedByMergeTag {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for UnchangedByMergeTag {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1397,14 +1357,6 @@ impl ::std::convert::TryFrom<&str> for Unsatisfiable3B {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for Unsatisfiable3B {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for Unsatisfiable3B {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -1461,14 +1413,6 @@ impl ::std::str::FromStr for Unsatisfiable3C {
 impl ::std::convert::TryFrom<&str> for Unsatisfiable3C {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for Unsatisfiable3C {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }

--- a/typify/tests/schemas/property-pattern.rs
+++ b/typify/tests/schemas/property-pattern.rs
@@ -104,14 +104,6 @@ impl ::std::convert::TryFrom<&str> for TestGrammarForPatternPropertiesRulesKey {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for TestGrammarForPatternPropertiesRulesKey {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for TestGrammarForPatternPropertiesRulesKey {
     type Error = self::error::ConversionError;
     fn try_from(

--- a/typify/tests/schemas/rust-collisions.rs
+++ b/typify/tests/schemas/rust-collisions.rs
@@ -286,14 +286,6 @@ impl ::std::convert::TryFrom<&str> for FormatCollision {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for FormatCollision {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for FormatCollision {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -525,14 +517,6 @@ impl ::std::str::FromStr for MapOfKeywordsKeywordMapValue {
 impl ::std::convert::TryFrom<&str> for MapOfKeywordsKeywordMapValue {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for MapOfKeywordsKeywordMapValue {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1428,14 +1412,6 @@ impl ::std::convert::TryFrom<&str> for StringEnum {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for StringEnum {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for StringEnum {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -1485,14 +1461,6 @@ impl ::std::str::FromStr for StringNewtype {
 impl ::std::convert::TryFrom<&str> for StringNewtype {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for StringNewtype {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }

--- a/typify/tests/schemas/string-enum-with-default.rs
+++ b/typify/tests/schemas/string-enum-with-default.rs
@@ -87,14 +87,6 @@ impl ::std::convert::TryFrom<&str> for TestEnum {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for TestEnum {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for TestEnum {
     type Error = self::error::ConversionError;
     fn try_from(

--- a/typify/tests/schemas/types-with-more-impls.rs
+++ b/typify/tests/schemas/types-with-more-impls.rs
@@ -67,14 +67,6 @@ impl ::std::convert::TryFrom<&str> for PatternString {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for PatternString {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for PatternString {
     type Error = self::error::ConversionError;
     fn try_from(

--- a/typify/tests/schemas/untyped-enum-with-null.rs
+++ b/typify/tests/schemas/untyped-enum-with-null.rs
@@ -120,14 +120,6 @@ impl ::std::convert::TryFrom<&str> for TestTypeValue {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for TestTypeValue {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for TestTypeValue {
     type Error = self::error::ConversionError;
     fn try_from(

--- a/typify/tests/schemas/various-enums-json-schema.rs
+++ b/typify/tests/schemas/various-enums-json-schema.rs
@@ -85,14 +85,6 @@ impl ::std::convert::TryFrom<&str> for AlternativeEnum {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AlternativeEnum {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AlternativeEnum {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -297,14 +289,6 @@ impl ::std::convert::TryFrom<&str> for CommentedVariants {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for CommentedVariants {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for CommentedVariants {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -408,14 +392,6 @@ impl ::std::str::FromStr for DiskAttachmentState {
 impl ::std::convert::TryFrom<&str> for DiskAttachmentState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for DiskAttachmentState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -677,14 +653,6 @@ impl ::std::convert::TryFrom<&str> for IpNet {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for IpNet {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for IpNet {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -763,14 +731,6 @@ impl ::std::convert::TryFrom<&str> for Ipv4Net {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for Ipv4Net {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for Ipv4Net {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -840,14 +800,6 @@ impl ::std::str::FromStr for Ipv6Net {
 impl ::std::convert::TryFrom<&str> for Ipv6Net {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for Ipv6Net {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1169,14 +1121,6 @@ impl ::std::str::FromStr for NullStringEnumWithUnknownFormatInner {
 impl ::std::convert::TryFrom<&str> for NullStringEnumWithUnknownFormatInner {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for NullStringEnumWithUnknownFormatInner {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1833,14 +1777,6 @@ impl ::std::str::FromStr for VariantsDifferByPunct {
 impl ::std::convert::TryFrom<&str> for VariantsDifferByPunct {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for VariantsDifferByPunct {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }

--- a/typify/tests/schemas/various-enums.rs
+++ b/typify/tests/schemas/various-enums.rs
@@ -84,14 +84,6 @@ impl ::std::convert::TryFrom<&str> for AlternativeEnum {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for AlternativeEnum {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for AlternativeEnum {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -275,14 +267,6 @@ impl ::std::convert::TryFrom<&str> for CommentedVariants {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for CommentedVariants {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for CommentedVariants {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -385,14 +369,6 @@ impl ::std::str::FromStr for DiskAttachmentState {
 impl ::std::convert::TryFrom<&str> for DiskAttachmentState {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for DiskAttachmentState {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -640,14 +616,6 @@ impl ::std::convert::TryFrom<&str> for IpNet {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for IpNet {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for IpNet {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -716,14 +684,6 @@ impl ::std::convert::TryFrom<&str> for Ipv4Net {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for Ipv4Net {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
 impl ::std::convert::TryFrom<::std::string::String> for Ipv4Net {
     type Error = self::error::ConversionError;
     fn try_from(
@@ -783,14 +743,6 @@ impl ::std::str::FromStr for Ipv6Net {
 impl ::std::convert::TryFrom<&str> for Ipv6Net {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for Ipv6Net {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1086,14 +1038,6 @@ impl ::std::str::FromStr for NullStringEnumWithUnknownFormatInner {
 impl ::std::convert::TryFrom<&str> for NullStringEnumWithUnknownFormatInner {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for NullStringEnumWithUnknownFormatInner {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
@@ -1747,14 +1691,6 @@ impl ::std::str::FromStr for VariantsDifferByPunct {
 impl ::std::convert::TryFrom<&str> for VariantsDifferByPunct {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for VariantsDifferByPunct {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }


### PR DESCRIPTION
#946 removed the non-idiomatic `TryFrom<&String>` impl at one emission site (newtypes proxying an inner type's `FromStr`), but three other sites still generate the same impl:

- simple string enums
- untagged newtype enums with `FromStr` conversion
- string-constrained newtypes

This removes all three, completing #946. `TryFrom<&str>` covers `&String` callers via deref coercion, and `TryFrom<String>` remains for owned values. −7,143 lines across the test goldens (835 impl blocks).

Breaking for any caller spelling `T::try_from(&string)` where inference relied on the `&String` impl — same trade-off as accepted in #946.
