### PR TITLE
Use properties' declared defaults when rendering whole-type defaults

### DIFF
--- a/typify-impl/src/value.rs
+++ b/typify-impl/src/value.rs
@@ -8,8 +8,9 @@ use quote::{format_ident, quote};
 use crate::{
     convert::STD_NUM_NONZERO_PREFIX,
     type_entry::{
-        EnumTagType, StructProperty, StructPropertyRename, TypeEntry, TypeEntryDetails,
-        TypeEntryEnum, TypeEntryNative, TypeEntryNewtype, TypeEntryStruct, Variant, VariantDetails,
+        EnumTagType, StructProperty, StructPropertyRename, StructPropertyState, TypeEntry,
+        TypeEntryDetails, TypeEntryEnum, TypeEntryNative, TypeEntryNewtype, TypeEntryStruct,
+        Variant, VariantDetails,
     },
     TypeId, TypeSpace,
 };
@@ -399,8 +400,17 @@ fn value_for_struct_props(
             let prop_value = type_entry.output_value(type_space, value, scope)?;
 
             Some(quote! { #name_ident: #prop_value })
+        } else if let StructPropertyState::Default(default) = &prop.state {
+            // The property is absent from the whole-type default value, but it
+            // declares its own default. Use that so that `T::default()` agrees
+            // with deserializing the (partial) default value, which fills in
+            // absent properties via their serde default functions.
+            let type_entry = type_space.id_to_entry.get(&prop.type_id).unwrap();
+            let prop_value = type_entry.output_value(type_space, &default.0, scope)?;
+
+            Some(quote! { #name_ident: #prop_value })
         } else {
-            Some(quote! { #name_ident: Default::default() })
+            Some(quote! { #name_ident: ::std::default::Default::default() })
         }
     });
 
@@ -643,7 +653,7 @@ mod tests {
                         a: "aaaa".to_string(),
                         b: 7_u32,
                         c: ::std::option::Option::Some("cccc".to_string()),
-                        d: Default::default()
+                        d: ::std::default::Default::default()
                     }
                 }
                 .to_string()
@@ -685,7 +695,7 @@ mod tests {
                         a: "aaaa".to_string(),
                         b: 7_u32,
                         c: ::std::option::Option::Some("cccc".to_string()),
-                        d: Default::default()
+                        d: ::std::default::Default::default()
                     }
                 }
                 .to_string()

--- a/typify/tests/schemas/types-with-defaults.json
+++ b/typify/tests/schemas/types-with-defaults.json
@@ -86,6 +86,47 @@
         }
       }
     },
+    "SeparatorConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "default": {},
+      "properties": {
+        "lineThickness": {
+          "type": "integer",
+          "default": 1
+        },
+        "lineColor": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": "#B2000000"
+        }
+      }
+    },
+    "SeparatorHolder": {
+      "type": "object",
+      "properties": {
+        "separatorAll": {
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/SeparatorConfig"
+            }
+          ]
+        },
+        "separatorSome": {
+          "default": {
+            "lineThickness": 5
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/SeparatorConfig"
+            }
+          ]
+        }
+      }
+    },
     "UInt": {
       "type": "integer"
     },

--- a/typify/tests/schemas/types-with-defaults.rs
+++ b/typify/tests/schemas/types-with-defaults.rs
@@ -160,6 +160,111 @@ impl OuterThing {
         Default::default()
     }
 }
+#[doc = "`SeparatorConfig`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"default\": {},"]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"lineColor\": {"]
+#[doc = "      \"default\": \"#B2000000\","]
+#[doc = "      \"type\": ["]
+#[doc = "        \"string\","]
+#[doc = "        \"null\""]
+#[doc = "      ]"]
+#[doc = "    },"]
+#[doc = "    \"lineThickness\": {"]
+#[doc = "      \"default\": 1,"]
+#[doc = "      \"type\": \"integer\""]
+#[doc = "    }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct SeparatorConfig {
+    #[serde(
+        rename = "lineColor",
+        default = "defaults::separator_config_line_color"
+    )]
+    pub line_color: ::std::option::Option<::std::string::String>,
+    #[serde(rename = "lineThickness", default = "defaults::default_u64::<i64, 1>")]
+    pub line_thickness: i64,
+}
+impl ::std::default::Default for SeparatorConfig {
+    fn default() -> Self {
+        Self {
+            line_color: defaults::separator_config_line_color(),
+            line_thickness: defaults::default_u64::<i64, 1>(),
+        }
+    }
+}
+impl SeparatorConfig {
+    pub fn builder() -> builder::SeparatorConfig {
+        Default::default()
+    }
+}
+#[doc = "`SeparatorHolder`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"separatorAll\": {"]
+#[doc = "      \"default\": {},"]
+#[doc = "      \"allOf\": ["]
+#[doc = "        {"]
+#[doc = "          \"$ref\": \"#/definitions/SeparatorConfig\""]
+#[doc = "        }"]
+#[doc = "      ]"]
+#[doc = "    },"]
+#[doc = "    \"separatorSome\": {"]
+#[doc = "      \"default\": {"]
+#[doc = "        \"lineThickness\": 5"]
+#[doc = "      },"]
+#[doc = "      \"allOf\": ["]
+#[doc = "        {"]
+#[doc = "          \"$ref\": \"#/definitions/SeparatorConfig\""]
+#[doc = "        }"]
+#[doc = "      ]"]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+pub struct SeparatorHolder {
+    #[serde(
+        rename = "separatorAll",
+        default = "defaults::separator_holder_separator_all"
+    )]
+    pub separator_all: SeparatorConfig,
+    #[serde(
+        rename = "separatorSome",
+        default = "defaults::separator_holder_separator_some"
+    )]
+    pub separator_some: SeparatorConfig,
+}
+impl ::std::default::Default for SeparatorHolder {
+    fn default() -> Self {
+        Self {
+            separator_all: defaults::separator_holder_separator_all(),
+            separator_some: defaults::separator_holder_separator_some(),
+        }
+    }
+}
+impl SeparatorHolder {
+    pub fn builder() -> builder::SeparatorHolder {
+        Default::default()
+    }
+}
 #[doc = "`TestBed`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
@@ -252,7 +357,7 @@ pub struct ThingWithDefaults {
 impl ::std::default::Default for ThingWithDefaults {
     fn default() -> Self {
         ThingWithDefaults {
-            a: Default::default(),
+            a: ::std::default::Default::default(),
             type_: ::std::option::Option::Some("bee".to_string()),
         }
     }
@@ -505,6 +610,117 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
+    pub struct SeparatorConfig {
+        line_color: ::std::result::Result<
+            ::std::option::Option<::std::string::String>,
+            ::std::string::String,
+        >,
+        line_thickness: ::std::result::Result<i64, ::std::string::String>,
+    }
+    impl ::std::default::Default for SeparatorConfig {
+        fn default() -> Self {
+            Self {
+                line_color: Ok(super::defaults::separator_config_line_color()),
+                line_thickness: Ok(super::defaults::default_u64::<i64, 1>()),
+            }
+        }
+    }
+    impl SeparatorConfig {
+        pub fn line_color<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.line_color = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for line_color: {e}"));
+            self
+        }
+        pub fn line_thickness<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<i64>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.line_thickness = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for line_thickness: {e}"));
+            self
+        }
+    }
+    impl ::std::convert::TryFrom<SeparatorConfig> for super::SeparatorConfig {
+        type Error = super::error::ConversionError;
+        fn try_from(
+            value: SeparatorConfig,
+        ) -> ::std::result::Result<Self, super::error::ConversionError> {
+            Ok(Self {
+                line_color: value.line_color?,
+                line_thickness: value.line_thickness?,
+            })
+        }
+    }
+    impl ::std::convert::From<super::SeparatorConfig> for SeparatorConfig {
+        fn from(value: super::SeparatorConfig) -> Self {
+            Self {
+                line_color: Ok(value.line_color),
+                line_thickness: Ok(value.line_thickness),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct SeparatorHolder {
+        separator_all: ::std::result::Result<super::SeparatorConfig, ::std::string::String>,
+        separator_some: ::std::result::Result<super::SeparatorConfig, ::std::string::String>,
+    }
+    impl ::std::default::Default for SeparatorHolder {
+        fn default() -> Self {
+            Self {
+                separator_all: Ok(super::defaults::separator_holder_separator_all()),
+                separator_some: Ok(super::defaults::separator_holder_separator_some()),
+            }
+        }
+    }
+    impl SeparatorHolder {
+        pub fn separator_all<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<super::SeparatorConfig>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.separator_all = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for separator_all: {e}"));
+            self
+        }
+        pub fn separator_some<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<super::SeparatorConfig>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.separator_some = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for separator_some: {e}"));
+            self
+        }
+    }
+    impl ::std::convert::TryFrom<SeparatorHolder> for super::SeparatorHolder {
+        type Error = super::error::ConversionError;
+        fn try_from(
+            value: SeparatorHolder,
+        ) -> ::std::result::Result<Self, super::error::ConversionError> {
+            Ok(Self {
+                separator_all: value.separator_all?,
+                separator_some: value.separator_some?,
+            })
+        }
+    }
+    impl ::std::convert::From<super::SeparatorHolder> for SeparatorHolder {
+        fn from(value: super::SeparatorHolder) -> Self {
+            Self {
+                separator_all: Ok(value.separator_all),
+                separator_some: Ok(value.separator_some),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
     pub struct TestBed {
         any: ::std::result::Result<::std::vec::Vec<::serde_json::Value>, ::std::string::String>,
         id: ::std::result::Result<::uuid::Uuid, ::std::string::String>,
@@ -659,6 +875,13 @@ pub mod builder {
 }
 #[doc = r" Generation of default values for serde."]
 pub mod defaults {
+    pub(super) fn default_u64<T, const V: u64>() -> T
+    where
+        T: ::std::convert::TryFrom<u64>,
+        <T as ::std::convert::TryFrom<u64>>::Error: ::std::fmt::Debug,
+    {
+        T::try_from(V).unwrap()
+    }
     pub(super) fn default_nzu64<T, const V: u64>() -> T
     where
         T: ::std::convert::TryFrom<::std::num::NonZeroU64>,
@@ -675,6 +898,21 @@ pub mod defaults {
     pub(super) fn mr_default_numbers_big_nullable() -> ::std::option::Option<::std::num::NonZeroU64>
     {
         ::std::option::Option::Some(::std::num::NonZeroU64::new(1).unwrap())
+    }
+    pub(super) fn separator_config_line_color() -> ::std::option::Option<::std::string::String> {
+        ::std::option::Option::Some("#B2000000".to_string())
+    }
+    pub(super) fn separator_holder_separator_all() -> super::SeparatorConfig {
+        super::SeparatorConfig {
+            line_color: ::std::option::Option::Some("#B2000000".to_string()),
+            line_thickness: 1_i64,
+        }
+    }
+    pub(super) fn separator_holder_separator_some() -> super::SeparatorConfig {
+        super::SeparatorConfig {
+            line_color: ::std::option::Option::Some("#B2000000".to_string()),
+            line_thickness: 5_i64,
+        }
     }
     pub(super) fn test_bed_any() -> ::std::vec::Vec<::serde_json::Value> {
         vec![

--- a/typify/tests/whole_type_defaults.rs
+++ b/typify/tests/whole_type_defaults.rs
@@ -1,0 +1,25 @@
+// Copyright 2026 Oxide Computer Company
+
+mod generated {
+    typify::import_types!("tests/schemas/types-with-defaults.json");
+}
+
+use generated::{SeparatorConfig, SeparatorHolder};
+
+fn assert_separator_eq(actual: &SeparatorConfig, expected: &SeparatorConfig) {
+    assert_eq!(actual.line_color, expected.line_color);
+    assert_eq!(actual.line_thickness, expected.line_thickness);
+}
+
+#[test]
+fn whole_type_defaults_match_deserialization() {
+    let holder = SeparatorHolder::default();
+
+    let empty: SeparatorConfig = serde_json::from_value(serde_json::json!({})).unwrap();
+    assert_separator_eq(&holder.separator_all, &empty);
+
+    let partial: SeparatorConfig =
+        serde_json::from_value(serde_json::json!({ "lineThickness": 5 })).unwrap();
+    assert_separator_eq(&holder.separator_some, &partial);
+    assert_eq!(holder.separator_some.line_thickness, 5);
+}


### PR DESCRIPTION
Fixes #662

When typify renders a whole-type default value — a struct type's `default` used for its `impl Default`, or a parent property's default expression — properties absent from the default JSON object were filled in with `Default::default()`, ignoring those properties' own declared `default` values from the schema.

Using the schema from #662:

```json
"separator": {
  "$ref": "#/definitions/SeparatorConfig",
  "default": {}
}
```

previously generated

```rust
super::SeparatorConfig {
    line_color: Default::default(),      // -> None
    line_thickness: Default::default(),  // -> 0
}
```

which disagrees with what deserializing the declared default value `{}` produces (the per-property serde default functions yield `Some("#B2000000")` / `1`). So the rendered default did not mean what the schema says it means.

With this change, a property absent from the whole-type default is rendered from its own declared default when it has one:

```rust
super::SeparatorConfig {
    line_color: ::std::option::Option::Some("#B2000000".to_string()),
    line_thickness: 1_i64,
}
```

falling back to `Default::default()` only when the property declares no default. While here, the fallback is fully qualified as `::std::default::Default::default()`, since a schema can legitimately define a type named `Default`.

The `types-with-defaults.json` golden test is extended with the `SeparatorConfig`/`SeparatorHolder` example from the issue, covering both a `default: {}` (all properties filled from their declared defaults) and a partial `default: { "lineThickness": 5 }` (the remaining properties filled from their declared defaults).
