### PR TITLE
Preserve definition-level defaults when types are reached via $ref

### DIFF
--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -706,6 +706,12 @@ impl TypeSpace {
 
     fn convert_ref_type(&mut self, type_name: Name, schema: Schema, type_id: TypeId) -> Result<()> {
         let (mut type_entry, metadata) = self.convert_schema(type_name.clone(), &schema)?;
+        // Note that the conversion may have already recorded a default drawn
+        // from the definition's own metadata (e.g. structs record it in
+        // TypeEntryStruct::from_metadata and return no metadata). Only
+        // override that value if the metadata returned by the conversion
+        // actually specifies a default--such as one declared at the reference
+        // site--rather than clobbering it with `None`.
         let default = metadata
             .as_ref()
             .and_then(|m| m.default.as_ref())
@@ -714,15 +720,21 @@ impl TypeSpace {
         let type_entry = match &mut type_entry.details {
             // The types that are already named are good to go.
             TypeEntryDetails::Enum(details) => {
-                details.default = default;
+                if default.is_some() {
+                    details.default = default;
+                }
                 type_entry
             }
             TypeEntryDetails::Struct(details) => {
-                details.default = default;
+                if default.is_some() {
+                    details.default = default;
+                }
                 type_entry
             }
             TypeEntryDetails::Newtype(details) => {
-                details.default = default;
+                if default.is_some() {
+                    details.default = default;
+                }
                 type_entry
             }
 

--- a/typify/tests/schemas/ref-with-default.json
+++ b/typify/tests/schemas/ref-with-default.json
@@ -1,0 +1,48 @@
+{
+  "$comment": "definition-level defaults should survive $ref resolution",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "DefaultedStruct": {
+      "type": "object",
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "default": {
+        "a": "hello"
+      }
+    },
+    "DefaultedEnum": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "gamma"
+      ],
+      "default": "beta"
+    },
+    "Root": {
+      "type": "object",
+      "properties": {
+        "via_ref": {
+          "$ref": "#/definitions/DefaultedStruct"
+        },
+        "enum_via_ref": {
+          "$ref": "#/definitions/DefaultedEnum"
+        },
+        "override_at_ref": {
+          "default": {
+            "a": "override"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/DefaultedStruct"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/typify/tests/schemas/ref-with-default.rs
+++ b/typify/tests/schemas/ref-with-default.rs
@@ -1,0 +1,313 @@
+#![deny(warnings)]
+#[doc = r" Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
+}
+#[doc = "`DefaultedEnum`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"default\": \"beta\","]
+#[doc = "  \"type\": \"string\","]
+#[doc = "  \"enum\": ["]
+#[doc = "    \"alpha\","]
+#[doc = "    \"beta\","]
+#[doc = "    \"gamma\""]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+)]
+pub enum DefaultedEnum {
+    #[serde(rename = "alpha")]
+    Alpha,
+    #[serde(rename = "beta")]
+    Beta,
+    #[serde(rename = "gamma")]
+    Gamma,
+}
+impl ::std::fmt::Display for DefaultedEnum {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match *self {
+            Self::Alpha => f.write_str("alpha"),
+            Self::Beta => f.write_str("beta"),
+            Self::Gamma => f.write_str("gamma"),
+        }
+    }
+}
+impl ::std::str::FromStr for DefaultedEnum {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        match value {
+            "alpha" => Ok(Self::Alpha),
+            "beta" => Ok(Self::Beta),
+            "gamma" => Ok(Self::Gamma),
+            _ => Err("invalid value".into()),
+        }
+    }
+}
+impl ::std::convert::TryFrom<&str> for DefaultedEnum {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<::std::string::String> for DefaultedEnum {
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: ::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::default::Default for DefaultedEnum {
+    fn default() -> Self {
+        DefaultedEnum::Beta
+    }
+}
+#[doc = "`DefaultedStruct`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"default\": {"]
+#[doc = "    \"a\": \"hello\""]
+#[doc = "  },"]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"a\": {"]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct DefaultedStruct {
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub a: ::std::option::Option<::std::string::String>,
+}
+impl ::std::default::Default for DefaultedStruct {
+    fn default() -> Self {
+        DefaultedStruct {
+            a: ::std::option::Option::Some("hello".to_string()),
+        }
+    }
+}
+impl DefaultedStruct {
+    pub fn builder() -> builder::DefaultedStruct {
+        Default::default()
+    }
+}
+#[doc = "`Root`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"enum_via_ref\": {"]
+#[doc = "      \"$ref\": \"#/definitions/DefaultedEnum\""]
+#[doc = "    },"]
+#[doc = "    \"override_at_ref\": {"]
+#[doc = "      \"default\": {"]
+#[doc = "        \"a\": \"override\""]
+#[doc = "      },"]
+#[doc = "      \"allOf\": ["]
+#[doc = "        {"]
+#[doc = "          \"$ref\": \"#/definitions/DefaultedStruct\""]
+#[doc = "        }"]
+#[doc = "      ]"]
+#[doc = "    },"]
+#[doc = "    \"via_ref\": {"]
+#[doc = "      \"$ref\": \"#/definitions/DefaultedStruct\""]
+#[doc = "    }"]
+#[doc = "  }"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+pub struct Root {
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub enum_via_ref: ::std::option::Option<DefaultedEnum>,
+    #[serde(default = "defaults::root_override_at_ref")]
+    pub override_at_ref: DefaultedStruct,
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub via_ref: ::std::option::Option<DefaultedStruct>,
+}
+impl ::std::default::Default for Root {
+    fn default() -> Self {
+        Self {
+            enum_via_ref: Default::default(),
+            override_at_ref: defaults::root_override_at_ref(),
+            via_ref: Default::default(),
+        }
+    }
+}
+impl Root {
+    pub fn builder() -> builder::Root {
+        Default::default()
+    }
+}
+#[doc = r" Types for composing complex structures."]
+pub mod builder {
+    #[derive(Clone, Debug)]
+    pub struct DefaultedStruct {
+        a: ::std::result::Result<
+            ::std::option::Option<::std::string::String>,
+            ::std::string::String,
+        >,
+    }
+    impl ::std::default::Default for DefaultedStruct {
+        fn default() -> Self {
+            Self {
+                a: Ok(Default::default()),
+            }
+        }
+    }
+    impl DefaultedStruct {
+        pub fn a<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.a = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for a: {e}"));
+            self
+        }
+    }
+    impl ::std::convert::TryFrom<DefaultedStruct> for super::DefaultedStruct {
+        type Error = super::error::ConversionError;
+        fn try_from(
+            value: DefaultedStruct,
+        ) -> ::std::result::Result<Self, super::error::ConversionError> {
+            Ok(Self { a: value.a? })
+        }
+    }
+    impl ::std::convert::From<super::DefaultedStruct> for DefaultedStruct {
+        fn from(value: super::DefaultedStruct) -> Self {
+            Self { a: Ok(value.a) }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct Root {
+        enum_via_ref: ::std::result::Result<
+            ::std::option::Option<super::DefaultedEnum>,
+            ::std::string::String,
+        >,
+        override_at_ref: ::std::result::Result<super::DefaultedStruct, ::std::string::String>,
+        via_ref: ::std::result::Result<
+            ::std::option::Option<super::DefaultedStruct>,
+            ::std::string::String,
+        >,
+    }
+    impl ::std::default::Default for Root {
+        fn default() -> Self {
+            Self {
+                enum_via_ref: Ok(Default::default()),
+                override_at_ref: Ok(super::defaults::root_override_at_ref()),
+                via_ref: Ok(Default::default()),
+            }
+        }
+    }
+    impl Root {
+        pub fn enum_via_ref<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::option::Option<super::DefaultedEnum>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.enum_via_ref = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for enum_via_ref: {e}"));
+            self
+        }
+        pub fn override_at_ref<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<super::DefaultedStruct>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.override_at_ref = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for override_at_ref: {e}"));
+            self
+        }
+        pub fn via_ref<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::option::Option<super::DefaultedStruct>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.via_ref = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for via_ref: {e}"));
+            self
+        }
+    }
+    impl ::std::convert::TryFrom<Root> for super::Root {
+        type Error = super::error::ConversionError;
+        fn try_from(value: Root) -> ::std::result::Result<Self, super::error::ConversionError> {
+            Ok(Self {
+                enum_via_ref: value.enum_via_ref?,
+                override_at_ref: value.override_at_ref?,
+                via_ref: value.via_ref?,
+            })
+        }
+    }
+    impl ::std::convert::From<super::Root> for Root {
+        fn from(value: super::Root) -> Self {
+            Self {
+                enum_via_ref: Ok(value.enum_via_ref),
+                override_at_ref: Ok(value.override_at_ref),
+                via_ref: Ok(value.via_ref),
+            }
+        }
+    }
+}
+#[doc = r" Generation of default values for serde."]
+pub mod defaults {
+    pub(super) fn root_override_at_ref() -> super::DefaultedStruct {
+        super::DefaultedStruct {
+            a: ::std::option::Option::Some("override".to_string()),
+        }
+    }
+}
+fn main() {}


### PR DESCRIPTION
## Bug

When a schema definition carries its own `default` value, that default is dropped when the type is reached via `$ref`. For example:

```json
{
  "definitions": {
    "DefaultedStruct": {
      "type": "object",
      "properties": { "a": { "type": "string" } },
      "default": { "a": "hello" }
    }
  }
}
```

Referenced via `"$ref": "#/definitions/DefaultedStruct"`, the generated type loses the definition-level default (its `Default` impl falls back to per-field defaults, yielding `a: None`). Inlining the identical schema preserves it (`a: Some("hello")`).

## Cause

`convert_ref_type` recomputes the default from the metadata returned by `convert_schema` and assigns it unconditionally. For struct conversions that returned metadata is `None` — `TypeEntryStruct::from_metadata` consumes the metadata and records the default itself — so the already-recorded default was clobbered with `None`. (Enums were unaffected because `convert_enum_string` returns `Some(metadata)`, which is why the asymmetry went unnoticed.)

## Fix

Only override the recorded default when the metadata returned by the conversion actually specifies one.

Precedence is preserved: a default declared at the reference site (sibling metadata alongside `$ref`, handled by the merge path) comes back as `Some` and still takes precedence over the definition-level default.

## Testing

New golden test `typify/tests/schemas/ref-with-default.json` covering:
- a definition-level struct default reached via `$ref` — now generates `Default for DefaultedStruct` with `a: Some("hello")`;
- a definition-level enum default reached via `$ref` — unchanged behavior;
- a ref-site override (`allOf` + sibling `default`) — still wins over the definition-level default.

No other golden outputs change. `cargo test --workspace --locked` passes; `cargo fmt --all -- --check` is clean.
