### PR TITLE
Make macro dependencies alias-safe

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,8 @@
 
 https://github.com/oxidecomputer/typify/compare/v0.7.0\...HEAD[Full list of commits]
 
+* `import_types!` no longer requires direct dependencies on `chrono`, `regress`, `serde`, `serde_json`, or `uuid`, including when the `typify` dependency is renamed.
+
 == 0.7.0 (released 2026-06-05)
 
 https://github.com/oxidecomputer/typify/compare/v0.6.2\...v0.7.0[Full list of commits]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,9 +623,9 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miniz_oxide"
@@ -753,6 +753,15 @@ checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
 dependencies = [
  "proc-macro2",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.1+spec-1.1.0",
 ]
 
 [[package]]
@@ -1153,7 +1162,7 @@ dependencies = [
  "serde",
  "serde_spanned 0.6.4",
  "toml_datetime 0.6.5",
- "toml_edit",
+ "toml_edit 0.21.0",
 ]
 
 [[package]]
@@ -1200,6 +1209,18 @@ dependencies = [
  "serde_spanned 0.6.4",
  "toml_datetime 0.6.5",
  "winnow 0.5.28",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "538ed8bc4ada0b2549f2a7be9654aac2dfa358faeabb97d7845c3eb5a297e5d6"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_parser",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -1334,6 +1355,7 @@ dependencies = [
 name = "typify-macro"
 version = "0.7.0"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "schemars",
@@ -1343,6 +1365,26 @@ dependencies = [
  "serde_tokenstream",
  "syn 3.0.3",
  "typify-impl",
+]
+
+[[package]]
+name = "typify-macro-direct-test"
+version = "0.0.0"
+dependencies = [
+ "chrono",
+ "regress",
+ "serde",
+ "serde_json",
+ "typify",
+ "typify-macro",
+ "uuid",
+]
+
+[[package]]
+name = "typify-macro-test"
+version = "0.0.0"
+dependencies = [
+ "typify",
 ]
 
 [[package]]
@@ -1796,6 +1838,9 @@ name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ members = [
 	"typify-impl",
 	"typify-macro",
 	"typify-test",
+	"typify-macro-test",
+	"typify-macro-direct-test",
 	"cargo-typify",
 	"example-build",
 	"example-macro",
@@ -12,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-typify = { version = "0.7.0", path = "typify" }
+typify = { version = "0.7.0", path = "typify", default-features = false }
 typify-impl = { version = "0.7.0", path = "typify-impl" }
 typify-macro = { version = "0.7.0", path = "typify-macro" }
 
@@ -30,6 +32,7 @@ newline-converter = "0.3.0"
 paste = "1.0.15"
 prettyplease = "0.3.0"
 proc-macro2 = "1.0.106"
+proc-macro-crate = "3.5.0"
 quote = "1.0.45"
 regress = "0.11.1"
 rustfmt-wrapper = "0.2.1"

--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ type to use.
 
 String schemas that include a known `format` are represented with the
 appropriate Rust type. For example `{ "type": "string", "format": "uuid" }` is
-represented as a `uuid::Uuid` (which requires the `uuid` crate be included as a
-dependency).
+represented as a `uuid::Uuid`. Code emitted by `cargo-typify` or a `build.rs`
+requires the corresponding crate as a dependency. The `import_types!` macro
+uses dependencies re-exported by `typify`, so macro consumers do not need to
+declare Typify's built-in generated-code dependencies themselves.
 
 ### Arrays
 

--- a/cargo-typify/Cargo.toml
+++ b/cargo-typify/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["api-bindings", "compilers"]
 default-run = "cargo-typify"
 
 [dependencies]
-typify = { workspace = true }
+typify = { workspace = true, default-features = false }
 
 clap = { workspace = true }
 color-eyre = { workspace = true }

--- a/example-build/Cargo.toml
+++ b/example-build/Cargo.toml
@@ -12,4 +12,4 @@ prettyplease = "0.3"
 schemars = "0.8"
 serde_json = "1.0"
 syn = "3.0"
-typify = { path = "../typify" }
+typify = { path = "../typify", default-features = false }

--- a/typify-impl/src/convert.rs
+++ b/typify-impl/src/convert.rs
@@ -9,6 +9,7 @@ use crate::type_entry::{
 };
 use crate::util::{all_mutually_exclusive, ref_key, ReorderedInstanceType, StringValidator};
 use log::{debug, info};
+use quote::quote;
 use schemars::schema::{
     ArrayValidation, InstanceType, Metadata, ObjectValidation, Schema, SchemaObject, SingleOrVec,
     StringValidation, SubschemaValidation,
@@ -16,7 +17,7 @@ use schemars::schema::{
 
 use crate::util::get_type_name;
 
-use crate::{Error, Name, Result, TypeSpace, TypeSpaceImpl};
+use crate::{Error, GeneratedCrate, Name, Result, TypeSpace, TypeSpaceImpl};
 
 pub const STD_NUM_NONZERO_PREFIX: &str = "::std::num::NonZero";
 
@@ -803,9 +804,10 @@ impl TypeSpace {
         match format.as_ref().map(String::as_str) {
             Some("uuid") => {
                 self.uses_uuid = true;
+                let uuid = self.settings.generated_crate_path(GeneratedCrate::Uuid);
                 Ok((
                     TypeEntry::new_native(
-                        "::uuid::Uuid",
+                        quote!(#uuid::Uuid),
                         &[TypeSpaceImpl::Display, TypeSpaceImpl::FromStr],
                     ),
                     metadata,
@@ -814,9 +816,10 @@ impl TypeSpace {
 
             Some("date") => {
                 self.uses_chrono = true;
+                let chrono = self.settings.generated_crate_path(GeneratedCrate::Chrono);
                 Ok((
                     TypeEntry::new_native(
-                        "::chrono::naive::NaiveDate",
+                        quote!(#chrono::naive::NaiveDate),
                         &[TypeSpaceImpl::Display, TypeSpaceImpl::FromStr],
                     ),
                     metadata,
@@ -824,9 +827,10 @@ impl TypeSpace {
             }
             Some("date-time") => {
                 self.uses_chrono = true;
+                let chrono = self.settings.generated_crate_path(GeneratedCrate::Chrono);
                 Ok((
                     TypeEntry::new_native(
-                        "::chrono::DateTime<::chrono::offset::Utc>",
+                        quote!(#chrono::DateTime<#chrono::offset::Utc>),
                         &[TypeSpaceImpl::Display, TypeSpaceImpl::FromStr],
                     ),
                     metadata,

--- a/typify-impl/src/lib.rs
+++ b/typify-impl/src/lib.rs
@@ -308,6 +308,38 @@ pub struct TypeSpaceSettings {
     patch: BTreeMap<String, TypeSpacePatch>,
     replace: BTreeMap<String, TypeSpaceReplace>,
     convert: Vec<TypeSpaceConversion>,
+
+    reexported_crates: Option<CratePath>,
+}
+
+#[derive(Clone)]
+struct CratePath(syn::Path);
+
+impl std::fmt::Debug for CratePath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.to_token_stream().fmt(f)
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum GeneratedCrate {
+    Chrono,
+    Regress,
+    Serde,
+    SerdeJson,
+    Uuid,
+}
+
+impl GeneratedCrate {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Chrono => "chrono",
+            Self::Regress => "regress",
+            Self::Serde => "serde",
+            Self::SerdeJson => "serde_json",
+            Self::Uuid => "uuid",
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -560,6 +592,56 @@ impl TypeSpaceSettings {
     pub fn with_map_type<T: Into<MapType>>(&mut self, map_type: T) -> &mut Self {
         self.map_type = map_type.into();
         self
+    }
+
+    /// Route references to generated-code dependencies through a module that
+    /// re-exports them under their conventional crate names.
+    ///
+    /// This is used by the `typify` facade when expanding [`import_types!`].
+    /// Stand-alone generators should retain the default direct crate paths.
+    ///
+    /// [`import_types!`]: https://docs.rs/typify/latest/typify/macro.import_types.html
+    #[doc(hidden)]
+    pub fn with_reexported_crates(&mut self, path: syn::Path) -> &mut Self {
+        self.reexported_crates = Some(CratePath(path));
+        self
+    }
+
+    /// The path to use when referring to `generated_crate` in generated code:
+    /// the re-exported path when one is configured, otherwise the direct
+    /// `::<crate>` path.
+    pub(crate) fn generated_crate_path(&self, generated_crate: GeneratedCrate) -> syn::Path {
+        self.reexported_crate_path(generated_crate)
+            .unwrap_or_else(|| {
+                let name = format_ident!("{}", generated_crate.name());
+                syn::parse_quote!(::#name)
+            })
+    }
+
+    /// The re-exported path to `generated_crate`, or `None` when generated code
+    /// should use direct crate paths. A `Some` result also signals that derives
+    /// resolving the crate by name (e.g. serde) need a `crate = "..."` override.
+    pub(crate) fn reexported_crate_path(
+        &self,
+        generated_crate: GeneratedCrate,
+    ) -> Option<syn::Path> {
+        self.reexported_crates.as_ref().map(|prefix| {
+            let name = format_ident!("{}", generated_crate.name());
+            let mut path = prefix.0.clone();
+            path.segments.push(name.into());
+            path
+        })
+    }
+
+    /// The `crate = "..."` argument that points serde's derive at the
+    /// re-exported `serde`, or `None` when the derive can resolve `serde`
+    /// directly. Callers splice the result into a `#[serde(...)]` attribute.
+    pub(crate) fn serde_crate_attr_arg(&self) -> Option<TokenStream> {
+        self.reexported_crate_path(GeneratedCrate::Serde)
+            .map(|serde| {
+                let serde = serde.to_token_stream().to_string();
+                quote! { crate = #serde }
+            })
     }
 }
 

--- a/typify-impl/src/structs.rs
+++ b/typify-impl/src/structs.rs
@@ -12,7 +12,7 @@ use crate::{
         WrappedValue,
     },
     util::{get_type_name, metadata_description, recase, Case},
-    Name, Result, TypeEntryDetails, TypeId, TypeSpace,
+    GeneratedCrate, Name, Result, TypeEntryDetails, TypeId, TypeSpace,
 };
 
 impl TypeSpace {
@@ -376,8 +376,22 @@ pub(crate) fn generate_serde_attr(
             if key_ty.details == TypeEntryDetails::String
                 && value_ty.details == TypeEntryDetails::JsonValue
             {
+                // This path lands inside a string literal, whose contents
+                // rustfmt does not reformat, so we can't reuse
+                // `generated_crate_path` here: its `quote!`-derived default
+                // would emit a spaced `":: serde_json :: ..."` into the source
+                // that `build.rs`/`cargo-typify` write out. Spell the direct
+                // path literally and only route through the re-export when one
+                // is configured (macro expansion, which nobody reads).
+                let is_empty = type_space
+                    .settings
+                    .reexported_crate_path(GeneratedCrate::SerdeJson)
+                    .map_or_else(
+                        || "::serde_json::Map::is_empty".to_string(),
+                        |serde_json| quote!(#serde_json::Map::is_empty).to_string(),
+                    );
                 serde_options.push(quote! {
-                    skip_serializing_if = "::serde_json::Map::is_empty"
+                    skip_serializing_if = #is_empty
                 });
             } else {
                 let is_empty = format!("{}::is_empty", map_to_use);

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -14,7 +14,7 @@ use crate::{
     sanitize,
     structs::{generate_serde_attr, DefaultFunction},
     util::{get_type_name, metadata_description, unique, TypePatch},
-    Case, DefaultImpl, Name, Result, TypeId, TypeSpace, TypeSpaceImpl,
+    Case, DefaultImpl, GeneratedCrate, Name, Result, TypeId, TypeSpace, TypeSpaceImpl,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -734,11 +734,14 @@ impl TypeEntry {
     }
 
     pub(crate) fn output(&self, type_space: &TypeSpace, output: &mut OutputSpace) {
+        let serde = type_space
+            .settings
+            .generated_crate_path(GeneratedCrate::Serde);
         let derive_set = [
-            "::serde::Serialize",
-            "::serde::Deserialize",
-            "Debug",
-            "Clone",
+            quote!(#serde::Serialize).to_string(),
+            quote!(#serde::Deserialize).to_string(),
+            "Debug".to_string(),
+            "Clone".to_string(),
         ]
         .into_iter()
         .collect::<BTreeSet<_>>();
@@ -768,7 +771,7 @@ impl TypeEntry {
         type_space: &TypeSpace,
         output: &mut OutputSpace,
         enum_details: &TypeEntryEnum,
-        mut derive_set: BTreeSet<&str>,
+        mut derive_set: BTreeSet<String>,
     ) {
         let TypeEntryEnum {
             name,
@@ -790,10 +793,14 @@ impl TypeEntry {
             .iter()
             .all(|variant| matches!(variant.details, VariantDetails::Simple))
         {
-            derive_set.extend(["Copy", "PartialOrd", "Ord", "PartialEq", "Eq", "Hash"]);
+            derive_set
+                .extend(["Copy", "PartialOrd", "Ord", "PartialEq", "Eq", "Hash"].map(String::from));
         }
 
         let mut serde_options = Vec::new();
+        if let Some(serde_crate) = type_space.settings.serde_crate_attr_arg() {
+            serde_options.push(serde_crate);
+        }
         if let Some(old_name) = rename {
             serde_options.push(quote! { rename = #old_name });
         }
@@ -1093,7 +1100,7 @@ impl TypeEntry {
         type_space: &TypeSpace,
         output: &mut OutputSpace,
         struct_details: &TypeEntryStruct,
-        derive_set: BTreeSet<&str>,
+        derive_set: BTreeSet<String>,
     ) {
         enum PropDefault {
             None(String),
@@ -1114,6 +1121,9 @@ impl TypeEntry {
 
         // Generate the serde directives as needed.
         let mut serde_options = Vec::new();
+        if let Some(serde_crate) = type_space.settings.serde_crate_attr_arg() {
+            serde_options.push(serde_crate);
+        }
         if let Some(old_name) = rename {
             serde_options.push(quote! { rename = #old_name });
         }
@@ -1337,12 +1347,12 @@ impl TypeEntry {
         }
     }
 
-    fn output_newtype<'a>(
+    fn output_newtype(
         &self,
-        type_space: &'a TypeSpace,
+        type_space: &TypeSpace,
         output: &mut OutputSpace,
         newtype_details: &TypeEntryNewtype,
-        mut derive_set: BTreeSet<&'a str>,
+        mut derive_set: BTreeSet<String>,
     ) {
         let TypeEntryNewtype {
             name,
@@ -1364,10 +1374,21 @@ impl TypeEntry {
         // If this is just a wrapper around a string, we can derive some more
         // useful traits.
         if is_str {
-            derive_set.extend(["PartialOrd", "Ord", "PartialEq", "Eq", "Hash"]);
+            derive_set.extend(["PartialOrd", "Ord", "PartialEq", "Eq", "Hash"].map(String::from));
         }
 
-        derive_set.extend(type_space.settings.extra_derives.iter().map(|s| s.as_str()));
+        derive_set.extend(type_space.settings.extra_derives.iter().cloned());
+
+        let regress = type_space
+            .settings
+            .generated_crate_path(GeneratedCrate::Regress);
+        let serde = type_space
+            .settings
+            .generated_crate_path(GeneratedCrate::Serde);
+        let serde_deserialize = quote!(#serde::Deserialize).to_string();
+        let serde_json = type_space
+            .settings
+            .generated_crate_path(GeneratedCrate::SerdeJson);
 
         let constraint_impl = match constraints {
             // In the unconstrained case we proxy impls through the inner type.
@@ -1461,7 +1482,7 @@ impl TypeEntry {
 
                 // We're going to impl Deserialize so we can remove it
                 // from the set of derived impls.
-                derive_set.remove("::serde::Deserialize");
+                derive_set.remove(&serde_deserialize);
 
                 let value_output = enum_values
                     .iter()
@@ -1492,7 +1513,7 @@ impl TypeEntry {
                                         .into_object();
                                 let not = ::schemars::schema::SchemaObject {
                                     enum_values: ::std::option::Option::Some([
-                                        #( ::serde_json::from_str(#value_string).unwrap(), )*
+                                        #( #serde_json::from_str(#value_string).unwrap(), )*
                                     ].into_iter().collect()),
                                     ..::std::default::Default::default()
                                 };
@@ -1516,7 +1537,7 @@ impl TypeEntry {
                                         ::json_schema(gen)
                                         .into_object();
                                 schema.enum_values = ::std::option::Option::Some([
-                                    #( ::serde_json::from_str(#value_string).unwrap(), )*
+                                    #( #serde_json::from_str(#value_string).unwrap(), )*
                                 ].into_iter().collect());
                                 schema.into()
                             }
@@ -1551,18 +1572,18 @@ impl TypeEntry {
                         }
                     }
 
-                    impl<'de> ::serde::Deserialize<'de> for #type_name {
+                    impl<'de> #serde::Deserialize<'de> for #type_name {
                         fn deserialize<D>(
                             deserializer: D,
                         ) -> ::std::result::Result<Self, D::Error>
                         where
-                            D: ::serde::Deserializer<'de>,
+                            D: #serde::Deserializer<'de>,
                         {
                             Self::try_from(
                                 <#inner_type_name>::deserialize(deserializer)?,
                             )
                             .map_err(|e| {
-                                <D::Error as ::serde::de::Error>::custom(
+                                <D::Error as #serde::de::Error>::custom(
                                     e.to_string(),
                                 )
                             })
@@ -1600,8 +1621,8 @@ impl TypeEntry {
                 let pat = pattern.as_ref().map(|p| {
                     let err = format!("doesn't match pattern \"{}\"", p);
                     quote! {
-                        static PATTERN: ::std::sync::LazyLock<::regress::Regex> = ::std::sync::LazyLock::new(|| {
-                            ::regress::Regex::new(#p).unwrap()
+                        static PATTERN: ::std::sync::LazyLock<#regress::Regex> = ::std::sync::LazyLock::new(|| {
+                            #regress::Regex::new(#p).unwrap()
                         });
                         if PATTERN.find(value).is_none() {
                             return Err(#err.into());
@@ -1611,7 +1632,7 @@ impl TypeEntry {
 
                 // We're going to impl Deserialize so we can remove it
                 // from the set of derived impls.
-                derive_set.remove("::serde::Deserialize");
+                derive_set.remove(&serde_deserialize);
 
                 // TODO: if a user were to derive schemars::JsonSchema, it
                 // wouldn't be accurate.
@@ -1646,17 +1667,17 @@ impl TypeEntry {
                         }
                     }
 
-                    impl<'de> ::serde::Deserialize<'de> for #type_name {
+                    impl<'de> #serde::Deserialize<'de> for #type_name {
                         fn deserialize<D>(
                             deserializer: D,
                         ) -> ::std::result::Result<Self, D::Error>
                         where
-                            D: ::serde::Deserializer<'de>,
+                            D: #serde::Deserializer<'de>,
                         {
                             ::std::string::String::deserialize(deserializer)?
                             .parse()
                             .map_err(|e: self::error::ConversionError| {
-                                <D::Error as ::serde::de::Error>::custom(
+                                <D::Error as #serde::de::Error>::custom(
                                     e.to_string(),
                                 )
                             })
@@ -1690,10 +1711,16 @@ impl TypeEntry {
 
         let attrs = strings_to_attrs(&self.extra_attrs, &type_space.settings.extra_attrs);
 
+        let serde_crate = type_space
+            .settings
+            .serde_crate_attr_arg()
+            .map(|arg| quote! { #[serde(#arg)] });
+
         let item = quote! {
             #doc
             #(#attrs)*
             #[derive(#(#derives),*)]
+            #serde_crate
             #[serde(transparent)]
             pub struct #type_name(#vis #inner_type_name);
 
@@ -1791,7 +1818,10 @@ impl TypeEntry {
                 if key_ty.details == TypeEntryDetails::String
                     && value_ty.details == TypeEntryDetails::JsonValue
                 {
-                    quote! { ::serde_json::Map<::std::string::String, ::serde_json::Value> }
+                    let serde_json = type_space
+                        .settings
+                        .generated_crate_path(GeneratedCrate::SerdeJson);
+                    quote! { #serde_json::Map<::std::string::String, #serde_json::Value> }
                 } else {
                     let key_ident = key_ty.type_ident(type_space, type_mod);
                     let value_ident = value_ty.type_ident(type_space, type_mod);
@@ -1867,7 +1897,12 @@ impl TypeEntry {
             TypeEntryDetails::Unit => quote! { () },
             TypeEntryDetails::String => quote! { ::std::string::String },
             TypeEntryDetails::Boolean => quote! { bool },
-            TypeEntryDetails::JsonValue => quote! { ::serde_json::Value },
+            TypeEntryDetails::JsonValue => {
+                let serde_json = type_space
+                    .settings
+                    .generated_crate_path(GeneratedCrate::SerdeJson);
+                quote! { #serde_json::Value }
+            }
             TypeEntryDetails::Integer(name) | TypeEntryDetails::Float(name) => {
                 syn::parse_str::<syn::TypePath>(name)
                     .unwrap()
@@ -2031,16 +2066,16 @@ fn make_doc(name: &str, description: Option<&String>, schema: &Schema) -> TokenS
     }
 }
 
-fn strings_to_derives<'a>(
-    derive_set: BTreeSet<&'a str>,
-    type_derives: &'a BTreeSet<String>,
-    extra_derives: &'a [String],
-) -> impl Iterator<Item = TokenStream> + 'a {
-    let mut combined_derives = derive_set.clone();
-    combined_derives.extend(extra_derives.iter().map(String::as_str));
-    combined_derives.extend(type_derives.iter().map(String::as_str));
+fn strings_to_derives(
+    derive_set: BTreeSet<String>,
+    type_derives: &BTreeSet<String>,
+    extra_derives: &[String],
+) -> impl Iterator<Item = TokenStream> {
+    let mut combined_derives = derive_set;
+    combined_derives.extend(extra_derives.iter().cloned());
+    combined_derives.extend(type_derives.iter().cloned());
     combined_derives.into_iter().map(|derive| {
-        syn::parse_str::<syn::Path>(derive)
+        syn::parse_str::<syn::Path>(&derive)
             .unwrap()
             .into_token_stream()
     })

--- a/typify-impl/src/value.rs
+++ b/typify-impl/src/value.rs
@@ -11,7 +11,7 @@ use crate::{
         EnumTagType, StructProperty, StructPropertyRename, TypeEntry, TypeEntryDetails,
         TypeEntryEnum, TypeEntryNative, TypeEntryNewtype, TypeEntryStruct, Variant, VariantDetails,
     },
-    TypeId, TypeSpace,
+    GeneratedCrate, TypeId, TypeSpace,
 };
 
 impl TypeEntry {
@@ -28,6 +28,9 @@ impl TypeEntry {
         value: &serde_json::Value,
         scope: &TokenStream,
     ) -> Option<TokenStream> {
+        let serde_json = type_space
+            .settings
+            .generated_crate_path(GeneratedCrate::SerdeJson);
         let v = match &self.details {
             TypeEntryDetails::Enum(TypeEntryEnum {
                 name,
@@ -146,13 +149,13 @@ impl TypeEntry {
                 // unfortunate, but unavoidable without getting in the
                 // underpants of the serialized form of these built-in types.
                 quote! {
-                    ::serde_json::from_str::< #type_path >(#text).unwrap()
+                    #serde_json::from_str::< #type_path >(#text).unwrap()
                 }
             }
             TypeEntryDetails::JsonValue => {
                 let text = value.to_string();
                 quote! {
-                    ::serde_json::from_str::<::serde_json::Value>(#text).unwrap()
+                    #serde_json::from_str::<#serde_json::Value>(#text).unwrap()
                 }
             }
             TypeEntryDetails::Boolean => {

--- a/typify-macro-direct-test/Cargo.toml
+++ b/typify-macro-direct-test/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "typify-macro-direct-test"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+chrono = { workspace = true }
+regress = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+typify-disabled = { package = "typify", path = "../typify", default-features = false }
+typify-macro = { workspace = true }
+uuid = { workspace = true, features = ["serde"] }

--- a/typify-macro-direct-test/src/lib.rs
+++ b/typify-macro-direct-test/src/lib.rs
@@ -1,0 +1,14 @@
+typify_macro::import_types!("../typify-macro-test/schema.json");
+
+#[cfg(test)]
+mod tests {
+    use super::MacroDependencies;
+
+    #[test]
+    fn retains_direct_dependency_paths() {
+        let value: Option<MacroDependencies> = None;
+        assert!(value.is_none());
+
+        let _ = typify_disabled::TypeSpace::default();
+    }
+}

--- a/typify-macro-test/Cargo.toml
+++ b/typify-macro-test/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "typify-macro-test"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+typify-renamed = { package = "typify", path = "../typify" }

--- a/typify-macro-test/schema.json
+++ b/typify-macro-test/schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MacroDependencies",
+  "type": "object",
+  "properties": {
+    "anything": {},
+    "date": {
+      "type": "string",
+      "format": "date"
+    },
+    "date_time": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "pattern": {
+      "type": "string",
+      "pattern": "^[a-z]+$"
+    }
+  },
+  "required": ["anything", "date", "date_time", "id", "pattern"]
+}

--- a/typify-macro-test/src/lib.rs
+++ b/typify-macro-test/src/lib.rs
@@ -1,0 +1,12 @@
+typify_renamed::import_types!("schema.json");
+
+#[cfg(test)]
+mod tests {
+    use super::MacroDependencies;
+
+    #[test]
+    fn generates_root_type() {
+        let value: Option<MacroDependencies> = None;
+        assert!(value.is_none());
+    }
+}

--- a/typify-macro/Cargo.toml
+++ b/typify-macro/Cargo.toml
@@ -12,6 +12,7 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = { workspace = true }
+proc-macro-crate = { workspace = true }
 quote = { workspace = true }
 schemars = { workspace = true }
 semver = { workspace = true }

--- a/typify-macro/src/lib.rs
+++ b/typify-macro/src/lib.rs
@@ -7,7 +7,8 @@
 use std::{collections::HashMap, path::Path};
 
 use proc_macro::TokenStream;
-use quote::{quote, ToTokens};
+use proc_macro_crate::{crate_name, FoundCrate};
+use quote::{format_ident, quote, ToTokens};
 use serde::Deserialize;
 use serde_tokenstream::{ParseWrapper, TokenStreamWrapper};
 use syn::LitStr;
@@ -191,7 +192,7 @@ impl From<MacroPatch> for TypeSpacePatch {
 
 fn do_import_types(item: TokenStream) -> Result<TokenStream, syn::Error> {
     // Allow the caller to give us either a simple string or a compound object.
-    let (schema, settings) = if let Ok(ll) = syn::parse::<LitStr>(item.clone()) {
+    let (schema, mut settings) = if let Ok(ll) = syn::parse::<LitStr>(item.clone()) {
         (ll, TypeSpaceSettings::default())
     } else {
         let MacroSettings {
@@ -244,6 +245,22 @@ fn do_import_types(item: TokenStream) -> Result<TokenStream, syn::Error> {
 
         (schema.into_inner(), settings)
     };
+
+    // A direct typify-macro dependency signals direct macro use, which keeps
+    // the traditional direct dependency paths. Otherwise route generated-code
+    // dependencies through the typify facade when it is available.
+    if crate_name("typify-macro").is_err() {
+        if let Ok(found_crate) = crate_name("typify") {
+            let path = match found_crate {
+                FoundCrate::Itself => syn::parse_quote!(::typify::__private),
+                FoundCrate::Name(name) => {
+                    let name = format_ident!("{}", name);
+                    syn::parse_quote!(::#name::__private)
+                }
+            };
+            settings.with_reexported_crates(path);
+        }
+    }
 
     let dir = std::env::var("CARGO_MANIFEST_DIR").map_or_else(
         |_| std::env::current_dir().unwrap(),

--- a/typify-test/Cargo.toml
+++ b/typify-test/Cargo.toml
@@ -9,7 +9,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 
 [build-dependencies]
-typify = { path = "../typify" }
+typify = { path = "../typify", default-features = false }
 
 ipnetwork = { workspace = true }
 prettyplease = { workspace = true }

--- a/typify/Cargo.toml
+++ b/typify/Cargo.toml
@@ -11,11 +11,23 @@ categories = ["api-bindings", "compilers"]
 
 [features]
 default = ["macro"]
-macro = ["typify-macro"]
+macro = [
+	"dep:chrono",
+	"dep:regress",
+	"dep:serde",
+	"dep:serde_json",
+	"dep:typify-macro",
+	"dep:uuid",
+]
 
 [dependencies]
+chrono = { workspace = true, optional = true }
+regress = { workspace = true, optional = true }
+serde = { workspace = true, features = ["derive"], optional = true }
+serde_json = { workspace = true, optional = true }
 typify-macro = { workspace = true, optional = true }
 typify-impl = { workspace = true }
+uuid = { workspace = true, features = ["serde"], optional = true }
 
 [dev-dependencies]
 chrono = { workspace = true }

--- a/typify/src/lib.rs
+++ b/typify/src/lib.rs
@@ -148,6 +148,19 @@
 
 #![deny(missing_docs)]
 
+extern crate self as typify;
+
+/// Dependencies used by code generated through [`import_types!`].
+#[cfg(feature = "macro")]
+#[doc(hidden)]
+pub mod __private {
+    pub use chrono;
+    pub use regress;
+    pub use serde;
+    pub use serde_json;
+    pub use uuid;
+}
+
 pub use typify_impl::accept_as_ident;
 pub use typify_impl::CrateVers;
 pub use typify_impl::Error;


### PR DESCRIPTION
## Summary

- route all built-in generated-code dependencies through hidden `typify` re-exports when using `import_types!`
- resolve the downstream Cargo name for `typify`, including dependency aliases
- configure Serde derives with the re-exported crate path
- gate macro-only dependencies behind the `macro` feature and disable that feature for generator-only workspace consumers
- add a downstream compile fixture that aliases `typify` and declares no peer dependencies

## Context

This follows the approach proposed by @jeffs in #1009 and makes it comprehensive. That PR handled `regress` (only) this version applies the same policy to `chrono`, `regress`, `serde`, `serde_json`, and `uuid`, while also accounting for Cargo dependency aliases and Serde derive expansion.

Generated code previously used hard-coded absolute crate paths. Macro consumers therefore needed direct dependencies on Typify's implementation crates, and routing through `::typify` alone would fail when the package was imported under a different name.

Standalone `TypeSpace`, `build.rs`, and `cargo-typify` output retains the existing direct crate paths.

## User impact

Consumers of `typify::import_types!` only need to declare `typify` for built-in generated types. Renaming that dependency in `Cargo.toml` is supported. User-specified replacement types, conversions, and additional derives still require their own dependencies.