### PR TITLE
select CI toolchains explicitly

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: dtolnay/rust-toolchain@stable
     - name: Report cargo version
       run: cargo --version
     - name: Report rustfmt version
@@ -26,8 +27,15 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
+        rust: [ stable ]
+        include:
+        - os: ubuntu-latest
+          rust: nightly
     steps:
     - uses: actions/checkout@v2
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.rust }}
     - name: Build
       run: cargo build --locked --tests --verbose
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,3 +32,16 @@ jobs:
       run: cargo build --locked --tests --verbose
     - name: Run tests
       run: cargo test --locked --verbose
+
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: taiki-e/install-action@cargo-hack
+    - name: Check published packages on their declared MSRV
+      run: >-
+        cargo hack --workspace
+        --exclude typify-test
+        --exclude example-build
+        --exclude example-macro
+        --no-dev-deps --rust-version check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ members = [
 
 resolver = "2"
 
+[workspace.package]
+rust-version = "1.88.0"
+
 [workspace.dependencies]
 typify = { version = "0.7.0", path = "typify" }
 typify-impl = { version = "0.7.0", path = "typify-impl" }

--- a/cargo-typify/Cargo.toml
+++ b/cargo-typify/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/oxidecomputer/typify"
 readme = "README.md"
 keywords = ["json", "schema", "cargo"]
 categories = ["api-bindings", "compilers"]
+rust-version.workspace = true
 
 default-run = "cargo-typify"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "1.89.0"
-profile = "default"

--- a/typify-impl/Cargo.toml
+++ b/typify-impl/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0"
 description = "typify backend implementation"
 repository = "https://github.com/oxidecomputer/typify"
 readme = "../README.md"
+rust-version.workspace = true
 
 [dependencies]
 heck = { workspace = true }

--- a/typify-macro/Cargo.toml
+++ b/typify-macro/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0"
 description = "typify macro implementation"
 repository = "https://github.com/oxidecomputer/typify"
 readme = "../README.md"
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/typify-test/Cargo.toml
+++ b/typify-test/Cargo.toml
@@ -14,6 +14,6 @@ typify = { path = "../typify" }
 ipnetwork = { workspace = true }
 prettyplease = { workspace = true }
 schemars = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 syn = { workspace = true }

--- a/typify/Cargo.toml
+++ b/typify/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/oxidecomputer/typify"
 readme = "../README.md"
 keywords = ["json", "schema", "proc_macro"]
 categories = ["api-bindings", "compilers"]
+rust-version.workspace = true
 
 [features]
 default = ["macro"]


### PR DESCRIPTION
## Summary

- remove the repository-level `rust-toolchain.toml` pin;
- select the intended Rust toolchain explicitly in each CI job;
- test stable on Linux, macOS, and Windows;
- add a nightly Linux test without changing unrelated action versions.

## Relationship to #938

This is stacked on #938, which declares and checks the project's MSRV. The current diff therefore includes #938 until that PR merges; after it lands, this PR should be rebased onto `main` and will contain only the toolchain-policy and CI-matrix changes.

`rust-toolchain.toml` is useful for pinning a contributor toolchain, but it does not declare or enforce the minimum Rust version supported by downstream consumers. #938 establishes that contract. This follow-up removes the contributor pin and makes each CI toolchain choice explicit instead.

## Validation

- formatting and workspace tests pass;
- the MSRV check from #938 passes on Rust 1.88;
- stable CI covers Linux, macOS, and Windows;
- nightly CI covers Linux.
