### PR TITLE
improve marginal test json input

### DIFF
--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -1806,7 +1806,9 @@ impl TypeEntry {
                 if key_ty.details == TypeEntryDetails::String
                     && value_ty.details == TypeEntryDetails::JsonValue
                 {
-                    quote! { ::serde_json::Map<::std::string::String, ::serde_json::Value> }
+                    quote! {
+                        ::serde_json::Map<::std::string::String, ::serde_json::Value>
+                    }
                 } else {
                     let key_ident = key_ty.type_ident(type_space, type_mod);
                     let value_ident = value_ty.type_ident(type_space, type_mod);
@@ -1824,7 +1826,7 @@ impl TypeEntry {
                 let item = inner_ty.type_ident(type_space, type_mod);
                 // TODO we'll want this to be a Set of some kind, but we need
                 // to get the derives right first.
-                quote! { Vec<#item> }
+                quote! { ::std::vec::Vec<#item> }
             }
 
             TypeEntryDetails::Tuple(items) => {

--- a/typify/tests/schemas/arrays-and-tuples.json
+++ b/typify/tests/schemas/arrays-and-tuples.json
@@ -63,7 +63,15 @@
     "array-sans-items": {
       "type": "array",
       "minItems": 1,
-      "uniqueItems": true
+      "uniqueItems": false
+    },
+    "set-avec-item": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string"
+      }
     }
   }
 }

--- a/typify/tests/schemas/arrays-and-tuples.rs
+++ b/typify/tests/schemas/arrays-and-tuples.rs
@@ -33,26 +33,26 @@ pub mod error {
 #[doc = "{"]
 #[doc = "  \"type\": \"array\","]
 #[doc = "  \"minItems\": 1,"]
-#[doc = "  \"uniqueItems\": true"]
+#[doc = "  \"uniqueItems\": false"]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(transparent)]
-pub struct ArraySansItems(pub Vec<::serde_json::Value>);
+pub struct ArraySansItems(pub ::std::vec::Vec<::serde_json::Value>);
 impl ::std::ops::Deref for ArraySansItems {
-    type Target = Vec<::serde_json::Value>;
-    fn deref(&self) -> &Vec<::serde_json::Value> {
+    type Target = ::std::vec::Vec<::serde_json::Value>;
+    fn deref(&self) -> &::std::vec::Vec<::serde_json::Value> {
         &self.0
     }
 }
-impl ::std::convert::From<ArraySansItems> for Vec<::serde_json::Value> {
+impl ::std::convert::From<ArraySansItems> for ::std::vec::Vec<::serde_json::Value> {
     fn from(value: ArraySansItems) -> Self {
         value.0
     }
 }
-impl ::std::convert::From<Vec<::serde_json::Value>> for ArraySansItems {
-    fn from(value: Vec<::serde_json::Value>) -> Self {
+impl ::std::convert::From<::std::vec::Vec<::serde_json::Value>> for ArraySansItems {
+    fn from(value: ::std::vec::Vec<::serde_json::Value>) -> Self {
         Self(value)
     }
 }
@@ -95,6 +95,40 @@ impl ::std::convert::From<LessSimpleTwoTuple> for (::std::string::String, ::std:
 }
 impl ::std::convert::From<(::std::string::String, ::std::string::String)> for LessSimpleTwoTuple {
     fn from(value: (::std::string::String, ::std::string::String)) -> Self {
+        Self(value)
+    }
+}
+#[doc = "`SetAvecItem`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"array\","]
+#[doc = "  \"items\": {"]
+#[doc = "    \"type\": \"string\""]
+#[doc = "  },"]
+#[doc = "  \"minItems\": 1,"]
+#[doc = "  \"uniqueItems\": true"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
+pub struct SetAvecItem(pub ::std::vec::Vec<::std::string::String>);
+impl ::std::ops::Deref for SetAvecItem {
+    type Target = ::std::vec::Vec<::std::string::String>;
+    fn deref(&self) -> &::std::vec::Vec<::std::string::String> {
+        &self.0
+    }
+}
+impl ::std::convert::From<SetAvecItem> for ::std::vec::Vec<::std::string::String> {
+    fn from(value: SetAvecItem) -> Self {
+        value.0
+    }
+}
+impl ::std::convert::From<::std::vec::Vec<::std::string::String>> for SetAvecItem {
+    fn from(value: ::std::vec::Vec<::std::string::String>) -> Self {
         Self(value)
     }
 }


### PR DESCRIPTION
```json
{
      "type": "array",
      "minItems": 1,
      "uniqueItems": true
}
```

It's kind of bullshit. It works today because we don't deal with Sets properly, but a HashSet<serde_json::Value> or BTreeSet<serde_json::Value> won't work because it's not `Eq` or `Ord` (because of the float in there). Let's change this to something we ostensibly know how to construct.