### PR TITLE
small output changes (mostly cosmetic)

### DIFF
--- a/cargo-typify/tests/outputs/attr.rs
+++ b/cargo-typify/tests/outputs/attr.rs
@@ -3,32 +3,6 @@
 #![allow(clippy::match_single_binding)]
 #![allow(clippy::clone_on_copy)]
 
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`Fruit`"]
 #[extra_attr]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
@@ -93,4 +67,30 @@ pub struct Veggies {
     pub fruits: ::std::vec::Vec<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub vegetables: ::std::vec::Vec<Veggie>,
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
 }

--- a/cargo-typify/tests/outputs/builder.rs
+++ b/cargo-typify/tests/outputs/builder.rs
@@ -3,32 +3,6 @@
 #![allow(clippy::match_single_binding)]
 #![allow(clippy::clone_on_copy)]
 
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`Fruit`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(transparent)]
@@ -100,7 +74,7 @@ impl Veggies {
         Default::default()
     }
 }
-#[doc = r" Types for composing complex structures."]
+#[doc = " Types for composing complex structures."]
 pub mod builder {
     #[derive(Clone, Debug)]
     pub struct Veggie {
@@ -205,6 +179,32 @@ pub mod builder {
                 fruits: Ok(value.fruits),
                 vegetables: Ok(value.vegetables),
             }
+        }
+    }
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
         }
     }
 }

--- a/cargo-typify/tests/outputs/custom_btree_map.rs
+++ b/cargo-typify/tests/outputs/custom_btree_map.rs
@@ -3,32 +3,6 @@
 #![allow(clippy::match_single_binding)]
 #![allow(clippy::clone_on_copy)]
 
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`Fruit`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(transparent)]
@@ -101,7 +75,7 @@ impl Veggies {
         Default::default()
     }
 }
-#[doc = r" Types for composing complex structures."]
+#[doc = " Types for composing complex structures."]
 pub mod builder {
     #[derive(Clone, Debug)]
     pub struct Veggie {
@@ -206,6 +180,32 @@ pub mod builder {
                 fruits: Ok(value.fruits),
                 vegetables: Ok(value.vegetables),
             }
+        }
+    }
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
         }
     }
 }

--- a/cargo-typify/tests/outputs/derive.rs
+++ b/cargo-typify/tests/outputs/derive.rs
@@ -3,32 +3,6 @@
 #![allow(clippy::match_single_binding)]
 #![allow(clippy::clone_on_copy)]
 
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`Fruit`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, ExtraDerive)]
 #[serde(transparent)]
@@ -89,4 +63,30 @@ pub struct Veggies {
     pub fruits: ::std::vec::Vec<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub vegetables: ::std::vec::Vec<Veggie>,
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
 }

--- a/cargo-typify/tests/outputs/multi_derive.rs
+++ b/cargo-typify/tests/outputs/multi_derive.rs
@@ -3,32 +3,6 @@
 #![allow(clippy::match_single_binding)]
 #![allow(clippy::clone_on_copy)]
 
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`Fruit`"]
 #[derive(
     :: serde :: Deserialize, :: serde :: Serialize, AnotherDerive, Clone, Debug, ExtraDerive,
@@ -103,4 +77,30 @@ pub struct Veggies {
     pub fruits: ::std::vec::Vec<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub vegetables: ::std::vec::Vec<Veggie>,
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
 }

--- a/cargo-typify/tests/outputs/no-builder.rs
+++ b/cargo-typify/tests/outputs/no-builder.rs
@@ -3,32 +3,6 @@
 #![allow(clippy::match_single_binding)]
 #![allow(clippy::clone_on_copy)]
 
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`Fruit`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(transparent)]
@@ -89,4 +63,30 @@ pub struct Veggies {
     pub fruits: ::std::vec::Vec<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub vegetables: ::std::vec::Vec<Veggie>,
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
 }

--- a/typify-impl/src/output.rs
+++ b/typify-impl/src/output.rs
@@ -12,10 +12,10 @@ pub struct OutputSpace {
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum OutputSpaceMod {
-    Error,
     Crate,
     Builder,
     Defaults,
+    Error,
 }
 
 impl OutputSpace {
@@ -49,19 +49,19 @@ impl OutputSpace {
                 #items
             },
             OutputSpaceMod::Builder => quote! {
-                /// Types for composing complex structures.
+                #[doc = " Types for composing complex structures."]
                 pub mod builder {
                     #items
                 }
             },
             OutputSpaceMod::Defaults => quote! {
-                /// Generation of default values for serde.
+                #[doc = " Generation of default values for serde."]
                 pub mod defaults {
                     #items
                 }
             },
             OutputSpaceMod::Error => quote! {
-                /// Error types.
+                #[doc = " Error types."]
                 pub mod error {
                     #items
                 }

--- a/typify-impl/src/structs.rs
+++ b/typify-impl/src/structs.rs
@@ -351,7 +351,6 @@ pub(crate) fn generate_serde_attr(
 
     let default_fn = match (state, &prop_type.details) {
         (StructPropertyState::Optional, TypeEntryDetails::Option(_)) => {
-            serde_options.push(quote! { default });
             serde_options.push(quote! { skip_serializing_if = "::std::option::Option::is_none" });
             DefaultFunction::Default
         }
@@ -403,6 +402,11 @@ pub(crate) fn generate_serde_attr(
             DefaultFunction::Custom(fn_name)
         }
 
+        // Required Option types need a serde annotation.
+        (StructPropertyState::Required, TypeEntryDetails::Option(_)) => {
+            serde_options.push(quote! { deserialize_with = "::std::option::Option::deserialize" });
+            DefaultFunction::None
+        }
         (StructPropertyState::Required, _) => DefaultFunction::None,
     };
 

--- a/typify-impl/src/type_entry.rs
+++ b/typify-impl/src/type_entry.rs
@@ -1081,8 +1081,8 @@ impl TypeEntry {
 
             #simple_enum_impl
             #default_impl
-            #untagged_newtype_from_string_impl
             #untagged_newtype_to_string_impl
+            #untagged_newtype_from_string_impl
             #convenience_from
         };
         output.add_item(OutputSpaceMod::Crate, name, item);
@@ -1458,9 +1458,9 @@ impl TypeEntry {
                         }
                     }
 
+                    #display_impl
                     #str_impl
                     #from_str_impl
-                    #display_impl
                 }
             }
 

--- a/typify-impl/tests/generator.out
+++ b/typify-impl/tests/generator.out
@@ -1,30 +1,4 @@
 mod types {
-    #[doc = r" Error types."]
-    pub mod error {
-        #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-        pub struct ConversionError(::std::borrow::Cow<'static, str>);
-        impl ::std::error::Error for ConversionError {}
-        impl ::std::fmt::Display for ConversionError {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-                ::std::fmt::Display::fmt(&self.0, f)
-            }
-        }
-        impl ::std::fmt::Debug for ConversionError {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-                ::std::fmt::Debug::fmt(&self.0, f)
-            }
-        }
-        impl From<&'static str> for ConversionError {
-            fn from(value: &'static str) -> Self {
-                Self(value.into())
-            }
-        }
-        impl From<String> for ConversionError {
-            fn from(value: String) -> Self {
-                Self(value.into())
-            }
-        }
-    }
     #[doc = "`AllTheTraits`"]
     #[derive(
         :: serde :: Deserialize,
@@ -131,7 +105,7 @@ mod types {
             value.parse()
         }
     }
-    #[doc = r" Types for composing complex structures."]
+    #[doc = " Types for composing complex structures."]
     pub mod builder {
         #[derive(Clone, Debug)]
         pub struct AllTheTraits {
@@ -276,13 +250,39 @@ mod types {
             }
         }
     }
-    #[doc = r" Generation of default values for serde."]
+    #[doc = " Generation of default values for serde."]
     pub mod defaults {
         pub(super) fn pair_a() -> super::StringEnum {
             super::StringEnum::One
         }
         pub(super) fn pair_b() -> super::StringEnum {
             super::StringEnum::Two
+        }
+    }
+    #[doc = " Error types."]
+    pub mod error {
+        #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+        pub struct ConversionError(::std::borrow::Cow<'static, str>);
+        impl ::std::error::Error for ConversionError {}
+        impl ::std::fmt::Display for ConversionError {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+                ::std::fmt::Display::fmt(&self.0, f)
+            }
+        }
+        impl ::std::fmt::Debug for ConversionError {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+                ::std::fmt::Debug::fmt(&self.0, f)
+            }
+        }
+        impl From<&'static str> for ConversionError {
+            fn from(value: &'static str) -> Self {
+                Self(value.into())
+            }
+        }
+        impl From<String> for ConversionError {
+            fn from(value: String) -> Self {
+                Self(value.into())
+            }
         }
     }
 }

--- a/typify-impl/tests/github.out
+++ b/typify-impl/tests/github.out
@@ -1,29 +1,3 @@
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`AlertInstance`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
@@ -32,13 +6,13 @@ pub struct AlertInstance {
     pub analysis_key: ::std::string::String,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub classifications: ::std::vec::Vec<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub commit_sha: ::std::option::Option<::std::string::String>,
     #[doc = "Identifies the variable values associated with the environment in which the analysis that generated this alert instance was performed, such as the language that was analyzed."]
     pub environment: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub location: ::std::option::Option<AlertInstanceLocation>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub message: ::std::option::Option<AlertInstanceMessage>,
     #[doc = "The full Git reference, formatted as `refs/heads/<branch name>`."]
     #[serde(rename = "ref")]
@@ -50,22 +24,22 @@ pub struct AlertInstance {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct AlertInstanceLocation {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub end_column: ::std::option::Option<i64>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub end_line: ::std::option::Option<i64>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub path: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub start_column: ::std::option::Option<i64>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub start_line: ::std::option::Option<i64>,
 }
 #[doc = "`AlertInstanceMessage`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct AlertInstanceMessage {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub text: ::std::option::Option<::std::string::String>,
 }
 #[doc = "State of a code scanning alert."]
@@ -128,6 +102,7 @@ impl ::std::convert::TryFrom<::std::string::String> for AlertInstanceState {
 #[serde(deny_unknown_fields)]
 pub struct App {
     pub created_at: ::chrono::DateTime<::chrono::offset::Utc>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub description: ::std::option::Option<::std::string::String>,
     #[doc = "The list of events for the GitHub app"]
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
@@ -140,10 +115,10 @@ pub struct App {
     pub name: ::std::string::String,
     pub node_id: ::std::string::String,
     pub owner: User,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub permissions: ::std::option::Option<AppPermissions>,
     #[doc = "The slug name of the GitHub app"]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub slug: ::std::option::Option<::std::string::String>,
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
 }
@@ -370,75 +345,75 @@ impl ::std::convert::TryFrom<::std::string::String> for AppEventsItem {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct AppPermissions {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub actions: ::std::option::Option<AppPermissionsActions>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub administration: ::std::option::Option<AppPermissionsAdministration>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub checks: ::std::option::Option<AppPermissionsChecks>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub content_references: ::std::option::Option<AppPermissionsContentReferences>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub contents: ::std::option::Option<AppPermissionsContents>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub deployments: ::std::option::Option<AppPermissionsDeployments>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub discussions: ::std::option::Option<AppPermissionsDiscussions>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub emails: ::std::option::Option<AppPermissionsEmails>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub environments: ::std::option::Option<AppPermissionsEnvironments>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub issues: ::std::option::Option<AppPermissionsIssues>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub members: ::std::option::Option<AppPermissionsMembers>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub metadata: ::std::option::Option<AppPermissionsMetadata>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_administration:
         ::std::option::Option<AppPermissionsOrganizationAdministration>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_hooks: ::std::option::Option<AppPermissionsOrganizationHooks>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_packages: ::std::option::Option<AppPermissionsOrganizationPackages>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_plan: ::std::option::Option<AppPermissionsOrganizationPlan>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_projects: ::std::option::Option<AppPermissionsOrganizationProjects>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_secrets: ::std::option::Option<AppPermissionsOrganizationSecrets>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_self_hosted_runners:
         ::std::option::Option<AppPermissionsOrganizationSelfHostedRunners>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_user_blocking: ::std::option::Option<AppPermissionsOrganizationUserBlocking>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub packages: ::std::option::Option<AppPermissionsPackages>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub pages: ::std::option::Option<AppPermissionsPages>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub pull_requests: ::std::option::Option<AppPermissionsPullRequests>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub repository_hooks: ::std::option::Option<AppPermissionsRepositoryHooks>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub repository_projects: ::std::option::Option<AppPermissionsRepositoryProjects>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub secret_scanning_alerts: ::std::option::Option<AppPermissionsSecretScanningAlerts>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub secrets: ::std::option::Option<AppPermissionsSecrets>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub security_events: ::std::option::Option<AppPermissionsSecurityEvents>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub security_scanning_alert: ::std::option::Option<AppPermissionsSecurityScanningAlert>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub single_file: ::std::option::Option<AppPermissionsSingleFile>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub statuses: ::std::option::Option<AppPermissionsStatuses>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub team_discussions: ::std::option::Option<AppPermissionsTeamDiscussions>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub vulnerability_alerts: ::std::option::Option<AppPermissionsVulnerabilityAlerts>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub workflows: ::std::option::Option<AppPermissionsWorkflows>,
 }
 #[doc = "`AppPermissionsActions`"]
@@ -2406,9 +2381,9 @@ impl ::std::convert::TryFrom<::std::string::String>
 #[serde(deny_unknown_fields)]
 pub struct BranchProtectionRuleCreated {
     pub action: BranchProtectionRuleCreatedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub rule: BranchProtectionRule,
@@ -2466,9 +2441,9 @@ impl ::std::convert::TryFrom<::std::string::String> for BranchProtectionRuleCrea
 #[serde(deny_unknown_fields)]
 pub struct BranchProtectionRuleDeleted {
     pub action: BranchProtectionRuleDeletedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub rule: BranchProtectionRule,
@@ -2527,9 +2502,9 @@ impl ::std::convert::TryFrom<::std::string::String> for BranchProtectionRuleDele
 pub struct BranchProtectionRuleEdited {
     pub action: BranchProtectionRuleEditedAction,
     pub changes: BranchProtectionRuleEditedChanges,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub rule: BranchProtectionRule,
@@ -2586,10 +2561,10 @@ impl ::std::convert::TryFrom<::std::string::String> for BranchProtectionRuleEdit
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct BranchProtectionRuleEditedChanges {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub authorized_actor_names:
         ::std::option::Option<BranchProtectionRuleEditedChangesAuthorizedActorNames>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub authorized_actors_only:
         ::std::option::Option<BranchProtectionRuleEditedChangesAuthorizedActorsOnly>,
 }
@@ -3035,13 +3010,13 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub struct CheckRunCompleted {
     pub action: CheckRunCompletedAction,
     pub check_run: CheckRunCompletedCheckRun,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     #[doc = "The action requested by the user."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub requested_action: ::std::option::Option<CheckRunCompletedRequestedAction>,
     pub sender: User,
 }
@@ -3101,8 +3076,9 @@ pub struct CheckRunCompletedCheckRun {
     #[doc = "The time the check completed. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."]
     pub completed_at: ::std::string::String,
     #[doc = "The result of the completed check run. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub conclusion: ::std::option::Option<CheckRunCompletedCheckRunConclusion>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub details_url: ::std::option::Option<::std::string::String>,
     pub external_id: ::std::string::String,
     #[doc = "The SHA of the commit that is being checked."]
@@ -3112,7 +3088,7 @@ pub struct CheckRunCompletedCheckRun {
     pub id: i64,
     #[doc = "The name of the check run."]
     pub name: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub node_id: ::std::option::Option<::std::string::String>,
     pub output: CheckRunCompletedCheckRunOutput,
     pub pull_requests: ::std::vec::Vec<CheckRunPullRequest>,
@@ -3126,19 +3102,23 @@ pub struct CheckRunCompletedCheckRun {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCompletedCheckRunCheckSuite {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub after: ::std::option::Option<::std::string::String>,
     pub app: App,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub before: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub conclusion: ::std::option::Option<CheckRunCompletedCheckRunCheckSuiteConclusion>,
     pub created_at: ::chrono::DateTime<::chrono::offset::Utc>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub deployment: ::std::option::Option<CheckRunDeployment>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub head_branch: ::std::option::Option<::std::string::String>,
     #[doc = "The SHA of the head commit that is being checked."]
     pub head_sha: ::std::string::String,
     #[doc = "The id of the check suite that this check run is part of."]
     pub id: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub node_id: ::std::option::Option<::std::string::String>,
     #[doc = "An array of pull requests that match this check suite. A pull request matches a check suite if they have the same `head_sha` and `head_branch`. When the check suite's `head_branch` is in a forked repository it will be `null` and the `pull_requests` array will be empty."]
     pub pull_requests: ::std::vec::Vec<CheckRunPullRequest>,
@@ -3355,9 +3335,11 @@ impl ::std::convert::TryFrom<::std::string::String> for CheckRunCompletedCheckRu
 pub struct CheckRunCompletedCheckRunOutput {
     pub annotations_count: i64,
     pub annotations_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub summary: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub text: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<::std::string::String>,
 }
 #[doc = "The current status of the check run. Can be `queued`, `in_progress`, or `completed`."]
@@ -3412,7 +3394,7 @@ impl ::std::convert::TryFrom<::std::string::String> for CheckRunCompletedCheckRu
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCompletedRequestedAction {
     #[doc = "The integrator reference of the action requested by the user."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub identifier: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`CheckRunCreated`"]
@@ -3421,13 +3403,13 @@ pub struct CheckRunCompletedRequestedAction {
 pub struct CheckRunCreated {
     pub action: CheckRunCreatedAction,
     pub check_run: CheckRunCreatedCheckRun,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     #[doc = "The action requested by the user."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub requested_action: ::std::option::Option<CheckRunCreatedRequestedAction>,
     pub sender: User,
 }
@@ -3485,10 +3467,12 @@ pub struct CheckRunCreatedCheckRun {
     pub app: App,
     pub check_suite: CheckRunCreatedCheckRunCheckSuite,
     #[doc = "The time the check completed. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub completed_at: ::std::option::Option<::std::string::String>,
     #[doc = "The result of the completed check run. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub conclusion: ::std::option::Option<CheckRunCreatedCheckRunConclusion>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub details_url: ::std::option::Option<::std::string::String>,
     pub external_id: ::std::string::String,
     #[doc = "The SHA of the commit that is being checked."]
@@ -3498,7 +3482,7 @@ pub struct CheckRunCreatedCheckRun {
     pub id: i64,
     #[doc = "The name of the check run."]
     pub name: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub node_id: ::std::option::Option<::std::string::String>,
     pub output: CheckRunCreatedCheckRunOutput,
     pub pull_requests: ::std::vec::Vec<CheckRunPullRequest>,
@@ -3512,19 +3496,23 @@ pub struct CheckRunCreatedCheckRun {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCreatedCheckRunCheckSuite {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub after: ::std::option::Option<::std::string::String>,
     pub app: App,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub before: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub conclusion: ::std::option::Option<CheckRunCreatedCheckRunCheckSuiteConclusion>,
     pub created_at: ::chrono::DateTime<::chrono::offset::Utc>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub deployment: ::std::option::Option<CheckRunDeployment>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub head_branch: ::std::option::Option<::std::string::String>,
     #[doc = "The SHA of the head commit that is being checked."]
     pub head_sha: ::std::string::String,
     #[doc = "The id of the check suite that this check run is part of."]
     pub id: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub node_id: ::std::option::Option<::std::string::String>,
     #[doc = "An array of pull requests that match this check suite. A pull request matches a check suite if they have the same `head_sha` and `head_branch`. When the check suite's `head_branch` is in a forked repository it will be `null` and the `pull_requests` array will be empty."]
     pub pull_requests: ::std::vec::Vec<CheckRunPullRequest>,
@@ -3741,9 +3729,11 @@ impl ::std::convert::TryFrom<::std::string::String> for CheckRunCreatedCheckRunC
 pub struct CheckRunCreatedCheckRunOutput {
     pub annotations_count: i64,
     pub annotations_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub summary: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub text: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<::std::string::String>,
 }
 #[doc = "The current status of the check run. Can be `queued`, `in_progress`, or `completed`."]
@@ -3806,7 +3796,7 @@ impl ::std::convert::TryFrom<::std::string::String> for CheckRunCreatedCheckRunS
 #[serde(deny_unknown_fields)]
 pub struct CheckRunCreatedRequestedAction {
     #[doc = "The integrator reference of the action requested by the user."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub identifier: ::std::option::Option<::std::string::String>,
 }
 #[doc = "A deployment to a repository environment. This will only be populated if the check run was created by a GitHub Actions workflow job that references an environment."]
@@ -3814,6 +3804,7 @@ pub struct CheckRunCreatedRequestedAction {
 #[serde(deny_unknown_fields)]
 pub struct CheckRunDeployment {
     pub created_at: ::chrono::DateTime<::chrono::offset::Utc>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub description: ::std::option::Option<::std::string::String>,
     pub environment: ::std::string::String,
     pub id: i64,
@@ -3888,9 +3879,9 @@ pub struct CheckRunPullRequestHead {
 pub struct CheckRunRequestedAction {
     pub action: CheckRunRequestedActionAction,
     pub check_run: CheckRunRequestedActionCheckRun,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub requested_action: CheckRunRequestedActionRequestedAction,
@@ -3950,10 +3941,12 @@ pub struct CheckRunRequestedActionCheckRun {
     pub app: App,
     pub check_suite: CheckRunRequestedActionCheckRunCheckSuite,
     #[doc = "The time the check completed. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub completed_at: ::std::option::Option<::std::string::String>,
     #[doc = "The result of the completed check run. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub conclusion: ::std::option::Option<CheckRunRequestedActionCheckRunConclusion>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub details_url: ::std::option::Option<::std::string::String>,
     pub external_id: ::std::string::String,
     #[doc = "The SHA of the commit that is being checked."]
@@ -3963,7 +3956,7 @@ pub struct CheckRunRequestedActionCheckRun {
     pub id: i64,
     #[doc = "The name of the check run."]
     pub name: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub node_id: ::std::option::Option<::std::string::String>,
     pub output: CheckRunRequestedActionCheckRunOutput,
     pub pull_requests: ::std::vec::Vec<CheckRunPullRequest>,
@@ -3977,19 +3970,23 @@ pub struct CheckRunRequestedActionCheckRun {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRequestedActionCheckRunCheckSuite {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub after: ::std::option::Option<::std::string::String>,
     pub app: App,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub before: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub conclusion: ::std::option::Option<CheckRunRequestedActionCheckRunCheckSuiteConclusion>,
     pub created_at: ::chrono::DateTime<::chrono::offset::Utc>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub deployment: ::std::option::Option<CheckRunDeployment>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub head_branch: ::std::option::Option<::std::string::String>,
     #[doc = "The SHA of the head commit that is being checked."]
     pub head_sha: ::std::string::String,
     #[doc = "The id of the check suite that this check run is part of."]
     pub id: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub node_id: ::std::option::Option<::std::string::String>,
     #[doc = "An array of pull requests that match this check suite. A pull request matches a check suite if they have the same `head_sha` and `head_branch`. When the check suite's `head_branch` is in a forked repository it will be `null` and the `pull_requests` array will be empty."]
     pub pull_requests: ::std::vec::Vec<CheckRunPullRequest>,
@@ -4208,9 +4205,11 @@ impl ::std::convert::TryFrom<::std::string::String> for CheckRunRequestedActionC
 pub struct CheckRunRequestedActionCheckRunOutput {
     pub annotations_count: i64,
     pub annotations_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub summary: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub text: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<::std::string::String>,
 }
 #[doc = "The current status of the check run. Can be `queued`, `in_progress`, or `completed`."]
@@ -4273,7 +4272,7 @@ impl ::std::convert::TryFrom<::std::string::String> for CheckRunRequestedActionC
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRequestedActionRequestedAction {
     #[doc = "The integrator reference of the action requested by the user."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub identifier: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`CheckRunRerequested`"]
@@ -4282,13 +4281,13 @@ pub struct CheckRunRequestedActionRequestedAction {
 pub struct CheckRunRerequested {
     pub action: CheckRunRerequestedAction,
     pub check_run: CheckRunRerequestedCheckRun,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     #[doc = "The action requested by the user."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub requested_action: ::std::option::Option<CheckRunRerequestedRequestedAction>,
     pub sender: User,
 }
@@ -4348,8 +4347,9 @@ pub struct CheckRunRerequestedCheckRun {
     #[doc = "The time the check completed. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."]
     pub completed_at: ::std::string::String,
     #[doc = "The result of the completed check run. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has `completed`."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub conclusion: ::std::option::Option<CheckRunRerequestedCheckRunConclusion>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub details_url: ::std::option::Option<::std::string::String>,
     pub external_id: ::std::string::String,
     #[doc = "The SHA of the commit that is being checked."]
@@ -4359,7 +4359,7 @@ pub struct CheckRunRerequestedCheckRun {
     pub id: i64,
     #[doc = "The name of the check."]
     pub name: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub node_id: ::std::option::Option<::std::string::String>,
     pub output: CheckRunRerequestedCheckRunOutput,
     pub pull_requests: ::std::vec::Vec<CheckRunPullRequest>,
@@ -4373,19 +4373,22 @@ pub struct CheckRunRerequestedCheckRun {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRerequestedCheckRunCheckSuite {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub after: ::std::option::Option<::std::string::String>,
     pub app: App,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub before: ::std::option::Option<::std::string::String>,
     pub conclusion: CheckRunRerequestedCheckRunCheckSuiteConclusion,
     pub created_at: ::chrono::DateTime<::chrono::offset::Utc>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub deployment: ::std::option::Option<CheckRunDeployment>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub head_branch: ::std::option::Option<::std::string::String>,
     #[doc = "The SHA of the head commit that is being checked."]
     pub head_sha: ::std::string::String,
     #[doc = "The id of the check suite that this check run is part of."]
     pub id: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub node_id: ::std::option::Option<::std::string::String>,
     #[doc = "An array of pull requests that match this check suite. A pull request matches a check suite if they have the same `head_sha` and `head_branch`. When the check suite's `head_branch` is in a forked repository it will be `null` and the `pull_requests` array will be empty."]
     pub pull_requests: ::std::vec::Vec<CheckRunPullRequest>,
@@ -4596,9 +4599,11 @@ impl ::std::convert::TryFrom<::std::string::String> for CheckRunRerequestedCheck
 pub struct CheckRunRerequestedCheckRunOutput {
     pub annotations_count: i64,
     pub annotations_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub summary: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub text: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<::std::string::String>,
 }
 #[doc = "The phase of the lifecycle that the check is currently in."]
@@ -4653,7 +4658,7 @@ impl ::std::convert::TryFrom<::std::string::String> for CheckRunRerequestedCheck
 #[serde(deny_unknown_fields)]
 pub struct CheckRunRerequestedRequestedAction {
     #[doc = "The integrator reference of the action requested by the user."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub identifier: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`CheckSuiteCompleted`"]
@@ -4662,9 +4667,9 @@ pub struct CheckRunRerequestedRequestedAction {
 pub struct CheckSuiteCompleted {
     pub action: CheckSuiteCompletedAction,
     pub check_suite: CheckSuiteCompletedCheckSuite,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -4722,12 +4727,15 @@ impl ::std::convert::TryFrom<::std::string::String> for CheckSuiteCompletedActio
 pub struct CheckSuiteCompletedCheckSuite {
     pub after: ::std::string::String,
     pub app: App,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub before: ::std::option::Option<::std::string::String>,
     pub check_runs_url: ::std::string::String,
     #[doc = "The summary conclusion for all check runs that are part of the check suite. Can be one of `success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has `completed`."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub conclusion: ::std::option::Option<CheckSuiteCompletedCheckSuiteConclusion>,
     pub created_at: ::chrono::DateTime<::chrono::offset::Utc>,
     #[doc = "The head branch name the changes are on."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub head_branch: ::std::option::Option<::std::string::String>,
     pub head_commit: CommitSimple,
     #[doc = "The SHA of the head commit that is being checked."]
@@ -4738,6 +4746,7 @@ pub struct CheckSuiteCompletedCheckSuite {
     #[doc = "An array of pull requests that match this check suite. A pull request matches a check suite if they have the same `head_sha` and `head_branch`. When the check suite's `head_branch` is in a forked repository it will be `null` and the `pull_requests` array will be empty."]
     pub pull_requests: ::std::vec::Vec<CheckRunPullRequest>,
     #[doc = "The summary status for all check runs that are part of the check suite. Can be `requested`, `in_progress`, or `completed`."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub status: ::std::option::Option<CheckSuiteCompletedCheckSuiteStatus>,
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     #[doc = "URL that points to the check suite API resource."]
@@ -4902,9 +4911,9 @@ impl ::std::convert::From<CheckSuiteRerequested> for CheckSuiteEvent {
 pub struct CheckSuiteRequested {
     pub action: CheckSuiteRequestedAction,
     pub check_suite: CheckSuiteRequestedCheckSuite,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -4962,12 +4971,15 @@ impl ::std::convert::TryFrom<::std::string::String> for CheckSuiteRequestedActio
 pub struct CheckSuiteRequestedCheckSuite {
     pub after: ::std::string::String,
     pub app: App,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub before: ::std::option::Option<::std::string::String>,
     pub check_runs_url: ::std::string::String,
     #[doc = "The summary conclusion for all check runs that are part of the check suite. Can be one of `success`, `failure`,` neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub conclusion: ::std::option::Option<CheckSuiteRequestedCheckSuiteConclusion>,
     pub created_at: ::chrono::DateTime<::chrono::offset::Utc>,
     #[doc = "The head branch name the changes are on."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub head_branch: ::std::option::Option<::std::string::String>,
     pub head_commit: CommitSimple,
     #[doc = "The SHA of the head commit that is being checked."]
@@ -4978,6 +4990,7 @@ pub struct CheckSuiteRequestedCheckSuite {
     #[doc = "An array of pull requests that match this check suite. A pull request matches a check suite if they have the same `head_sha` and `head_branch`. When the check suite's `head_branch` is in a forked repository it will be `null` and the `pull_requests` array will be empty."]
     pub pull_requests: ::std::vec::Vec<CheckRunPullRequest>,
     #[doc = "The summary status for all check runs that are part of the check suite. Can be `requested`, `in_progress`, or `completed`."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub status: ::std::option::Option<CheckSuiteRequestedCheckSuiteStatus>,
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     #[doc = "URL that points to the check suite API resource."]
@@ -5119,9 +5132,9 @@ impl ::std::convert::TryFrom<::std::string::String> for CheckSuiteRequestedCheck
 pub struct CheckSuiteRerequested {
     pub action: CheckSuiteRerequestedAction,
     pub check_suite: CheckSuiteRerequestedCheckSuite,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -5179,12 +5192,15 @@ impl ::std::convert::TryFrom<::std::string::String> for CheckSuiteRerequestedAct
 pub struct CheckSuiteRerequestedCheckSuite {
     pub after: ::std::string::String,
     pub app: App,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub before: ::std::option::Option<::std::string::String>,
     pub check_runs_url: ::std::string::String,
     #[doc = "The summary conclusion for all check runs that are part of the check suite. Can be one of `success`, `failure`,` neutral`, `cancelled`, `timed_out`, `action_required` or `stale`. This value will be `null` until the check run has completed."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub conclusion: ::std::option::Option<CheckSuiteRerequestedCheckSuiteConclusion>,
     pub created_at: ::chrono::DateTime<::chrono::offset::Utc>,
     #[doc = "The head branch name the changes are on."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub head_branch: ::std::option::Option<::std::string::String>,
     pub head_commit: CommitSimple,
     #[doc = "The SHA of the head commit that is being checked."]
@@ -5195,6 +5211,7 @@ pub struct CheckSuiteRerequestedCheckSuite {
     #[doc = "An array of pull requests that match this check suite. A pull request matches a check suite if they have the same `head_sha` and `head_branch`. When the check suite's `head_branch` is in a forked repository it will be `null` and the `pull_requests` array will be empty."]
     pub pull_requests: ::std::vec::Vec<CheckRunPullRequest>,
     #[doc = "The summary status for all check runs that are part of the check suite. Can be `requested`, `in_progress`, or `completed`."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub status: ::std::option::Option<CheckSuiteRerequestedCheckSuiteStatus>,
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     #[doc = "URL that points to the check suite API resource."]
@@ -5338,9 +5355,9 @@ pub struct CodeScanningAlertAppearedInBranch {
     pub alert: CodeScanningAlertAppearedInBranchAlert,
     #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
     pub commit_oid: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
     #[serde(rename = "ref")]
@@ -5402,15 +5419,18 @@ pub struct CodeScanningAlertAppearedInBranchAlert {
     #[doc = "The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`"]
     pub created_at: ::chrono::DateTime<::chrono::offset::Utc>,
     #[doc = "The time that the alert was dismissed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub dismissed_at: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub dismissed_by: ::std::option::Option<User>,
     #[doc = "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub dismissed_reason:
         ::std::option::Option<CodeScanningAlertAppearedInBranchAlertDismissedReason>,
     #[doc = "The GitHub URL of the alert resource."]
     pub html_url: ::std::string::String,
     pub instances: ::std::vec::Vec<AlertInstance>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub most_recent_instance: ::std::option::Option<AlertInstance>,
     #[doc = "The code scanning alert number."]
     pub number: i64,
@@ -5486,6 +5506,7 @@ pub struct CodeScanningAlertAppearedInBranchAlertRule {
     #[doc = "A unique identifier for the rule used to detect the alert."]
     pub id: ::std::string::String,
     #[doc = "The severity of the alert."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub severity: ::std::option::Option<CodeScanningAlertAppearedInBranchAlertRuleSeverity>,
 }
 #[doc = "The severity of the alert."]
@@ -5613,6 +5634,7 @@ pub struct CodeScanningAlertAppearedInBranchAlertTool {
     #[doc = "The name of the tool used to generate the code scanning analysis alert."]
     pub name: ::std::string::String,
     #[doc = "The version of the tool used to detect the alert."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub version: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`CodeScanningAlertClosedByUser`"]
@@ -5623,9 +5645,9 @@ pub struct CodeScanningAlertClosedByUser {
     pub alert: CodeScanningAlertClosedByUserAlert,
     #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
     pub commit_oid: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
     #[serde(rename = "ref")]
@@ -5690,11 +5712,12 @@ pub struct CodeScanningAlertClosedByUserAlert {
     pub dismissed_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub dismissed_by: User,
     #[doc = "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub dismissed_reason: ::std::option::Option<CodeScanningAlertClosedByUserAlertDismissedReason>,
     #[doc = "The GitHub URL of the alert resource."]
     pub html_url: ::std::string::String,
     pub instances: ::std::vec::Vec<CodeScanningAlertClosedByUserAlertInstancesItem>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub most_recent_instance: ::std::option::Option<AlertInstance>,
     #[doc = "The code scanning alert number."]
     pub number: i64,
@@ -5769,13 +5792,13 @@ pub struct CodeScanningAlertClosedByUserAlertInstancesItem {
     pub analysis_key: ::std::string::String,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub classifications: ::std::vec::Vec<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub commit_sha: ::std::option::Option<::std::string::String>,
     #[doc = "Identifies the variable values associated with the environment in which the analysis that generated this alert instance was performed, such as the language that was analyzed."]
     pub environment: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub location: ::std::option::Option<CodeScanningAlertClosedByUserAlertInstancesItemLocation>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub message: ::std::option::Option<CodeScanningAlertClosedByUserAlertInstancesItemMessage>,
     #[doc = "The full Git reference, formatted as `refs/heads/<branch name>`."]
     #[serde(rename = "ref")]
@@ -5786,22 +5809,22 @@ pub struct CodeScanningAlertClosedByUserAlertInstancesItem {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertClosedByUserAlertInstancesItemLocation {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub end_column: ::std::option::Option<i64>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub end_line: ::std::option::Option<i64>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub path: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub start_column: ::std::option::Option<i64>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub start_line: ::std::option::Option<i64>,
 }
 #[doc = "`CodeScanningAlertClosedByUserAlertInstancesItemMessage`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertClosedByUserAlertInstancesItemMessage {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub text: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`CodeScanningAlertClosedByUserAlertInstancesItemState`"]
@@ -5859,15 +5882,16 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub struct CodeScanningAlertClosedByUserAlertRule {
     #[doc = "A short description of the rule used to detect the alert."]
     pub description: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub full_description: ::std::option::Option<::std::string::String>,
     #[serde(default)]
     pub help: (),
     #[doc = "A unique identifier for the rule used to detect the alert."]
     pub id: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<::std::string::String>,
     #[doc = "The severity of the alert."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub severity: ::std::option::Option<CodeScanningAlertClosedByUserAlertRuleSeverity>,
     #[serde(default)]
     pub tags: (),
@@ -5984,11 +6008,12 @@ impl ::std::convert::TryFrom<::std::string::String> for CodeScanningAlertClosedB
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertClosedByUserAlertTool {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub guid: ::std::option::Option<::std::string::String>,
     #[doc = "The name of the tool used to generate the code scanning analysis alert."]
     pub name: ::std::string::String,
     #[doc = "The version of the tool used to detect the alert."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub version: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`CodeScanningAlertCreated`"]
@@ -5999,9 +6024,9 @@ pub struct CodeScanningAlertCreated {
     pub alert: CodeScanningAlertCreatedAlert,
     #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
     pub commit_oid: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
     #[serde(rename = "ref")]
@@ -6070,7 +6095,7 @@ pub struct CodeScanningAlertCreatedAlert {
     #[doc = "The GitHub URL of the alert resource."]
     pub html_url: ::std::string::String,
     pub instances: ::std::vec::Vec<CodeScanningAlertCreatedAlertInstancesItem>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub most_recent_instance: ::std::option::Option<AlertInstance>,
     #[doc = "The code scanning alert number."]
     pub number: i64,
@@ -6088,13 +6113,13 @@ pub struct CodeScanningAlertCreatedAlertInstancesItem {
     pub analysis_key: ::std::string::String,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub classifications: ::std::vec::Vec<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub commit_sha: ::std::option::Option<::std::string::String>,
     #[doc = "Identifies the variable values associated with the environment in which the analysis that generated this alert instance was performed, such as the language that was analyzed."]
     pub environment: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub location: ::std::option::Option<CodeScanningAlertCreatedAlertInstancesItemLocation>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub message: ::std::option::Option<CodeScanningAlertCreatedAlertInstancesItemMessage>,
     #[doc = "The full Git reference, formatted as `refs/heads/<branch name>`."]
     #[serde(rename = "ref")]
@@ -6105,22 +6130,22 @@ pub struct CodeScanningAlertCreatedAlertInstancesItem {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertCreatedAlertInstancesItemLocation {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub end_column: ::std::option::Option<i64>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub end_line: ::std::option::Option<i64>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub path: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub start_column: ::std::option::Option<i64>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub start_line: ::std::option::Option<i64>,
 }
 #[doc = "`CodeScanningAlertCreatedAlertInstancesItemMessage`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertCreatedAlertInstancesItemMessage {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub text: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`CodeScanningAlertCreatedAlertInstancesItemState`"]
@@ -6182,15 +6207,16 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub struct CodeScanningAlertCreatedAlertRule {
     #[doc = "A short description of the rule used to detect the alert."]
     pub description: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub full_description: ::std::option::Option<::std::string::String>,
     #[serde(default)]
     pub help: (),
     #[doc = "A unique identifier for the rule used to detect the alert."]
     pub id: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<::std::string::String>,
     #[doc = "The severity of the alert."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub severity: ::std::option::Option<CodeScanningAlertCreatedAlertRuleSeverity>,
     #[serde(default)]
     pub tags: (),
@@ -6309,11 +6335,12 @@ impl ::std::convert::TryFrom<::std::string::String> for CodeScanningAlertCreated
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertCreatedAlertTool {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub guid: ::std::option::Option<::std::string::String>,
     #[doc = "The name of the tool used to generate the code scanning analysis alert."]
     pub name: ::std::string::String,
     #[doc = "The version of the tool used to detect the alert."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub version: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`CodeScanningAlertEvent`"]
@@ -6365,9 +6392,9 @@ pub struct CodeScanningAlertFixed {
     pub alert: CodeScanningAlertFixedAlert,
     #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
     pub commit_oid: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
     #[serde(rename = "ref")]
@@ -6429,16 +6456,19 @@ pub struct CodeScanningAlertFixedAlert {
     #[doc = "The time that the alert was created in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ.`"]
     pub created_at: ::chrono::DateTime<::chrono::offset::Utc>,
     #[doc = "The time that the alert was dismissed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub dismissed_at: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub dismissed_by: ::std::option::Option<User>,
     #[doc = "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub dismissed_reason: ::std::option::Option<CodeScanningAlertFixedAlertDismissedReason>,
     #[doc = "The GitHub URL of the alert resource."]
     pub html_url: ::std::string::String,
     pub instances: ::std::vec::Vec<CodeScanningAlertFixedAlertInstancesItem>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub instances_url: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub most_recent_instance: ::std::option::Option<AlertInstance>,
     #[doc = "The code scanning alert number."]
     pub number: i64,
@@ -6511,13 +6541,13 @@ pub struct CodeScanningAlertFixedAlertInstancesItem {
     pub analysis_key: ::std::string::String,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub classifications: ::std::vec::Vec<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub commit_sha: ::std::option::Option<::std::string::String>,
     #[doc = "Identifies the variable values associated with the environment in which the analysis that generated this alert instance was performed, such as the language that was analyzed."]
     pub environment: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub location: ::std::option::Option<CodeScanningAlertFixedAlertInstancesItemLocation>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub message: ::std::option::Option<CodeScanningAlertFixedAlertInstancesItemMessage>,
     #[doc = "The full Git reference, formatted as `refs/heads/<branch name>`."]
     #[serde(rename = "ref")]
@@ -6528,22 +6558,22 @@ pub struct CodeScanningAlertFixedAlertInstancesItem {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertFixedAlertInstancesItemLocation {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub end_column: ::std::option::Option<i64>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub end_line: ::std::option::Option<i64>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub path: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub start_column: ::std::option::Option<i64>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub start_line: ::std::option::Option<i64>,
 }
 #[doc = "`CodeScanningAlertFixedAlertInstancesItemMessage`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertFixedAlertInstancesItemMessage {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub text: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`CodeScanningAlertFixedAlertInstancesItemState`"]
@@ -6601,15 +6631,16 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub struct CodeScanningAlertFixedAlertRule {
     #[doc = "A short description of the rule used to detect the alert."]
     pub description: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub full_description: ::std::option::Option<::std::string::String>,
     #[serde(default)]
     pub help: (),
     #[doc = "A unique identifier for the rule used to detect the alert."]
     pub id: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<::std::string::String>,
     #[doc = "The severity of the alert."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub severity: ::std::option::Option<CodeScanningAlertFixedAlertRuleSeverity>,
     #[serde(default)]
     pub tags: (),
@@ -6724,11 +6755,12 @@ impl ::std::convert::TryFrom<::std::string::String> for CodeScanningAlertFixedAl
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertFixedAlertTool {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub guid: ::std::option::Option<::std::string::String>,
     #[doc = "The name of the tool used to generate the code scanning analysis alert."]
     pub name: ::std::string::String,
     #[doc = "The version of the tool used to detect the alert."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub version: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`CodeScanningAlertReopened`"]
@@ -6739,9 +6771,9 @@ pub struct CodeScanningAlertReopened {
     pub alert: CodeScanningAlertReopenedAlert,
     #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
     pub commit_oid: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
     #[serde(rename = "ref")]
@@ -6810,7 +6842,7 @@ pub struct CodeScanningAlertReopenedAlert {
     #[doc = "The GitHub URL of the alert resource."]
     pub html_url: ::std::string::String,
     pub instances: ::std::vec::Vec<CodeScanningAlertReopenedAlertInstancesItem>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub most_recent_instance: ::std::option::Option<AlertInstance>,
     #[doc = "The code scanning alert number."]
     pub number: i64,
@@ -6828,13 +6860,13 @@ pub struct CodeScanningAlertReopenedAlertInstancesItem {
     pub analysis_key: ::std::string::String,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub classifications: ::std::vec::Vec<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub commit_sha: ::std::option::Option<::std::string::String>,
     #[doc = "Identifies the variable values associated with the environment in which the analysis that generated this alert instance was performed, such as the language that was analyzed."]
     pub environment: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub location: ::std::option::Option<CodeScanningAlertReopenedAlertInstancesItemLocation>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub message: ::std::option::Option<CodeScanningAlertReopenedAlertInstancesItemMessage>,
     #[doc = "The full Git reference, formatted as `refs/heads/<branch name>`."]
     #[serde(rename = "ref")]
@@ -6845,22 +6877,22 @@ pub struct CodeScanningAlertReopenedAlertInstancesItem {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedAlertInstancesItemLocation {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub end_column: ::std::option::Option<i64>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub end_line: ::std::option::Option<i64>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub path: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub start_column: ::std::option::Option<i64>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub start_line: ::std::option::Option<i64>,
 }
 #[doc = "`CodeScanningAlertReopenedAlertInstancesItemMessage`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedAlertInstancesItemMessage {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub text: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`CodeScanningAlertReopenedAlertInstancesItemState`"]
@@ -6918,15 +6950,16 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub struct CodeScanningAlertReopenedAlertRule {
     #[doc = "A short description of the rule used to detect the alert."]
     pub description: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub full_description: ::std::option::Option<::std::string::String>,
     #[serde(default)]
     pub help: (),
     #[doc = "A unique identifier for the rule used to detect the alert."]
     pub id: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<::std::string::String>,
     #[doc = "The severity of the alert."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub severity: ::std::option::Option<CodeScanningAlertReopenedAlertRuleSeverity>,
     #[serde(default)]
     pub tags: (),
@@ -7049,11 +7082,12 @@ impl ::std::convert::TryFrom<::std::string::String> for CodeScanningAlertReopene
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedAlertTool {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub guid: ::std::option::Option<::std::string::String>,
     #[doc = "The name of the tool used to generate the code scanning analysis alert."]
     pub name: ::std::string::String,
     #[doc = "The version of the tool used to detect the alert."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub version: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`CodeScanningAlertReopenedByUser`"]
@@ -7064,9 +7098,9 @@ pub struct CodeScanningAlertReopenedByUser {
     pub alert: CodeScanningAlertReopenedByUserAlert,
     #[doc = "The commit SHA of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
     pub commit_oid: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     #[doc = "The Git reference of the code scanning alert. When the action is `reopened_by_user` or `closed_by_user`, the event was triggered by the `sender` and this value will be empty."]
     #[serde(rename = "ref")]
@@ -7135,7 +7169,7 @@ pub struct CodeScanningAlertReopenedByUserAlert {
     #[doc = "The GitHub URL of the alert resource."]
     pub html_url: ::std::string::String,
     pub instances: ::std::vec::Vec<CodeScanningAlertReopenedByUserAlertInstancesItem>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub most_recent_instance: ::std::option::Option<AlertInstance>,
     #[doc = "The code scanning alert number."]
     pub number: i64,
@@ -7153,13 +7187,13 @@ pub struct CodeScanningAlertReopenedByUserAlertInstancesItem {
     pub analysis_key: ::std::string::String,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub classifications: ::std::vec::Vec<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub commit_sha: ::std::option::Option<::std::string::String>,
     #[doc = "Identifies the variable values associated with the environment in which the analysis that generated this alert instance was performed, such as the language that was analyzed."]
     pub environment: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub location: ::std::option::Option<CodeScanningAlertReopenedByUserAlertInstancesItemLocation>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub message: ::std::option::Option<CodeScanningAlertReopenedByUserAlertInstancesItemMessage>,
     #[doc = "The full Git reference, formatted as `refs/heads/<branch name>`."]
     #[serde(rename = "ref")]
@@ -7170,22 +7204,22 @@ pub struct CodeScanningAlertReopenedByUserAlertInstancesItem {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedByUserAlertInstancesItemLocation {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub end_column: ::std::option::Option<i64>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub end_line: ::std::option::Option<i64>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub path: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub start_column: ::std::option::Option<i64>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub start_line: ::std::option::Option<i64>,
 }
 #[doc = "`CodeScanningAlertReopenedByUserAlertInstancesItemMessage`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CodeScanningAlertReopenedByUserAlertInstancesItemMessage {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub text: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`CodeScanningAlertReopenedByUserAlertInstancesItemState`"]
@@ -7246,6 +7280,7 @@ pub struct CodeScanningAlertReopenedByUserAlertRule {
     #[doc = "A unique identifier for the rule used to detect the alert."]
     pub id: ::std::string::String,
     #[doc = "The severity of the alert."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub severity: ::std::option::Option<CodeScanningAlertReopenedByUserAlertRuleSeverity>,
 }
 #[doc = "The severity of the alert."]
@@ -7363,6 +7398,7 @@ pub struct CodeScanningAlertReopenedByUserAlertTool {
     #[doc = "The name of the tool used to generate the code scanning analysis alert."]
     pub name: ::std::string::String,
     #[doc = "The version of the tool used to detect the alert."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub version: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`Commit`"]
@@ -7395,9 +7431,9 @@ pub struct CommitCommentCreated {
     #[doc = "The action performed. Can be `created`."]
     pub action: CommitCommentCreatedAction,
     pub comment: CommitCommentCreatedComment,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -7463,12 +7499,15 @@ pub struct CommitCommentCreatedComment {
     #[doc = "The ID of the commit comment."]
     pub id: i64,
     #[doc = "The line of the blob to which the comment applies. The last line of the range for a multi-line comment"]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub line: ::std::option::Option<i64>,
     #[doc = "The node ID of the commit comment."]
     pub node_id: ::std::string::String,
     #[doc = "The relative path of the file to which the comment applies."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub path: ::std::option::Option<::std::string::String>,
     #[doc = "The line index in the diff to which the comment applies."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub position: ::std::option::Option<i64>,
     pub updated_at: ::std::string::String,
     pub url: ::std::string::String,
@@ -7509,13 +7548,14 @@ pub struct CommitSimple {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct Committer {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub date: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
     #[doc = "The git author's email address."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub email: ::std::option::Option<::std::string::String>,
     #[doc = "The git author's name."]
     pub name: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub username: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`ContentReferenceCreated`"]
@@ -7525,7 +7565,7 @@ pub struct ContentReferenceCreated {
     pub action: ContentReferenceCreatedAction,
     pub content_reference: ContentReferenceCreatedContentReference,
     pub installation: InstallationLite,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -7610,12 +7650,13 @@ impl ::std::convert::From<ContentReferenceCreated> for ContentReferenceEvent {
 #[serde(deny_unknown_fields)]
 pub struct CreateEvent {
     #[doc = "The repository's current description."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub description: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     #[doc = "The name of the repository's default branch (usually `main`)."]
     pub master_branch: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     #[doc = "The pusher type for the event. Can be either `user` or a deploy key."]
     pub pusher_type: ::std::string::String,
@@ -7682,9 +7723,9 @@ impl ::std::convert::TryFrom<::std::string::String> for CreateEventRefType {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct DeleteEvent {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     #[doc = "The pusher type for the event. Can be either `user` or a deploy key."]
     pub pusher_type: ::std::string::String,
@@ -7752,10 +7793,10 @@ impl ::std::convert::TryFrom<::std::string::String> for DeleteEventRefType {
 #[serde(deny_unknown_fields)]
 pub struct DeployKeyCreated {
     pub action: DeployKeyCreatedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub key: DeployKeyCreatedKey,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -7824,10 +7865,10 @@ pub struct DeployKeyCreatedKey {
 #[serde(deny_unknown_fields)]
 pub struct DeployKeyDeleted {
     pub action: DeployKeyDeletedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub key: DeployKeyDeletedKey,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -7914,9 +7955,9 @@ impl ::std::convert::From<DeployKeyDeleted> for DeployKeyEvent {
 pub struct DeploymentCreated {
     pub action: DeploymentCreatedAction,
     pub deployment: DeploymentCreatedDeployment,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -7982,7 +8023,7 @@ pub struct DeploymentCreatedDeployment {
     pub node_id: ::std::string::String,
     pub original_environment: ::std::string::String,
     pub payload: DeploymentCreatedDeploymentPayload,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub performed_via_github_app: ::std::option::Option<App>,
     #[serde(rename = "ref")]
     pub ref_: ::std::string::String,
@@ -8024,9 +8065,9 @@ pub struct DeploymentStatusCreated {
     pub action: DeploymentStatusCreatedAction,
     pub deployment: DeploymentStatusCreatedDeployment,
     pub deployment_status: DeploymentStatusCreatedDeploymentStatus,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -8090,6 +8131,7 @@ pub struct DeploymentStatusCreatedDeployment {
     pub node_id: ::std::string::String,
     pub original_environment: ::std::string::String,
     pub payload: DeploymentStatusCreatedDeploymentPayload,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub performed_via_github_app: ::std::option::Option<App>,
     #[serde(rename = "ref")]
     pub ref_: ::std::string::String,
@@ -8116,7 +8158,7 @@ pub struct DeploymentStatusCreatedDeploymentStatus {
     pub environment: ::std::string::String,
     pub id: i64,
     pub node_id: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub performed_via_github_app: ::std::option::Option<App>,
     pub repository_url: ::std::string::String,
     #[doc = "The new state. Can be `pending`, `success`, `failure`, or `error`."]
@@ -8150,9 +8192,13 @@ impl ::std::convert::From<DeploymentStatusCreated> for DeploymentStatusEvent {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct Discussion {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub active_lock_reason: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub answer_chosen_at: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub answer_chosen_by: ::std::option::Option<User>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub answer_html_url: ::std::option::Option<::std::string::String>,
     pub author_association: AuthorAssociation,
     pub body: ::std::string::String,
@@ -8177,9 +8223,9 @@ pub struct DiscussionAnswered {
     pub action: DiscussionAnsweredAction,
     pub answer: DiscussionAnsweredAnswer,
     pub discussion: DiscussionAnsweredDiscussion,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -8252,6 +8298,7 @@ pub struct DiscussionAnsweredAnswer {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionAnsweredDiscussion {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub active_lock_reason: ::std::option::Option<::std::string::String>,
     pub answer_chosen_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub answer_chosen_by: DiscussionAnsweredDiscussionAnswerChosenBy,
@@ -8277,7 +8324,7 @@ pub struct DiscussionAnsweredDiscussion {
 #[serde(deny_unknown_fields)]
 pub struct DiscussionAnsweredDiscussionAnswerChosenBy {
     pub avatar_url: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub email: ::std::option::Option<::std::string::String>,
     pub events_url: ::std::string::String,
     pub followers_url: ::std::string::String,
@@ -8287,7 +8334,7 @@ pub struct DiscussionAnsweredDiscussionAnswerChosenBy {
     pub html_url: ::std::string::String,
     pub id: i64,
     pub login: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<::std::string::String>,
     pub node_id: ::std::string::String,
     pub organizations_url: ::std::string::String,
@@ -8444,9 +8491,9 @@ pub struct DiscussionCategoryChanged {
     pub action: DiscussionCategoryChangedAction,
     pub changes: DiscussionCategoryChangedChanges,
     pub discussion: Discussion,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -8532,7 +8579,7 @@ pub struct DiscussionCommentCreated {
     pub comment: DiscussionCommentCreatedComment,
     pub discussion: Discussion,
     pub installation: InstallationLite,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -8596,6 +8643,7 @@ pub struct DiscussionCommentCreatedComment {
     pub html_url: ::std::string::String,
     pub id: i64,
     pub node_id: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub parent_id: ::std::option::Option<i64>,
     pub repository_url: ::std::string::String,
     pub updated_at: ::std::string::String,
@@ -8609,7 +8657,7 @@ pub struct DiscussionCommentDeleted {
     pub comment: DiscussionCommentDeletedComment,
     pub discussion: Discussion,
     pub installation: InstallationLite,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -8673,6 +8721,7 @@ pub struct DiscussionCommentDeletedComment {
     pub html_url: ::std::string::String,
     pub id: i64,
     pub node_id: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub parent_id: ::std::option::Option<i64>,
     pub repository_url: ::std::string::String,
     pub updated_at: ::std::string::String,
@@ -8687,7 +8736,7 @@ pub struct DiscussionCommentEdited {
     pub comment: DiscussionCommentEditedComment,
     pub discussion: Discussion,
     pub installation: InstallationLite,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -8763,6 +8812,7 @@ pub struct DiscussionCommentEditedComment {
     pub html_url: ::std::string::String,
     pub id: i64,
     pub node_id: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub parent_id: ::std::option::Option<i64>,
     pub repository_url: ::std::string::String,
     pub updated_at: ::std::string::String,
@@ -8797,9 +8847,9 @@ impl ::std::convert::From<DiscussionCommentEdited> for DiscussionCommentEvent {
 pub struct DiscussionCreated {
     pub action: DiscussionCreatedAction,
     pub discussion: DiscussionCreatedDiscussion,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -8855,6 +8905,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionCreatedAction 
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionCreatedDiscussion {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub active_lock_reason: ::std::option::Option<::std::string::String>,
     pub answer_chosen_at: (),
     pub answer_chosen_by: (),
@@ -8946,9 +8997,9 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionCreatedDiscuss
 pub struct DiscussionDeleted {
     pub action: DiscussionDeletedAction,
     pub discussion: Discussion,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -9005,12 +9056,12 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionDeletedAction 
 #[serde(deny_unknown_fields)]
 pub struct DiscussionEdited {
     pub action: DiscussionEditedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub changes: ::std::option::Option<DiscussionEditedChanges>,
     pub discussion: Discussion,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -9066,9 +9117,9 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionEditedAction {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionEditedChanges {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub body: ::std::option::Option<DiscussionEditedChangesBody>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<DiscussionEditedChangesTitle>,
 }
 #[doc = "`DiscussionEditedChangesBody`"]
@@ -9172,10 +9223,10 @@ impl ::std::convert::From<DiscussionUnpinned> for DiscussionEvent {
 pub struct DiscussionLabeled {
     pub action: DiscussionLabeledAction,
     pub discussion: Discussion,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub label: Label,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -9233,9 +9284,9 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionLabeledAction 
 pub struct DiscussionLocked {
     pub action: DiscussionLockedAction,
     pub discussion: DiscussionLockedDiscussion,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -9291,9 +9342,13 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionLockedAction {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionLockedDiscussion {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub active_lock_reason: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub answer_chosen_at: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub answer_chosen_by: ::std::option::Option<User>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub answer_html_url: ::std::option::Option<::std::string::String>,
     pub author_association: AuthorAssociation,
     pub body: ::std::string::String,
@@ -9378,9 +9433,9 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionLockedDiscussi
 pub struct DiscussionPinned {
     pub action: DiscussionPinnedAction,
     pub discussion: Discussion,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -9494,9 +9549,9 @@ pub struct DiscussionTransferred {
     pub action: DiscussionTransferredAction,
     pub changes: DiscussionTransferredChanges,
     pub discussion: Discussion,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -9561,10 +9616,10 @@ pub struct DiscussionTransferredChanges {
 pub struct DiscussionUnanswered {
     pub action: DiscussionUnansweredAction,
     pub discussion: DiscussionUnansweredDiscussion,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub old_answer: DiscussionUnansweredOldAnswer,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -9620,6 +9675,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionUnansweredActi
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionUnansweredDiscussion {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub active_lock_reason: ::std::option::Option<::std::string::String>,
     pub answer_chosen_at: (),
     pub answer_chosen_by: (),
@@ -9732,10 +9788,10 @@ pub struct DiscussionUnansweredOldAnswer {
 pub struct DiscussionUnlabeled {
     pub action: DiscussionUnlabeledAction,
     pub discussion: Discussion,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub label: Label,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -9793,9 +9849,9 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionUnlabeledActio
 pub struct DiscussionUnlocked {
     pub action: DiscussionUnlockedAction,
     pub discussion: DiscussionUnlockedDiscussion,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -9851,9 +9907,13 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionUnlockedAction
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct DiscussionUnlockedDiscussion {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub active_lock_reason: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub answer_chosen_at: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub answer_chosen_by: ::std::option::Option<User>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub answer_html_url: ::std::option::Option<::std::string::String>,
     pub author_association: AuthorAssociation,
     pub body: ::std::string::String,
@@ -9938,9 +9998,9 @@ impl ::std::convert::TryFrom<::std::string::String> for DiscussionUnlockedDiscus
 pub struct DiscussionUnpinned {
     pub action: DiscussionUnpinnedAction,
     pub discussion: Discussion,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -10332,9 +10392,9 @@ impl ::std::convert::From<WorkflowRunEvent> for Everything {
 #[serde(deny_unknown_fields)]
 pub struct ForkEvent {
     pub forkee: ForkEventForkee,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -10347,7 +10407,7 @@ pub struct ForkEventForkee {
     #[serde(default)]
     pub allow_auto_merge: bool,
     #[doc = "Whether to allow private forks"]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub allow_forking: ::std::option::Option<bool>,
     #[doc = "Whether to allow merge commits for pull requests."]
     #[serde(default = "defaults::default_bool::<true>")]
@@ -10378,9 +10438,10 @@ pub struct ForkEventForkee {
     #[serde(default)]
     pub delete_branch_on_merge: bool,
     pub deployments_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub description: ::std::option::Option<::std::string::String>,
     #[doc = "Returns whether or not this repository is disabled."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub disabled: ::std::option::Option<bool>,
     pub downloads_url: ::std::string::String,
     pub events_url: ::std::string::String,
@@ -10402,6 +10463,7 @@ pub struct ForkEventForkee {
     pub has_projects: bool,
     #[doc = "Whether the wiki is enabled."]
     pub has_wiki: bool,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub homepage: ::std::option::Option<::std::string::String>,
     pub hooks_url: ::std::string::String,
     pub html_url: ::std::string::String,
@@ -10412,13 +10474,16 @@ pub struct ForkEventForkee {
     pub issues_url: ::std::string::String,
     pub keys_url: ::std::string::String,
     pub labels_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub language: ::std::option::Option<::std::string::String>,
     pub languages_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub license: ::std::option::Option<License>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub master_branch: ::std::option::Option<::std::string::String>,
     pub merges_url: ::std::string::String,
     pub milestones_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub mirror_url: ::std::option::Option<::std::string::String>,
     #[doc = "The name of the repository."]
     pub name: ::std::string::String,
@@ -10426,21 +10491,21 @@ pub struct ForkEventForkee {
     pub notifications_url: ::std::string::String,
     pub open_issues: i64,
     pub open_issues_count: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<::std::string::String>,
     pub owner: User,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub permissions: ::std::option::Option<ForkEventForkeePermissions>,
     #[doc = "Whether the repository is private or public."]
     pub private: bool,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub public: ::std::option::Option<bool>,
     pub pulls_url: ::std::string::String,
     pub pushed_at: ForkEventForkeePushedAt,
     pub releases_url: ::std::string::String,
     pub size: i64,
     pub ssh_url: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub stargazers: ::std::option::Option<i64>,
     pub stargazers_count: i64,
     pub stargazers_url: ::std::string::String,
@@ -10462,6 +10527,14 @@ pub struct ForkEventForkee {
 pub enum ForkEventForkeeCreatedAt {
     Integer(i64),
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
+}
+impl ::std::fmt::Display for ForkEventForkeeCreatedAt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Integer(x) => x.fmt(f),
+            Self::DateTime(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for ForkEventForkeeCreatedAt {
     type Err = self::error::ConversionError;
@@ -10489,14 +10562,6 @@ impl ::std::convert::TryFrom<::std::string::String> for ForkEventForkeeCreatedAt
         value.parse()
     }
 }
-impl ::std::fmt::Display for ForkEventForkeeCreatedAt {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Integer(x) => x.fmt(f),
-            Self::DateTime(x) => x.fmt(f),
-        }
-    }
-}
 impl ::std::convert::From<i64> for ForkEventForkeeCreatedAt {
     fn from(value: i64) -> Self {
         Self::Integer(value)
@@ -10512,11 +10577,11 @@ impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>> for ForkEve
 #[serde(deny_unknown_fields)]
 pub struct ForkEventForkeePermissions {
     pub admin: bool,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub maintain: ::std::option::Option<bool>,
     pub pull: bool,
     pub push: bool,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub triage: ::std::option::Option<bool>,
 }
 #[doc = "`ForkEventForkeePushedAt`"]
@@ -10626,7 +10691,7 @@ pub struct GithubOrg {
     pub html_url: ::std::string::String,
     pub id: i64,
     pub login: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<::std::string::String>,
     pub node_id: ::std::string::String,
     pub organizations_url: ::std::string::String,
@@ -10643,9 +10708,9 @@ pub struct GithubOrg {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct GollumEvent {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     #[doc = "The pages that were updated."]
     pub pages: ::std::vec::Vec<GollumEventPagesItem>,
@@ -10726,11 +10791,11 @@ pub struct Installation {
     pub access_tokens_url: ::std::string::String,
     pub account: User,
     pub app_id: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub app_slug: ::std::option::Option<::std::string::String>,
     pub created_at: InstallationCreatedAt,
     pub events: ::std::vec::Vec<InstallationEventsItem>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub has_multiple_single_files: ::std::option::Option<bool>,
     pub html_url: ::std::string::String,
     #[doc = "The ID of the installation."]
@@ -10739,10 +10804,13 @@ pub struct Installation {
     pub repositories_url: ::std::string::String,
     #[doc = "Describe whether all repositories have been selected or there's a selection involved"]
     pub repository_selection: InstallationRepositorySelection,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub single_file_name: ::std::option::Option<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub single_file_paths: ::std::vec::Vec<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub suspended_at: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub suspended_by: ::std::option::Option<User>,
     #[doc = "The ID of the user or organization this token is being scoped to."]
     pub target_id: i64,
@@ -10758,7 +10826,7 @@ pub struct InstallationCreated {
     #[doc = "An array of repository objects that the installation can access."]
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub repositories: ::std::vec::Vec<InstallationCreatedRepositoriesItem>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub requester: ::std::option::Option<User>,
     pub sender: User,
 }
@@ -10816,6 +10884,14 @@ pub enum InstallationCreatedAt {
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
     Integer(i64),
 }
+impl ::std::fmt::Display for InstallationCreatedAt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::DateTime(x) => x.fmt(f),
+            Self::Integer(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for InstallationCreatedAt {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -10840,14 +10916,6 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationCreatedAt {
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for InstallationCreatedAt {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::DateTime(x) => x.fmt(f),
-            Self::Integer(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>> for InstallationCreatedAt {
@@ -11289,79 +11357,79 @@ pub struct InstallationNewPermissionsAcceptedRepositoriesItem {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationPermissions {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub actions: ::std::option::Option<InstallationPermissionsActions>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub administration: ::std::option::Option<InstallationPermissionsAdministration>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub checks: ::std::option::Option<InstallationPermissionsChecks>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub content_references: ::std::option::Option<InstallationPermissionsContentReferences>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub contents: ::std::option::Option<InstallationPermissionsContents>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub deployments: ::std::option::Option<InstallationPermissionsDeployments>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub discussions: ::std::option::Option<InstallationPermissionsDiscussions>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub emails: ::std::option::Option<InstallationPermissionsEmails>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub environments: ::std::option::Option<InstallationPermissionsEnvironments>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub issues: ::std::option::Option<InstallationPermissionsIssues>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub members: ::std::option::Option<InstallationPermissionsMembers>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub metadata: ::std::option::Option<InstallationPermissionsMetadata>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_administration:
         ::std::option::Option<InstallationPermissionsOrganizationAdministration>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_events: ::std::option::Option<InstallationPermissionsOrganizationEvents>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_hooks: ::std::option::Option<InstallationPermissionsOrganizationHooks>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_packages: ::std::option::Option<InstallationPermissionsOrganizationPackages>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_plan: ::std::option::Option<InstallationPermissionsOrganizationPlan>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_projects: ::std::option::Option<InstallationPermissionsOrganizationProjects>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_secrets: ::std::option::Option<InstallationPermissionsOrganizationSecrets>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_self_hosted_runners:
         ::std::option::Option<InstallationPermissionsOrganizationSelfHostedRunners>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_user_blocking:
         ::std::option::Option<InstallationPermissionsOrganizationUserBlocking>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub packages: ::std::option::Option<InstallationPermissionsPackages>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub pages: ::std::option::Option<InstallationPermissionsPages>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub pull_requests: ::std::option::Option<InstallationPermissionsPullRequests>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub repository_hooks: ::std::option::Option<InstallationPermissionsRepositoryHooks>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub repository_projects: ::std::option::Option<InstallationPermissionsRepositoryProjects>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub secret_scanning_alerts: ::std::option::Option<InstallationPermissionsSecretScanningAlerts>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub secrets: ::std::option::Option<InstallationPermissionsSecrets>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub security_events: ::std::option::Option<InstallationPermissionsSecurityEvents>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub security_scanning_alert:
         ::std::option::Option<InstallationPermissionsSecurityScanningAlert>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub single_file: ::std::option::Option<InstallationPermissionsSingleFile>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub statuses: ::std::option::Option<InstallationPermissionsStatuses>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub team_discussions: ::std::option::Option<InstallationPermissionsTeamDiscussions>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub vulnerability_alerts: ::std::option::Option<InstallationPermissionsVulnerabilityAlerts>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub workflows: ::std::option::Option<InstallationPermissionsWorkflows>,
 }
 #[doc = "`InstallationPermissionsActions`"]
@@ -13175,6 +13243,7 @@ pub struct InstallationRepositoriesAdded {
     pub repositories_removed: ::std::vec::Vec<InstallationRepositoriesAddedRepositoriesRemovedItem>,
     #[doc = "Describe whether all repositories have been selected or there's a selection involved"]
     pub repository_selection: InstallationRepositoriesAddedRepositorySelection,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub requester: ::std::option::Option<User>,
     pub sender: User,
 }
@@ -13242,18 +13311,18 @@ pub struct InstallationRepositoriesAddedRepositoriesAddedItem {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationRepositoriesAddedRepositoriesRemovedItem {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub full_name: ::std::option::Option<::std::string::String>,
     #[doc = "Unique identifier of the repository"]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub id: ::std::option::Option<i64>,
     #[doc = "The name of the repository."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub node_id: ::std::option::Option<::std::string::String>,
     #[doc = "Whether the repository is private or public."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub private: ::std::option::Option<bool>,
 }
 #[doc = "Describe whether all repositories have been selected or there's a selection involved"]
@@ -13339,6 +13408,7 @@ pub struct InstallationRepositoriesRemoved {
         ::std::vec::Vec<InstallationRepositoriesRemovedRepositoriesRemovedItem>,
     #[doc = "Describe whether all repositories have been selected or there's a selection involved"]
     pub repository_selection: InstallationRepositoriesRemovedRepositorySelection,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub requester: ::std::option::Option<User>,
     pub sender: User,
 }
@@ -13586,11 +13656,11 @@ pub struct InstallationSuspendInstallation {
     pub access_tokens_url: ::std::string::String,
     pub account: User,
     pub app_id: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub app_slug: ::std::option::Option<::std::string::String>,
     pub created_at: InstallationSuspendInstallationCreatedAt,
     pub events: ::std::vec::Vec<InstallationSuspendInstallationEventsItem>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub has_multiple_single_files: ::std::option::Option<bool>,
     pub html_url: ::std::string::String,
     #[doc = "The ID of the installation."]
@@ -13599,6 +13669,7 @@ pub struct InstallationSuspendInstallation {
     pub repositories_url: ::std::string::String,
     #[doc = "Describe whether all repositories have been selected or there's a selection involved"]
     pub repository_selection: InstallationSuspendInstallationRepositorySelection,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub single_file_name: ::std::option::Option<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub single_file_paths: ::std::vec::Vec<::std::string::String>,
@@ -13615,6 +13686,14 @@ pub struct InstallationSuspendInstallation {
 pub enum InstallationSuspendInstallationCreatedAt {
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
     Integer(i64),
+}
+impl ::std::fmt::Display for InstallationSuspendInstallationCreatedAt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::DateTime(x) => x.fmt(f),
+            Self::Integer(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for InstallationSuspendInstallationCreatedAt {
     type Err = self::error::ConversionError;
@@ -13640,14 +13719,6 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationSuspendInsta
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for InstallationSuspendInstallationCreatedAt {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::DateTime(x) => x.fmt(f),
-            Self::Integer(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
@@ -13889,95 +13960,95 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationSuspendInsta
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationSuspendInstallationPermissions {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub actions: ::std::option::Option<InstallationSuspendInstallationPermissionsActions>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub administration:
         ::std::option::Option<InstallationSuspendInstallationPermissionsAdministration>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub checks: ::std::option::Option<InstallationSuspendInstallationPermissionsChecks>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub content_references:
         ::std::option::Option<InstallationSuspendInstallationPermissionsContentReferences>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub contents: ::std::option::Option<InstallationSuspendInstallationPermissionsContents>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub deployments: ::std::option::Option<InstallationSuspendInstallationPermissionsDeployments>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub discussions: ::std::option::Option<InstallationSuspendInstallationPermissionsDiscussions>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub emails: ::std::option::Option<InstallationSuspendInstallationPermissionsEmails>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub environments: ::std::option::Option<InstallationSuspendInstallationPermissionsEnvironments>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub issues: ::std::option::Option<InstallationSuspendInstallationPermissionsIssues>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub members: ::std::option::Option<InstallationSuspendInstallationPermissionsMembers>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub metadata: ::std::option::Option<InstallationSuspendInstallationPermissionsMetadata>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_administration:
         ::std::option::Option<InstallationSuspendInstallationPermissionsOrganizationAdministration>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_events:
         ::std::option::Option<InstallationSuspendInstallationPermissionsOrganizationEvents>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_hooks:
         ::std::option::Option<InstallationSuspendInstallationPermissionsOrganizationHooks>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_packages:
         ::std::option::Option<InstallationSuspendInstallationPermissionsOrganizationPackages>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_plan:
         ::std::option::Option<InstallationSuspendInstallationPermissionsOrganizationPlan>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_projects:
         ::std::option::Option<InstallationSuspendInstallationPermissionsOrganizationProjects>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_secrets:
         ::std::option::Option<InstallationSuspendInstallationPermissionsOrganizationSecrets>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_self_hosted_runners: ::std::option::Option<
         InstallationSuspendInstallationPermissionsOrganizationSelfHostedRunners,
     >,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_user_blocking:
         ::std::option::Option<InstallationSuspendInstallationPermissionsOrganizationUserBlocking>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub packages: ::std::option::Option<InstallationSuspendInstallationPermissionsPackages>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub pages: ::std::option::Option<InstallationSuspendInstallationPermissionsPages>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub pull_requests:
         ::std::option::Option<InstallationSuspendInstallationPermissionsPullRequests>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub repository_hooks:
         ::std::option::Option<InstallationSuspendInstallationPermissionsRepositoryHooks>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub repository_projects:
         ::std::option::Option<InstallationSuspendInstallationPermissionsRepositoryProjects>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub secret_scanning_alerts:
         ::std::option::Option<InstallationSuspendInstallationPermissionsSecretScanningAlerts>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub secrets: ::std::option::Option<InstallationSuspendInstallationPermissionsSecrets>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub security_events:
         ::std::option::Option<InstallationSuspendInstallationPermissionsSecurityEvents>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub security_scanning_alert:
         ::std::option::Option<InstallationSuspendInstallationPermissionsSecurityScanningAlert>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub single_file: ::std::option::Option<InstallationSuspendInstallationPermissionsSingleFile>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub statuses: ::std::option::Option<InstallationSuspendInstallationPermissionsStatuses>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub team_discussions:
         ::std::option::Option<InstallationSuspendInstallationPermissionsTeamDiscussions>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub vulnerability_alerts:
         ::std::option::Option<InstallationSuspendInstallationPermissionsVulnerabilityAlerts>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub workflows: ::std::option::Option<InstallationSuspendInstallationPermissionsWorkflows>,
 }
 #[doc = "`InstallationSuspendInstallationPermissionsActions`"]
@@ -15919,7 +15990,7 @@ impl ::std::convert::TryFrom<::std::string::String>
 #[serde(deny_unknown_fields)]
 pub struct InstallationSuspendInstallationSuspendedBy {
     pub avatar_url: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub email: ::std::option::Option<::std::string::String>,
     pub events_url: ::std::string::String,
     pub followers_url: ::std::string::String,
@@ -15929,7 +16000,7 @@ pub struct InstallationSuspendInstallationSuspendedBy {
     pub html_url: ::std::string::String,
     pub id: i64,
     pub login: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<::std::string::String>,
     pub node_id: ::std::string::String,
     pub organizations_url: ::std::string::String,
@@ -16052,6 +16123,14 @@ pub enum InstallationSuspendInstallationUpdatedAt {
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
     Integer(i64),
 }
+impl ::std::fmt::Display for InstallationSuspendInstallationUpdatedAt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::DateTime(x) => x.fmt(f),
+            Self::Integer(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for InstallationSuspendInstallationUpdatedAt {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -16076,14 +16155,6 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationSuspendInsta
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for InstallationSuspendInstallationUpdatedAt {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::DateTime(x) => x.fmt(f),
-            Self::Integer(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
@@ -16227,11 +16298,11 @@ pub struct InstallationUnsuspendInstallation {
     pub access_tokens_url: ::std::string::String,
     pub account: User,
     pub app_id: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub app_slug: ::std::option::Option<::std::string::String>,
     pub created_at: InstallationUnsuspendInstallationCreatedAt,
     pub events: ::std::vec::Vec<InstallationUnsuspendInstallationEventsItem>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub has_multiple_single_files: ::std::option::Option<bool>,
     pub html_url: ::std::string::String,
     #[doc = "The ID of the installation."]
@@ -16240,6 +16311,7 @@ pub struct InstallationUnsuspendInstallation {
     pub repositories_url: ::std::string::String,
     #[doc = "Describe whether all repositories have been selected or there's a selection involved"]
     pub repository_selection: InstallationUnsuspendInstallationRepositorySelection,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub single_file_name: ::std::option::Option<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub single_file_paths: ::std::vec::Vec<::std::string::String>,
@@ -16256,6 +16328,14 @@ pub struct InstallationUnsuspendInstallation {
 pub enum InstallationUnsuspendInstallationCreatedAt {
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
     Integer(i64),
+}
+impl ::std::fmt::Display for InstallationUnsuspendInstallationCreatedAt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::DateTime(x) => x.fmt(f),
+            Self::Integer(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for InstallationUnsuspendInstallationCreatedAt {
     type Err = self::error::ConversionError;
@@ -16281,14 +16361,6 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationUnsuspendIns
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for InstallationUnsuspendInstallationCreatedAt {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::DateTime(x) => x.fmt(f),
-            Self::Integer(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
@@ -16532,97 +16604,97 @@ impl ::std::convert::TryFrom<::std::string::String>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct InstallationUnsuspendInstallationPermissions {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub actions: ::std::option::Option<InstallationUnsuspendInstallationPermissionsActions>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub administration:
         ::std::option::Option<InstallationUnsuspendInstallationPermissionsAdministration>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub checks: ::std::option::Option<InstallationUnsuspendInstallationPermissionsChecks>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub content_references:
         ::std::option::Option<InstallationUnsuspendInstallationPermissionsContentReferences>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub contents: ::std::option::Option<InstallationUnsuspendInstallationPermissionsContents>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub deployments: ::std::option::Option<InstallationUnsuspendInstallationPermissionsDeployments>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub discussions: ::std::option::Option<InstallationUnsuspendInstallationPermissionsDiscussions>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub emails: ::std::option::Option<InstallationUnsuspendInstallationPermissionsEmails>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub environments:
         ::std::option::Option<InstallationUnsuspendInstallationPermissionsEnvironments>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub issues: ::std::option::Option<InstallationUnsuspendInstallationPermissionsIssues>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub members: ::std::option::Option<InstallationUnsuspendInstallationPermissionsMembers>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub metadata: ::std::option::Option<InstallationUnsuspendInstallationPermissionsMetadata>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_administration: ::std::option::Option<
         InstallationUnsuspendInstallationPermissionsOrganizationAdministration,
     >,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_events:
         ::std::option::Option<InstallationUnsuspendInstallationPermissionsOrganizationEvents>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_hooks:
         ::std::option::Option<InstallationUnsuspendInstallationPermissionsOrganizationHooks>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_packages:
         ::std::option::Option<InstallationUnsuspendInstallationPermissionsOrganizationPackages>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_plan:
         ::std::option::Option<InstallationUnsuspendInstallationPermissionsOrganizationPlan>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_projects:
         ::std::option::Option<InstallationUnsuspendInstallationPermissionsOrganizationProjects>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_secrets:
         ::std::option::Option<InstallationUnsuspendInstallationPermissionsOrganizationSecrets>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_self_hosted_runners: ::std::option::Option<
         InstallationUnsuspendInstallationPermissionsOrganizationSelfHostedRunners,
     >,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization_user_blocking:
         ::std::option::Option<InstallationUnsuspendInstallationPermissionsOrganizationUserBlocking>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub packages: ::std::option::Option<InstallationUnsuspendInstallationPermissionsPackages>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub pages: ::std::option::Option<InstallationUnsuspendInstallationPermissionsPages>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub pull_requests:
         ::std::option::Option<InstallationUnsuspendInstallationPermissionsPullRequests>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub repository_hooks:
         ::std::option::Option<InstallationUnsuspendInstallationPermissionsRepositoryHooks>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub repository_projects:
         ::std::option::Option<InstallationUnsuspendInstallationPermissionsRepositoryProjects>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub secret_scanning_alerts:
         ::std::option::Option<InstallationUnsuspendInstallationPermissionsSecretScanningAlerts>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub secrets: ::std::option::Option<InstallationUnsuspendInstallationPermissionsSecrets>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub security_events:
         ::std::option::Option<InstallationUnsuspendInstallationPermissionsSecurityEvents>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub security_scanning_alert:
         ::std::option::Option<InstallationUnsuspendInstallationPermissionsSecurityScanningAlert>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub single_file: ::std::option::Option<InstallationUnsuspendInstallationPermissionsSingleFile>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub statuses: ::std::option::Option<InstallationUnsuspendInstallationPermissionsStatuses>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub team_discussions:
         ::std::option::Option<InstallationUnsuspendInstallationPermissionsTeamDiscussions>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub vulnerability_alerts:
         ::std::option::Option<InstallationUnsuspendInstallationPermissionsVulnerabilityAlerts>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub workflows: ::std::option::Option<InstallationUnsuspendInstallationPermissionsWorkflows>,
 }
 #[doc = "`InstallationUnsuspendInstallationPermissionsActions`"]
@@ -18627,6 +18699,14 @@ pub enum InstallationUnsuspendInstallationUpdatedAt {
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
     Integer(i64),
 }
+impl ::std::fmt::Display for InstallationUnsuspendInstallationUpdatedAt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::DateTime(x) => x.fmt(f),
+            Self::Integer(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for InstallationUnsuspendInstallationUpdatedAt {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -18651,14 +18731,6 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationUnsuspendIns
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for InstallationUnsuspendInstallationUpdatedAt {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::DateTime(x) => x.fmt(f),
-            Self::Integer(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
@@ -18693,6 +18765,14 @@ pub enum InstallationUpdatedAt {
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
     Integer(i64),
 }
+impl ::std::fmt::Display for InstallationUpdatedAt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::DateTime(x) => x.fmt(f),
+            Self::Integer(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for InstallationUpdatedAt {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -18719,14 +18799,6 @@ impl ::std::convert::TryFrom<::std::string::String> for InstallationUpdatedAt {
         value.parse()
     }
 }
-impl ::std::fmt::Display for InstallationUpdatedAt {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::DateTime(x) => x.fmt(f),
-            Self::Integer(x) => x.fmt(f),
-        }
-    }
-}
 impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>> for InstallationUpdatedAt {
     fn from(value: ::chrono::DateTime<::chrono::offset::Utc>) -> Self {
         Self::DateTime(value)
@@ -18741,13 +18813,16 @@ impl ::std::convert::From<i64> for InstallationUpdatedAt {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct Issue {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub active_lock_reason: ::std::option::Option<IssueActiveLockReason>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub assignee: ::std::option::Option<User>,
     pub assignees: ::std::vec::Vec<User>,
     pub author_association: AuthorAssociation,
     #[doc = "Contents of the issue"]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub body: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub closed_at: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
     pub comments: i64,
     pub comments_url: ::std::string::String,
@@ -18758,18 +18833,19 @@ pub struct Issue {
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub labels: ::std::vec::Vec<Label>,
     pub labels_url: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub locked: ::std::option::Option<bool>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub milestone: ::std::option::Option<Milestone>,
     pub node_id: ::std::string::String,
     pub number: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub performed_via_github_app: ::std::option::Option<App>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub pull_request: ::std::option::Option<IssuePullRequest>,
     pub repository_url: ::std::string::String,
     #[doc = "State of the issue; either 'open' or 'closed'"]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub state: ::std::option::Option<IssueState>,
     #[doc = "Title of the issue"]
     pub title: ::std::string::String,
@@ -18850,6 +18926,7 @@ pub struct IssueComment {
     pub id: i64,
     pub issue_url: ::std::string::String,
     pub node_id: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub performed_via_github_app: ::std::option::Option<App>,
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     #[doc = "URL for the issue comment"]
@@ -18862,10 +18939,10 @@ pub struct IssueComment {
 pub struct IssueCommentCreated {
     pub action: IssueCommentCreatedAction,
     pub comment: IssueComment,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub issue: IssueCommentCreatedIssue,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -18921,12 +18998,16 @@ impl ::std::convert::TryFrom<::std::string::String> for IssueCommentCreatedActio
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentCreatedIssue {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub active_lock_reason: ::std::option::Option<IssueCommentCreatedIssueActiveLockReason>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub assignee: ::std::option::Option<IssueCommentCreatedIssueAssignee>,
     pub assignees: ::std::vec::Vec<User>,
     pub author_association: AuthorAssociation,
     #[doc = "Contents of the issue"]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub body: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub closed_at: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
     pub comments: i64,
     pub comments_url: ::std::string::String,
@@ -18937,12 +19018,13 @@ pub struct IssueCommentCreatedIssue {
     pub labels: ::std::vec::Vec<Label>,
     pub labels_url: ::std::string::String,
     pub locked: bool,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub milestone: ::std::option::Option<Milestone>,
     pub node_id: ::std::string::String,
     pub number: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub performed_via_github_app: ::std::option::Option<App>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub pull_request: ::std::option::Option<IssueCommentCreatedIssuePullRequest>,
     pub repository_url: ::std::string::String,
     pub state: IssueCommentCreatedIssueState,
@@ -19017,7 +19099,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssueCommentCreatedIssue
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentCreatedIssueAssignee {
     pub avatar_url: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub email: ::std::option::Option<::std::string::String>,
     pub events_url: ::std::string::String,
     pub followers_url: ::std::string::String,
@@ -19027,7 +19109,7 @@ pub struct IssueCommentCreatedIssueAssignee {
     pub html_url: ::std::string::String,
     pub id: i64,
     pub login: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<::std::string::String>,
     pub node_id: ::std::string::String,
     pub organizations_url: ::std::string::String,
@@ -19158,10 +19240,10 @@ impl ::std::convert::TryFrom<::std::string::String> for IssueCommentCreatedIssue
 pub struct IssueCommentDeleted {
     pub action: IssueCommentDeletedAction,
     pub comment: IssueComment,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub issue: IssueCommentDeletedIssue,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -19217,12 +19299,16 @@ impl ::std::convert::TryFrom<::std::string::String> for IssueCommentDeletedActio
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentDeletedIssue {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub active_lock_reason: ::std::option::Option<IssueCommentDeletedIssueActiveLockReason>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub assignee: ::std::option::Option<IssueCommentDeletedIssueAssignee>,
     pub assignees: ::std::vec::Vec<User>,
     pub author_association: AuthorAssociation,
     #[doc = "Contents of the issue"]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub body: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub closed_at: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
     pub comments: i64,
     pub comments_url: ::std::string::String,
@@ -19233,12 +19319,13 @@ pub struct IssueCommentDeletedIssue {
     pub labels: ::std::vec::Vec<Label>,
     pub labels_url: ::std::string::String,
     pub locked: bool,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub milestone: ::std::option::Option<Milestone>,
     pub node_id: ::std::string::String,
     pub number: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub performed_via_github_app: ::std::option::Option<App>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub pull_request: ::std::option::Option<IssueCommentDeletedIssuePullRequest>,
     pub repository_url: ::std::string::String,
     pub state: IssueCommentDeletedIssueState,
@@ -19313,7 +19400,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssueCommentDeletedIssue
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentDeletedIssueAssignee {
     pub avatar_url: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub email: ::std::option::Option<::std::string::String>,
     pub events_url: ::std::string::String,
     pub followers_url: ::std::string::String,
@@ -19323,7 +19410,7 @@ pub struct IssueCommentDeletedIssueAssignee {
     pub html_url: ::std::string::String,
     pub id: i64,
     pub login: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<::std::string::String>,
     pub node_id: ::std::string::String,
     pub organizations_url: ::std::string::String,
@@ -19455,10 +19542,10 @@ pub struct IssueCommentEdited {
     pub action: IssueCommentEditedAction,
     pub changes: IssueCommentEditedChanges,
     pub comment: IssueComment,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub issue: IssueCommentEditedIssue,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -19514,7 +19601,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssueCommentEditedAction
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentEditedChanges {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub body: ::std::option::Option<IssueCommentEditedChangesBody>,
 }
 #[doc = "`IssueCommentEditedChangesBody`"]
@@ -19528,12 +19615,16 @@ pub struct IssueCommentEditedChangesBody {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentEditedIssue {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub active_lock_reason: ::std::option::Option<IssueCommentEditedIssueActiveLockReason>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub assignee: ::std::option::Option<IssueCommentEditedIssueAssignee>,
     pub assignees: ::std::vec::Vec<User>,
     pub author_association: AuthorAssociation,
     #[doc = "Contents of the issue"]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub body: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub closed_at: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
     pub comments: i64,
     pub comments_url: ::std::string::String,
@@ -19544,12 +19635,13 @@ pub struct IssueCommentEditedIssue {
     pub labels: ::std::vec::Vec<Label>,
     pub labels_url: ::std::string::String,
     pub locked: bool,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub milestone: ::std::option::Option<Milestone>,
     pub node_id: ::std::string::String,
     pub number: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub performed_via_github_app: ::std::option::Option<App>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub pull_request: ::std::option::Option<IssueCommentEditedIssuePullRequest>,
     pub repository_url: ::std::string::String,
     pub state: IssueCommentEditedIssueState,
@@ -19624,7 +19716,7 @@ impl ::std::convert::TryFrom<::std::string::String> for IssueCommentEditedIssueA
 #[serde(deny_unknown_fields)]
 pub struct IssueCommentEditedIssueAssignee {
     pub avatar_url: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub email: ::std::option::Option<::std::string::String>,
     pub events_url: ::std::string::String,
     pub followers_url: ::std::string::String,
@@ -19634,7 +19726,7 @@ pub struct IssueCommentEditedIssueAssignee {
     pub html_url: ::std::string::String,
     pub id: i64,
     pub login: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<::std::string::String>,
     pub node_id: ::std::string::String,
     pub organizations_url: ::std::string::String,
@@ -19786,13 +19878,13 @@ impl ::std::convert::From<IssueCommentEdited> for IssueCommentEvent {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct IssuePullRequest {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub diff_url: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub html_url: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub patch_url: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub url: ::std::option::Option<::std::string::String>,
 }
 #[doc = "State of the issue; either 'open' or 'closed'"]
@@ -19853,12 +19945,12 @@ pub struct IssuesAssigned {
     #[doc = "The action that was performed."]
     pub action: IssuesAssignedAction,
     #[doc = "The optional user who was assigned or unassigned from the issue."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub assignee: ::std::option::Option<User>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub issue: Issue,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -19916,10 +20008,10 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesAssignedAction {
 pub struct IssuesClosed {
     #[doc = "The action that was performed."]
     pub action: IssuesClosedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub issue: IssuesClosedIssue,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -19975,12 +20067,14 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesClosedAction {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesClosedIssue {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub active_lock_reason: ::std::option::Option<IssuesClosedIssueActiveLockReason>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub assignee: ::std::option::Option<User>,
     pub assignees: ::std::vec::Vec<User>,
     pub author_association: AuthorAssociation,
     #[doc = "Contents of the issue"]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub body: ::std::option::Option<::std::string::String>,
     pub closed_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub comments: i64,
@@ -19992,14 +20086,15 @@ pub struct IssuesClosedIssue {
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub labels: ::std::vec::Vec<Label>,
     pub labels_url: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub locked: ::std::option::Option<bool>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub milestone: ::std::option::Option<Milestone>,
     pub node_id: ::std::string::String,
     pub number: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub performed_via_github_app: ::std::option::Option<App>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub pull_request: ::std::option::Option<IssuesClosedIssuePullRequest>,
     pub repository_url: ::std::string::String,
     pub state: IssuesClosedIssueState,
@@ -20073,13 +20168,13 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesClosedIssueActiveL
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesClosedIssuePullRequest {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub diff_url: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub html_url: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub patch_url: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub url: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`IssuesClosedIssueState`"]
@@ -20134,10 +20229,10 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesClosedIssueState {
 #[serde(deny_unknown_fields)]
 pub struct IssuesDeleted {
     pub action: IssuesDeletedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub issue: Issue,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -20194,11 +20289,11 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesDeletedAction {
 #[serde(deny_unknown_fields)]
 pub struct IssuesDemilestoned {
     pub action: IssuesDemilestonedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub issue: IssuesDemilestonedIssue,
     pub milestone: Milestone,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -20254,13 +20349,16 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesDemilestonedAction
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesDemilestonedIssue {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub active_lock_reason: ::std::option::Option<IssuesDemilestonedIssueActiveLockReason>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub assignee: ::std::option::Option<User>,
     pub assignees: ::std::vec::Vec<User>,
     pub author_association: AuthorAssociation,
     #[doc = "Contents of the issue"]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub body: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub closed_at: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
     pub comments: i64,
     pub comments_url: ::std::string::String,
@@ -20271,18 +20369,18 @@ pub struct IssuesDemilestonedIssue {
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub labels: ::std::vec::Vec<Label>,
     pub labels_url: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub locked: ::std::option::Option<bool>,
     pub milestone: (),
     pub node_id: ::std::string::String,
     pub number: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub performed_via_github_app: ::std::option::Option<App>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub pull_request: ::std::option::Option<IssuesDemilestonedIssuePullRequest>,
     pub repository_url: ::std::string::String,
     #[doc = "State of the issue; either 'open' or 'closed'"]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub state: ::std::option::Option<IssuesDemilestonedIssueState>,
     #[doc = "Title of the issue"]
     pub title: ::std::string::String,
@@ -20354,13 +20452,13 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesDemilestonedIssueA
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesDemilestonedIssuePullRequest {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub diff_url: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub html_url: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub patch_url: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub url: ::std::option::Option<::std::string::String>,
 }
 #[doc = "State of the issue; either 'open' or 'closed'"]
@@ -20420,12 +20518,12 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesDemilestonedIssueS
 pub struct IssuesEdited {
     pub action: IssuesEditedAction,
     pub changes: IssuesEditedChanges,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub issue: Issue,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub label: ::std::option::Option<Label>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -20481,9 +20579,9 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesEditedAction {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesEditedChanges {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub body: ::std::option::Option<IssuesEditedChangesBody>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<IssuesEditedChangesTitle>,
 }
 #[doc = "`IssuesEditedChangesBody`"]
@@ -20606,13 +20704,13 @@ impl ::std::convert::From<IssuesUnpinned> for IssuesEvent {
 #[serde(deny_unknown_fields)]
 pub struct IssuesLabeled {
     pub action: IssuesLabeledAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub issue: Issue,
     #[doc = "The label that was added to the issue."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub label: ::std::option::Option<Label>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -20669,10 +20767,10 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesLabeledAction {
 #[serde(deny_unknown_fields)]
 pub struct IssuesLocked {
     pub action: IssuesLockedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub issue: IssuesLockedIssue,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -20728,13 +20826,16 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesLockedAction {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesLockedIssue {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub active_lock_reason: ::std::option::Option<IssuesLockedIssueActiveLockReason>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub assignee: ::std::option::Option<User>,
     pub assignees: ::std::vec::Vec<User>,
     pub author_association: AuthorAssociation,
     #[doc = "Contents of the issue"]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub body: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub closed_at: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
     pub comments: i64,
     pub comments_url: ::std::string::String,
@@ -20746,16 +20847,17 @@ pub struct IssuesLockedIssue {
     pub labels: ::std::vec::Vec<Label>,
     pub labels_url: ::std::string::String,
     pub locked: bool,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub milestone: ::std::option::Option<Milestone>,
     pub node_id: ::std::string::String,
     pub number: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub performed_via_github_app: ::std::option::Option<App>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub pull_request: ::std::option::Option<IssuesLockedIssuePullRequest>,
     pub repository_url: ::std::string::String,
     #[doc = "State of the issue; either 'open' or 'closed'"]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub state: ::std::option::Option<IssuesLockedIssueState>,
     #[doc = "Title of the issue"]
     pub title: ::std::string::String,
@@ -20827,13 +20929,13 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesLockedIssueActiveL
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesLockedIssuePullRequest {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub diff_url: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub html_url: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub patch_url: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub url: ::std::option::Option<::std::string::String>,
 }
 #[doc = "State of the issue; either 'open' or 'closed'"]
@@ -20892,11 +20994,11 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesLockedIssueState {
 #[serde(deny_unknown_fields)]
 pub struct IssuesMilestoned {
     pub action: IssuesMilestonedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub issue: IssuesMilestonedIssue,
     pub milestone: Milestone,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -20952,13 +21054,16 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesMilestonedAction {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesMilestonedIssue {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub active_lock_reason: ::std::option::Option<IssuesMilestonedIssueActiveLockReason>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub assignee: ::std::option::Option<User>,
     pub assignees: ::std::vec::Vec<User>,
     pub author_association: AuthorAssociation,
     #[doc = "Contents of the issue"]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub body: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub closed_at: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
     pub comments: i64,
     pub comments_url: ::std::string::String,
@@ -20969,18 +21074,18 @@ pub struct IssuesMilestonedIssue {
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub labels: ::std::vec::Vec<Label>,
     pub labels_url: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub locked: ::std::option::Option<bool>,
     pub milestone: IssuesMilestonedIssueMilestone,
     pub node_id: ::std::string::String,
     pub number: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub performed_via_github_app: ::std::option::Option<App>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub pull_request: ::std::option::Option<IssuesMilestonedIssuePullRequest>,
     pub repository_url: ::std::string::String,
     #[doc = "State of the issue; either 'open' or 'closed'"]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub state: ::std::option::Option<IssuesMilestonedIssueState>,
     #[doc = "Title of the issue"]
     pub title: ::std::string::String,
@@ -21052,11 +21157,14 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesMilestonedIssueAct
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesMilestonedIssueMilestone {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub closed_at: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
     pub closed_issues: i64,
     pub created_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub creator: User,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub description: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub due_on: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
     pub html_url: ::std::string::String,
     pub id: i64,
@@ -21124,13 +21232,13 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesMilestonedIssueMil
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesMilestonedIssuePullRequest {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub diff_url: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub html_url: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub patch_url: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub url: ::std::option::Option<::std::string::String>,
 }
 #[doc = "State of the issue; either 'open' or 'closed'"]
@@ -21189,12 +21297,12 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesMilestonedIssueSta
 #[serde(deny_unknown_fields)]
 pub struct IssuesOpened {
     pub action: IssuesOpenedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub changes: ::std::option::Option<IssuesOpenedChanges>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub issue: IssuesOpenedIssue,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -21257,12 +21365,14 @@ pub struct IssuesOpenedChanges {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesOpenedIssue {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub active_lock_reason: ::std::option::Option<IssuesOpenedIssueActiveLockReason>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub assignee: ::std::option::Option<User>,
     pub assignees: ::std::vec::Vec<User>,
     pub author_association: AuthorAssociation,
     #[doc = "Contents of the issue"]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub body: ::std::option::Option<::std::string::String>,
     pub closed_at: (),
     pub comments: i64,
@@ -21274,14 +21384,15 @@ pub struct IssuesOpenedIssue {
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub labels: ::std::vec::Vec<Label>,
     pub labels_url: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub locked: ::std::option::Option<bool>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub milestone: ::std::option::Option<Milestone>,
     pub node_id: ::std::string::String,
     pub number: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub performed_via_github_app: ::std::option::Option<App>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub pull_request: ::std::option::Option<IssuesOpenedIssuePullRequest>,
     pub repository_url: ::std::string::String,
     pub state: IssuesOpenedIssueState,
@@ -21355,13 +21466,13 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesOpenedIssueActiveL
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesOpenedIssuePullRequest {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub diff_url: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub html_url: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub patch_url: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub url: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`IssuesOpenedIssueState`"]
@@ -21416,10 +21527,10 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesOpenedIssueState {
 #[serde(deny_unknown_fields)]
 pub struct IssuesPinned {
     pub action: IssuesPinnedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub issue: Issue,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -21476,10 +21587,10 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesPinnedAction {
 #[serde(deny_unknown_fields)]
 pub struct IssuesReopened {
     pub action: IssuesReopenedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub issue: IssuesReopenedIssue,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -21535,13 +21646,16 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesReopenedAction {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesReopenedIssue {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub active_lock_reason: ::std::option::Option<IssuesReopenedIssueActiveLockReason>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub assignee: ::std::option::Option<User>,
     pub assignees: ::std::vec::Vec<User>,
     pub author_association: AuthorAssociation,
     #[doc = "Contents of the issue"]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub body: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub closed_at: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
     pub comments: i64,
     pub comments_url: ::std::string::String,
@@ -21552,14 +21666,15 @@ pub struct IssuesReopenedIssue {
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub labels: ::std::vec::Vec<Label>,
     pub labels_url: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub locked: ::std::option::Option<bool>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub milestone: ::std::option::Option<Milestone>,
     pub node_id: ::std::string::String,
     pub number: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub performed_via_github_app: ::std::option::Option<App>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub pull_request: ::std::option::Option<IssuesReopenedIssuePullRequest>,
     pub repository_url: ::std::string::String,
     pub state: IssuesReopenedIssueState,
@@ -21633,13 +21748,13 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesReopenedIssueActiv
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesReopenedIssuePullRequest {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub diff_url: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub html_url: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub patch_url: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub url: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`IssuesReopenedIssueState`"]
@@ -21695,10 +21810,10 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesReopenedIssueState
 pub struct IssuesTransferred {
     pub action: IssuesTransferredAction,
     pub changes: IssuesTransferredChanges,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub issue: Issue,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -21764,12 +21879,12 @@ pub struct IssuesUnassigned {
     #[doc = "The action that was performed."]
     pub action: IssuesUnassignedAction,
     #[doc = "The optional user who was assigned or unassigned from the issue."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub assignee: ::std::option::Option<User>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub issue: Issue,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -21826,13 +21941,13 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesUnassignedAction {
 #[serde(deny_unknown_fields)]
 pub struct IssuesUnlabeled {
     pub action: IssuesUnlabeledAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub issue: Issue,
     #[doc = "The label that was removed from the issue."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub label: ::std::option::Option<Label>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -21889,10 +22004,10 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesUnlabeledAction {
 #[serde(deny_unknown_fields)]
 pub struct IssuesUnlocked {
     pub action: IssuesUnlockedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub issue: IssuesUnlockedIssue,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -21949,12 +22064,14 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesUnlockedAction {
 #[serde(deny_unknown_fields)]
 pub struct IssuesUnlockedIssue {
     pub active_lock_reason: IssuesUnlockedIssueActiveLockReason,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub assignee: ::std::option::Option<User>,
     pub assignees: ::std::vec::Vec<User>,
     pub author_association: AuthorAssociation,
     #[doc = "Contents of the issue"]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub body: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub closed_at: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
     pub comments: i64,
     pub comments_url: ::std::string::String,
@@ -21966,16 +22083,17 @@ pub struct IssuesUnlockedIssue {
     pub labels: ::std::vec::Vec<Label>,
     pub labels_url: ::std::string::String,
     pub locked: bool,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub milestone: ::std::option::Option<Milestone>,
     pub node_id: ::std::string::String,
     pub number: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub performed_via_github_app: ::std::option::Option<App>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub pull_request: ::std::option::Option<IssuesUnlockedIssuePullRequest>,
     pub repository_url: ::std::string::String,
     #[doc = "State of the issue; either 'open' or 'closed'"]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub state: ::std::option::Option<IssuesUnlockedIssueState>,
     #[doc = "Title of the issue"]
     pub title: ::std::string::String,
@@ -22022,13 +22140,13 @@ impl<'de> ::serde::Deserialize<'de> for IssuesUnlockedIssueActiveLockReason {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct IssuesUnlockedIssuePullRequest {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub diff_url: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub html_url: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub patch_url: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub url: ::std::option::Option<::std::string::String>,
 }
 #[doc = "State of the issue; either 'open' or 'closed'"]
@@ -22087,10 +22205,10 @@ impl ::std::convert::TryFrom<::std::string::String> for IssuesUnlockedIssueState
 #[serde(deny_unknown_fields)]
 pub struct IssuesUnpinned {
     pub action: IssuesUnpinnedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub issue: Issue,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -22149,6 +22267,7 @@ pub struct Label {
     #[doc = "6-character hex code, without the leading #, identifying the color"]
     pub color: ::std::string::String,
     pub default: bool,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub description: ::std::option::Option<::std::string::String>,
     pub id: i64,
     #[doc = "The name of the label."]
@@ -22162,11 +22281,11 @@ pub struct Label {
 #[serde(deny_unknown_fields)]
 pub struct LabelCreated {
     pub action: LabelCreatedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     #[doc = "The label that was added."]
     pub label: Label,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -22223,11 +22342,11 @@ impl ::std::convert::TryFrom<::std::string::String> for LabelCreatedAction {
 #[serde(deny_unknown_fields)]
 pub struct LabelDeleted {
     pub action: LabelDeletedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     #[doc = "The label that was removed."]
     pub label: Label,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -22284,13 +22403,13 @@ impl ::std::convert::TryFrom<::std::string::String> for LabelDeletedAction {
 #[serde(deny_unknown_fields)]
 pub struct LabelEdited {
     pub action: LabelEditedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub changes: ::std::option::Option<LabelEditedChanges>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     #[doc = "The label that was edited."]
     pub label: Label,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -22346,11 +22465,11 @@ impl ::std::convert::TryFrom<::std::string::String> for LabelEditedAction {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct LabelEditedChanges {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub color: ::std::option::Option<LabelEditedChangesColor>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub description: ::std::option::Option<LabelEditedChangesDescription>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<LabelEditedChangesName>,
 }
 #[doc = "`LabelEditedChangesColor`"]
@@ -22405,6 +22524,7 @@ pub struct License {
     pub name: ::std::string::String,
     pub node_id: ::std::string::String,
     pub spdx_id: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub url: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`Link`"]
@@ -22420,7 +22540,7 @@ pub struct MarketplacePurchase {
     pub account: MarketplacePurchaseAccount,
     pub billing_cycle: ::std::string::String,
     pub free_trial_ends_on: (),
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub next_billing_date: ::std::option::Option<::std::string::String>,
     pub on_free_trial: bool,
     pub plan: MarketplacePurchasePlan,
@@ -22444,7 +22564,7 @@ pub struct MarketplacePurchaseCancelled {
     pub action: MarketplacePurchaseCancelledAction,
     pub effective_date: ::std::string::String,
     pub marketplace_purchase: MarketplacePurchaseCancelledMarketplacePurchase,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub previous_marketplace_purchase: ::std::option::Option<MarketplacePurchase>,
     pub sender: MarketplacePurchaseCancelledSender,
 }
@@ -22529,6 +22649,7 @@ pub struct MarketplacePurchaseCancelledMarketplacePurchasePlan {
     pub monthly_price_in_cents: i64,
     pub name: ::std::string::String,
     pub price_model: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub unit_name: ::std::option::Option<::std::string::String>,
     pub yearly_price_in_cents: i64,
 }
@@ -22563,7 +22684,7 @@ pub struct MarketplacePurchaseChanged {
     pub action: MarketplacePurchaseChangedAction,
     pub effective_date: ::std::string::String,
     pub marketplace_purchase: MarketplacePurchaseChangedMarketplacePurchase,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub previous_marketplace_purchase: ::std::option::Option<MarketplacePurchase>,
     pub sender: MarketplacePurchaseChangedSender,
 }
@@ -22648,6 +22769,7 @@ pub struct MarketplacePurchaseChangedMarketplacePurchasePlan {
     pub monthly_price_in_cents: i64,
     pub name: ::std::string::String,
     pub price_model: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub unit_name: ::std::option::Option<::std::string::String>,
     pub yearly_price_in_cents: i64,
 }
@@ -22717,7 +22839,7 @@ pub struct MarketplacePurchasePendingChange {
     pub action: MarketplacePurchasePendingChangeAction,
     pub effective_date: ::std::string::String,
     pub marketplace_purchase: MarketplacePurchasePendingChangeMarketplacePurchase,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub previous_marketplace_purchase: ::std::option::Option<MarketplacePurchase>,
     pub sender: MarketplacePurchasePendingChangeSender,
 }
@@ -22775,7 +22897,7 @@ pub struct MarketplacePurchasePendingChangeCancelled {
     pub action: MarketplacePurchasePendingChangeCancelledAction,
     pub effective_date: ::std::string::String,
     pub marketplace_purchase: MarketplacePurchasePendingChangeCancelledMarketplacePurchase,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub previous_marketplace_purchase: ::std::option::Option<MarketplacePurchase>,
     pub sender: MarketplacePurchasePendingChangeCancelledSender,
 }
@@ -22862,6 +22984,7 @@ pub struct MarketplacePurchasePendingChangeCancelledMarketplacePurchasePlan {
     pub monthly_price_in_cents: i64,
     pub name: ::std::string::String,
     pub price_model: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub unit_name: ::std::option::Option<::std::string::String>,
     pub yearly_price_in_cents: i64,
 }
@@ -22923,6 +23046,7 @@ pub struct MarketplacePurchasePendingChangeMarketplacePurchasePlan {
     pub monthly_price_in_cents: i64,
     pub name: ::std::string::String,
     pub price_model: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub unit_name: ::std::option::Option<::std::string::String>,
     pub yearly_price_in_cents: i64,
 }
@@ -22961,6 +23085,7 @@ pub struct MarketplacePurchasePlan {
     pub monthly_price_in_cents: i64,
     pub name: ::std::string::String,
     pub price_model: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub unit_name: ::std::option::Option<::std::string::String>,
     pub yearly_price_in_cents: i64,
 }
@@ -22971,7 +23096,7 @@ pub struct MarketplacePurchasePurchased {
     pub action: MarketplacePurchasePurchasedAction,
     pub effective_date: ::std::string::String,
     pub marketplace_purchase: MarketplacePurchasePurchasedMarketplacePurchase,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub previous_marketplace_purchase: ::std::option::Option<MarketplacePurchase>,
     pub sender: MarketplacePurchasePurchasedSender,
 }
@@ -23056,6 +23181,7 @@ pub struct MarketplacePurchasePurchasedMarketplacePurchasePlan {
     pub monthly_price_in_cents: i64,
     pub name: ::std::string::String,
     pub price_model: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub unit_name: ::std::option::Option<::std::string::String>,
     pub yearly_price_in_cents: i64,
 }
@@ -23088,9 +23214,9 @@ pub struct MarketplacePurchasePurchasedSender {
 #[serde(deny_unknown_fields)]
 pub struct MemberAdded {
     pub action: MemberAddedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub changes: ::std::option::Option<MemberAddedChanges>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     #[doc = "The user that was added."]
     pub member: User,
@@ -23148,7 +23274,7 @@ impl ::std::convert::TryFrom<::std::string::String> for MemberAddedAction {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct MemberAddedChanges {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub permission: ::std::option::Option<MemberAddedChangesPermission>,
 }
 #[doc = "`MemberAddedChangesPermission`"]
@@ -23214,7 +23340,7 @@ impl ::std::convert::TryFrom<::std::string::String> for MemberAddedChangesPermis
 pub struct MemberEdited {
     pub action: MemberEditedAction,
     pub changes: MemberEditedChanges,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     #[doc = "The user who's permissions are changed."]
     pub member: User,
@@ -23309,7 +23435,7 @@ impl ::std::convert::From<MemberRemoved> for MemberEvent {
 #[serde(deny_unknown_fields)]
 pub struct MemberRemoved {
     pub action: MemberRemovedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     #[doc = "The user that was removed."]
     pub member: User,
@@ -23378,7 +23504,7 @@ pub struct Membership {
 #[serde(deny_unknown_fields)]
 pub struct MembershipAdded {
     pub action: MembershipAddedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     #[doc = "The [user](https://docs.github.com/en/rest/reference/users) that was added or removed."]
     pub member: User,
@@ -23505,7 +23631,7 @@ impl ::std::convert::From<MembershipRemoved> for MembershipEvent {
 #[serde(deny_unknown_fields)]
 pub struct MembershipRemoved {
     pub action: MembershipRemovedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     #[doc = "The [user](https://docs.github.com/en/rest/reference/users) that was added or removed."]
     pub member: User,
@@ -23620,7 +23746,7 @@ impl ::std::convert::TryFrom<::std::string::String> for MembershipRemovedScope {
 pub enum MembershipRemovedTeam {
     Team(Team),
     Object {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         deleted: ::std::option::Option<bool>,
         id: i64,
         name: ::std::string::String,
@@ -23786,11 +23912,14 @@ impl ::std::convert::From<MetaDeleted> for MetaEvent {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct Milestone {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub closed_at: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
     pub closed_issues: i64,
     pub created_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub creator: User,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub description: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub due_on: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
     pub html_url: ::std::string::String,
     pub id: i64,
@@ -23811,10 +23940,10 @@ pub struct Milestone {
 #[serde(deny_unknown_fields)]
 pub struct MilestoneClosed {
     pub action: MilestoneClosedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub milestone: MilestoneClosedMilestone,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -23874,7 +24003,9 @@ pub struct MilestoneClosedMilestone {
     pub closed_issues: i64,
     pub created_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub creator: User,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub description: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub due_on: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
     pub html_url: ::std::string::String,
     pub id: i64,
@@ -23941,10 +24072,10 @@ impl ::std::convert::TryFrom<::std::string::String> for MilestoneClosedMilestone
 #[serde(deny_unknown_fields)]
 pub struct MilestoneCreated {
     pub action: MilestoneCreatedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub milestone: MilestoneCreatedMilestone,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -24004,7 +24135,9 @@ pub struct MilestoneCreatedMilestone {
     pub closed_issues: i64,
     pub created_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub creator: User,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub description: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub due_on: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
     pub html_url: ::std::string::String,
     pub id: i64,
@@ -24071,10 +24204,10 @@ impl ::std::convert::TryFrom<::std::string::String> for MilestoneCreatedMileston
 #[serde(deny_unknown_fields)]
 pub struct MilestoneDeleted {
     pub action: MilestoneDeletedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub milestone: Milestone,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -24132,10 +24265,10 @@ impl ::std::convert::TryFrom<::std::string::String> for MilestoneDeletedAction {
 pub struct MilestoneEdited {
     pub action: MilestoneEditedAction,
     pub changes: MilestoneEditedChanges,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub milestone: Milestone,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -24191,11 +24324,11 @@ impl ::std::convert::TryFrom<::std::string::String> for MilestoneEditedAction {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct MilestoneEditedChanges {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub description: ::std::option::Option<MilestoneEditedChangesDescription>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub due_on: ::std::option::Option<MilestoneEditedChangesDueOn>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<MilestoneEditedChangesTitle>,
 }
 #[doc = "`MilestoneEditedChangesDescription`"]
@@ -24259,10 +24392,10 @@ impl ::std::convert::From<MilestoneOpened> for MilestoneEvent {
 #[serde(deny_unknown_fields)]
 pub struct MilestoneOpened {
     pub action: MilestoneOpenedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub milestone: MilestoneOpenedMilestone,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -24322,7 +24455,9 @@ pub struct MilestoneOpenedMilestone {
     pub closed_issues: i64,
     pub created_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub creator: User,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub description: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub due_on: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
     pub html_url: ::std::string::String,
     pub id: i64,
@@ -24442,7 +24577,7 @@ pub struct OrgBlockBlocked {
     pub action: OrgBlockBlockedAction,
     #[doc = "Information about the user that was blocked or unblocked."]
     pub blocked_user: User,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub organization: Organization,
     pub sender: User,
@@ -24518,7 +24653,7 @@ pub struct OrgBlockUnblocked {
     pub action: OrgBlockUnblockedAction,
     #[doc = "Information about the user that was blocked or unblocked."]
     pub blocked_user: User,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub organization: Organization,
     pub sender: User,
@@ -24575,10 +24710,11 @@ impl ::std::convert::TryFrom<::std::string::String> for OrgBlockUnblockedAction 
 #[serde(deny_unknown_fields)]
 pub struct Organization {
     pub avatar_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub description: ::std::option::Option<::std::string::String>,
     pub events_url: ::std::string::String,
     pub hooks_url: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub html_url: ::std::option::Option<::std::string::String>,
     pub id: i64,
     pub issues_url: ::std::string::String,
@@ -24594,7 +24730,7 @@ pub struct Organization {
 #[serde(deny_unknown_fields)]
 pub struct OrganizationDeleted {
     pub action: OrganizationDeletedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub membership: Membership,
     pub organization: Organization,
@@ -24687,7 +24823,7 @@ impl ::std::convert::From<OrganizationRenamed> for OrganizationEvent {
 #[serde(deny_unknown_fields)]
 pub struct OrganizationMemberAdded {
     pub action: OrganizationMemberAddedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub membership: Membership,
     pub organization: Organization,
@@ -24745,7 +24881,7 @@ impl ::std::convert::TryFrom<::std::string::String> for OrganizationMemberAddedA
 #[serde(deny_unknown_fields)]
 pub struct OrganizationMemberInvited {
     pub action: OrganizationMemberInvitedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub invitation: OrganizationMemberInvitedInvitation,
     pub organization: Organization,
@@ -24804,8 +24940,11 @@ impl ::std::convert::TryFrom<::std::string::String> for OrganizationMemberInvite
 #[serde(deny_unknown_fields)]
 pub struct OrganizationMemberInvitedInvitation {
     pub created_at: ::chrono::DateTime<::chrono::offset::Utc>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub email: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub failed_at: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub failed_reason: ::std::option::Option<::std::string::String>,
     pub id: f64,
     pub invitation_teams_url: ::std::string::String,
@@ -24820,7 +24959,7 @@ pub struct OrganizationMemberInvitedInvitation {
 #[serde(deny_unknown_fields)]
 pub struct OrganizationMemberRemoved {
     pub action: OrganizationMemberRemovedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub membership: Membership,
     pub organization: Organization,
@@ -24878,7 +25017,7 @@ impl ::std::convert::TryFrom<::std::string::String> for OrganizationMemberRemove
 #[serde(deny_unknown_fields)]
 pub struct OrganizationRenamed {
     pub action: OrganizationRenamedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub membership: Membership,
     pub organization: Organization,
@@ -24953,7 +25092,7 @@ impl ::std::convert::From<PackageUpdated> for PackageEvent {
 #[serde(deny_unknown_fields)]
 pub struct PackagePublished {
     pub action: PackagePublishedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub package: PackagePublishedPackage,
     pub repository: Repository,
@@ -25011,6 +25150,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PackagePublishedAction {
 #[serde(deny_unknown_fields)]
 pub struct PackagePublishedPackage {
     pub created_at: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub description: ::std::option::Option<::std::string::String>,
     pub ecosystem: ::std::string::String,
     pub html_url: ::std::string::String,
@@ -25099,7 +25239,7 @@ pub struct PackagePublishedPackageRegistry {
 #[serde(deny_unknown_fields)]
 pub struct PackageUpdated {
     pub action: PackageUpdatedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub package: PackageUpdatedPackage,
     pub repository: Repository,
@@ -25157,6 +25297,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PackageUpdatedAction {
 #[serde(deny_unknown_fields)]
 pub struct PackageUpdatedPackage {
     pub created_at: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub description: ::std::option::Option<::std::string::String>,
     pub ecosystem: ::std::string::String,
     pub html_url: ::std::string::String,
@@ -25246,9 +25387,9 @@ pub struct PackageUpdatedPackageRegistry {
 pub struct PageBuildEvent {
     pub build: PageBuildEventBuild,
     pub id: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -25270,6 +25411,7 @@ pub struct PageBuildEventBuild {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct PageBuildEventBuildError {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub message: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`PingEvent`"]
@@ -25279,11 +25421,11 @@ pub struct PingEvent {
     pub hook: PingEventHook,
     #[doc = "The ID of the webhook that triggered the ping."]
     pub hook_id: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub repository: ::std::option::Option<Repository>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub sender: ::std::option::Option<User>,
     pub zen: ::std::string::String,
 }
@@ -25293,17 +25435,17 @@ pub struct PingEvent {
 pub struct PingEventHook {
     pub active: bool,
     #[doc = "When you register a new GitHub App, GitHub sends a ping event to the **webhook URL** you specified during registration. The event contains the `app_id`, which is required for [authenticating](https://docs.github.com/en/apps/building-integrations/setting-up-and-registering-github-apps/about-authentication-options-for-github-apps) an app."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub app_id: ::std::option::Option<i64>,
     pub config: PingEventHookConfig,
     pub created_at: ::std::string::String,
     pub events: WebhookEvents,
     pub id: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub last_response: ::std::option::Option<PingEventHookLastResponse>,
     pub name: ::std::string::String,
     pub ping_url: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub test_url: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]
     pub type_: ::std::string::String,
@@ -25316,7 +25458,7 @@ pub struct PingEventHook {
 pub struct PingEventHookConfig {
     pub content_type: PingEventHookConfigContentType,
     pub insecure_ssl: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub secret: ::std::option::Option<::std::string::String>,
     pub url: ::std::string::String,
 }
@@ -25384,6 +25526,7 @@ pub struct PingEventHookLastResponse {
 #[serde(deny_unknown_fields)]
 pub struct Project {
     #[doc = "Body of the project"]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub body: ::std::option::Option<::std::string::String>,
     pub columns_url: ::std::string::String,
     pub created_at: ::chrono::DateTime<::chrono::offset::Utc>,
@@ -25410,13 +25553,14 @@ pub struct ProjectCard {
     pub archived: bool,
     pub column_id: i64,
     pub column_url: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub content_url: ::std::option::Option<::std::string::String>,
     pub created_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub creator: User,
     #[doc = "The project card's ID"]
     pub id: i64,
     pub node_id: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub note: ::std::option::Option<::std::string::String>,
     pub project_url: ::std::string::String,
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
@@ -25428,9 +25572,9 @@ pub struct ProjectCard {
 pub struct ProjectCardConverted {
     pub action: ProjectCardConvertedAction,
     pub changes: ProjectCardConvertedChanges,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub project_card: ProjectCard,
     pub repository: Repository,
@@ -25500,9 +25644,9 @@ pub struct ProjectCardConvertedChangesNote {
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardCreated {
     pub action: ProjectCardCreatedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub project_card: ProjectCard,
     pub repository: Repository,
@@ -25560,9 +25704,9 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectCardCreatedAction
 #[serde(deny_unknown_fields)]
 pub struct ProjectCardDeleted {
     pub action: ProjectCardDeletedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub project_card: ProjectCard,
     pub repository: Repository,
@@ -25621,9 +25765,9 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectCardDeletedAction
 pub struct ProjectCardEdited {
     pub action: ProjectCardEditedAction,
     pub changes: ProjectCardEditedChanges,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub project_card: ProjectCard,
     pub repository: Repository,
@@ -25729,9 +25873,9 @@ impl ::std::convert::From<ProjectCardMoved> for ProjectCardEvent {
 pub struct ProjectCardMoved {
     pub action: ProjectCardMovedAction,
     pub changes: ProjectCardMovedChanges,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub project_card: ProjectCardMovedProjectCard,
     pub repository: Repository,
@@ -25805,13 +25949,14 @@ pub struct ProjectCardMovedProjectCard {
     pub archived: bool,
     pub column_id: i64,
     pub column_url: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub content_url: ::std::option::Option<::std::string::String>,
     pub created_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub creator: User,
     #[doc = "The project card's ID"]
     pub id: i64,
     pub node_id: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub note: ::std::option::Option<::std::string::String>,
     pub project_url: ::std::string::String,
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
@@ -25822,9 +25967,9 @@ pub struct ProjectCardMovedProjectCard {
 #[serde(deny_unknown_fields)]
 pub struct ProjectClosed {
     pub action: ProjectClosedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub project: Project,
     pub repository: Repository,
@@ -25897,9 +26042,9 @@ pub struct ProjectColumn {
 #[serde(deny_unknown_fields)]
 pub struct ProjectColumnCreated {
     pub action: ProjectColumnCreatedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub project_column: ProjectColumn,
     pub repository: Repository,
@@ -25957,9 +26102,9 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectColumnCreatedActi
 #[serde(deny_unknown_fields)]
 pub struct ProjectColumnDeleted {
     pub action: ProjectColumnDeletedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub project_column: ProjectColumn,
     pub repository: Repository,
@@ -26018,9 +26163,9 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectColumnDeletedActi
 pub struct ProjectColumnEdited {
     pub action: ProjectColumnEditedAction,
     pub changes: ProjectColumnEditedChanges,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub project_column: ProjectColumn,
     pub repository: Repository,
@@ -26077,7 +26222,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectColumnEditedActio
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectColumnEditedChanges {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<ProjectColumnEditedChangesName>,
 }
 #[doc = "`ProjectColumnEditedChangesName`"]
@@ -26120,9 +26265,9 @@ impl ::std::convert::From<ProjectColumnMoved> for ProjectColumnEvent {
 #[serde(deny_unknown_fields)]
 pub struct ProjectColumnMoved {
     pub action: ProjectColumnMovedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub project_column: ProjectColumn,
     pub repository: Repository,
@@ -26180,9 +26325,9 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectColumnMovedAction
 #[serde(deny_unknown_fields)]
 pub struct ProjectCreated {
     pub action: ProjectCreatedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub project: Project,
     pub repository: Repository,
@@ -26240,9 +26385,9 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectCreatedAction {
 #[serde(deny_unknown_fields)]
 pub struct ProjectDeleted {
     pub action: ProjectDeletedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub project: Project,
     pub repository: Repository,
@@ -26301,9 +26446,9 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectDeletedAction {
 pub struct ProjectEdited {
     pub action: ProjectEditedAction,
     pub changes: ProjectEditedChanges,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub project: Project,
     pub repository: Repository,
@@ -26360,9 +26505,9 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectEditedAction {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectEditedChanges {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub body: ::std::option::Option<ProjectEditedChangesBody>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<ProjectEditedChangesName>,
 }
 #[doc = "`ProjectEditedChangesBody`"]
@@ -26419,9 +26564,9 @@ impl ::std::convert::From<ProjectReopened> for ProjectEvent {
 #[serde(deny_unknown_fields)]
 pub struct ProjectReopened {
     pub action: ProjectReopenedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub project: Project,
     pub repository: Repository,
@@ -26529,9 +26674,9 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectState {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct PublicEvent {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: PublicEventRepository,
     pub sender: User,
@@ -26544,7 +26689,7 @@ pub struct PublicEventRepository {
     #[serde(default)]
     pub allow_auto_merge: bool,
     #[doc = "Whether to allow private forks"]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub allow_forking: ::std::option::Option<bool>,
     #[doc = "Whether to allow merge commits for pull requests."]
     #[serde(default = "defaults::default_bool::<true>")]
@@ -26575,9 +26720,10 @@ pub struct PublicEventRepository {
     #[serde(default)]
     pub delete_branch_on_merge: bool,
     pub deployments_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub description: ::std::option::Option<::std::string::String>,
     #[doc = "Returns whether or not this repository is disabled."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub disabled: ::std::option::Option<bool>,
     pub downloads_url: ::std::string::String,
     pub events_url: ::std::string::String,
@@ -26599,6 +26745,7 @@ pub struct PublicEventRepository {
     pub has_projects: bool,
     #[doc = "Whether the wiki is enabled."]
     pub has_wiki: bool,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub homepage: ::std::option::Option<::std::string::String>,
     pub hooks_url: ::std::string::String,
     pub html_url: ::std::string::String,
@@ -26609,13 +26756,16 @@ pub struct PublicEventRepository {
     pub issues_url: ::std::string::String,
     pub keys_url: ::std::string::String,
     pub labels_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub language: ::std::option::Option<::std::string::String>,
     pub languages_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub license: ::std::option::Option<License>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub master_branch: ::std::option::Option<::std::string::String>,
     pub merges_url: ::std::string::String,
     pub milestones_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub mirror_url: ::std::option::Option<::std::string::String>,
     #[doc = "The name of the repository."]
     pub name: ::std::string::String,
@@ -26623,20 +26773,20 @@ pub struct PublicEventRepository {
     pub notifications_url: ::std::string::String,
     pub open_issues: i64,
     pub open_issues_count: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<::std::string::String>,
     pub owner: User,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub permissions: ::std::option::Option<PublicEventRepositoryPermissions>,
     pub private: bool,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub public: ::std::option::Option<bool>,
     pub pulls_url: ::std::string::String,
     pub pushed_at: PublicEventRepositoryPushedAt,
     pub releases_url: ::std::string::String,
     pub size: i64,
     pub ssh_url: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub stargazers: ::std::option::Option<i64>,
     pub stargazers_count: i64,
     pub stargazers_url: ::std::string::String,
@@ -26658,6 +26808,14 @@ pub struct PublicEventRepository {
 pub enum PublicEventRepositoryCreatedAt {
     Integer(i64),
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
+}
+impl ::std::fmt::Display for PublicEventRepositoryCreatedAt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Integer(x) => x.fmt(f),
+            Self::DateTime(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for PublicEventRepositoryCreatedAt {
     type Err = self::error::ConversionError;
@@ -26685,14 +26843,6 @@ impl ::std::convert::TryFrom<::std::string::String> for PublicEventRepositoryCre
         value.parse()
     }
 }
-impl ::std::fmt::Display for PublicEventRepositoryCreatedAt {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Integer(x) => x.fmt(f),
-            Self::DateTime(x) => x.fmt(f),
-        }
-    }
-}
 impl ::std::convert::From<i64> for PublicEventRepositoryCreatedAt {
     fn from(value: i64) -> Self {
         Self::Integer(value)
@@ -26710,11 +26860,11 @@ impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
 #[serde(deny_unknown_fields)]
 pub struct PublicEventRepositoryPermissions {
     pub admin: bool,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub maintain: ::std::option::Option<bool>,
     pub pull: bool,
     pub push: bool,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub triage: ::std::option::Option<bool>,
 }
 #[doc = "`PublicEventRepositoryPushedAt`"]
@@ -26741,15 +26891,19 @@ impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequest {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub active_lock_reason: ::std::option::Option<PullRequestActiveLockReason>,
     pub additions: i64,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub assignee: ::std::option::Option<User>,
     pub assignees: ::std::vec::Vec<User>,
     pub author_association: AuthorAssociation,
     pub auto_merge: (),
     pub base: PullRequestBase,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub body: ::std::option::Option<::std::string::String>,
     pub changed_files: i64,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub closed_at: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
     pub comments: i64,
     pub comments_url: ::std::string::String,
@@ -26770,17 +26924,24 @@ pub struct PullRequest {
     pub locked: bool,
     #[doc = "Indicates whether maintainers can modify the pull request."]
     pub maintainer_can_modify: bool,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub merge_commit_sha: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub mergeable: ::std::option::Option<bool>,
     pub mergeable_state: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub merged: ::std::option::Option<bool>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub merged_at: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub merged_by: ::std::option::Option<User>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub milestone: ::std::option::Option<Milestone>,
     pub node_id: ::std::string::String,
     #[doc = "Number uniquely identifying the pull request within its repository."]
     pub number: i64,
     pub patch_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub rebaseable: ::std::option::Option<bool>,
     pub requested_reviewers: ::std::vec::Vec<PullRequestRequestedReviewersItem>,
     pub requested_teams: ::std::vec::Vec<Team>,
@@ -26861,11 +27022,11 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestActiveLockRea
 pub struct PullRequestAssigned {
     pub action: PullRequestAssignedAction,
     pub assignee: User,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     #[doc = "The pull request number."]
     pub number: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub pull_request: PullRequest,
     pub repository: Repository,
@@ -26923,10 +27084,10 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestAssignedActio
 #[serde(deny_unknown_fields)]
 pub struct PullRequestAutoMergeDisabled {
     pub action: PullRequestAutoMergeDisabledAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub number: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub pull_request: PullRequest,
     pub repository: Repository,
@@ -26984,10 +27145,10 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestAutoMergeDisa
 #[serde(deny_unknown_fields)]
 pub struct PullRequestAutoMergeEnabled {
     pub action: PullRequestAutoMergeEnabledAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub number: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub pull_request: PullRequest,
     pub repository: Repository,
@@ -27056,11 +27217,11 @@ pub struct PullRequestBase {
 #[serde(deny_unknown_fields)]
 pub struct PullRequestClosed {
     pub action: PullRequestClosedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     #[doc = "The pull request number."]
     pub number: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub pull_request: PullRequestClosedPullRequest,
     pub repository: Repository,
@@ -27117,13 +27278,16 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestClosedAction 
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestClosedPullRequest {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub active_lock_reason: ::std::option::Option<PullRequestClosedPullRequestActiveLockReason>,
     pub additions: i64,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub assignee: ::std::option::Option<User>,
     pub assignees: ::std::vec::Vec<User>,
     pub author_association: AuthorAssociation,
     pub auto_merge: (),
     pub base: PullRequestClosedPullRequestBase,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub body: ::std::option::Option<::std::string::String>,
     pub changed_files: i64,
     pub closed_at: ::chrono::DateTime<::chrono::offset::Utc>,
@@ -27146,17 +27310,23 @@ pub struct PullRequestClosedPullRequest {
     pub locked: bool,
     #[doc = "Indicates whether maintainers can modify the pull request."]
     pub maintainer_can_modify: bool,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub merge_commit_sha: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub mergeable: ::std::option::Option<bool>,
     pub mergeable_state: ::std::string::String,
     pub merged: bool,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub merged_at: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub merged_by: ::std::option::Option<User>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub milestone: ::std::option::Option<Milestone>,
     pub node_id: ::std::string::String,
     #[doc = "Number uniquely identifying the pull request within its repository."]
     pub number: i64,
     pub patch_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub rebaseable: ::std::option::Option<bool>,
     pub requested_reviewers: ::std::vec::Vec<PullRequestClosedPullRequestRequestedReviewersItem>,
     pub requested_teams: ::std::vec::Vec<Team>,
@@ -27337,11 +27507,11 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestClosedPullReq
 #[serde(deny_unknown_fields)]
 pub struct PullRequestConvertedToDraft {
     pub action: PullRequestConvertedToDraftAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     #[doc = "The pull request number."]
     pub number: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub pull_request: PullRequestConvertedToDraftPullRequest,
     pub repository: Repository,
@@ -27398,14 +27568,17 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestConvertedToDr
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestConvertedToDraftPullRequest {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub active_lock_reason:
         ::std::option::Option<PullRequestConvertedToDraftPullRequestActiveLockReason>,
     pub additions: i64,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub assignee: ::std::option::Option<User>,
     pub assignees: ::std::vec::Vec<User>,
     pub author_association: AuthorAssociation,
     pub auto_merge: (),
     pub base: PullRequestConvertedToDraftPullRequestBase,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub body: ::std::option::Option<::std::string::String>,
     pub changed_files: i64,
     pub closed_at: (),
@@ -27427,17 +27600,21 @@ pub struct PullRequestConvertedToDraftPullRequest {
     pub locked: bool,
     #[doc = "Indicates whether maintainers can modify the pull request."]
     pub maintainer_can_modify: bool,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub merge_commit_sha: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub mergeable: ::std::option::Option<bool>,
     pub mergeable_state: ::std::string::String,
     pub merged: bool,
     pub merged_at: (),
     pub merged_by: (),
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub milestone: ::std::option::Option<Milestone>,
     pub node_id: ::std::string::String,
     #[doc = "Number uniquely identifying the pull request within its repository."]
     pub number: i64,
     pub patch_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub rebaseable: ::std::option::Option<bool>,
     pub requested_reviewers:
         ::std::vec::Vec<PullRequestConvertedToDraftPullRequestRequestedReviewersItem>,
@@ -27627,11 +27804,11 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub struct PullRequestEdited {
     pub action: PullRequestEditedAction,
     pub changes: PullRequestEditedChanges,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     #[doc = "The pull request number."]
     pub number: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub pull_request: PullRequest,
     pub repository: Repository,
@@ -27688,9 +27865,9 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestEditedAction 
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestEditedChanges {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub body: ::std::option::Option<PullRequestEditedChangesBody>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<PullRequestEditedChangesTitle>,
 }
 #[doc = "`PullRequestEditedChangesBody`"]
@@ -27830,12 +28007,12 @@ pub struct PullRequestHead {
 #[serde(deny_unknown_fields)]
 pub struct PullRequestLabeled {
     pub action: PullRequestLabeledAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub label: Label,
     #[doc = "The pull request number."]
     pub number: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub pull_request: PullRequest,
     pub repository: Repository,
@@ -27907,11 +28084,11 @@ pub struct PullRequestLinks {
 #[serde(deny_unknown_fields)]
 pub struct PullRequestLocked {
     pub action: PullRequestLockedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     #[doc = "The pull request number."]
     pub number: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub pull_request: PullRequest,
     pub repository: Repository,
@@ -27969,11 +28146,11 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestLockedAction 
 #[serde(deny_unknown_fields)]
 pub struct PullRequestOpened {
     pub action: PullRequestOpenedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     #[doc = "The pull request number."]
     pub number: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub pull_request: PullRequestOpenedPullRequest,
     pub repository: Repository,
@@ -28032,11 +28209,13 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestOpenedAction 
 pub struct PullRequestOpenedPullRequest {
     pub active_lock_reason: PullRequestOpenedPullRequestActiveLockReason,
     pub additions: i64,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub assignee: ::std::option::Option<User>,
     pub assignees: ::std::vec::Vec<User>,
     pub author_association: AuthorAssociation,
     pub auto_merge: (),
     pub base: PullRequestOpenedPullRequestBase,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub body: ::std::option::Option<::std::string::String>,
     pub changed_files: i64,
     pub closed_at: (),
@@ -28060,16 +28239,20 @@ pub struct PullRequestOpenedPullRequest {
     #[doc = "Indicates whether maintainers can modify the pull request."]
     pub maintainer_can_modify: bool,
     pub merge_commit_sha: (),
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub mergeable: ::std::option::Option<bool>,
     pub mergeable_state: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub merged: ::std::option::Option<bool>,
     pub merged_at: (),
     pub merged_by: (),
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub milestone: ::std::option::Option<Milestone>,
     pub node_id: ::std::string::String,
     #[doc = "Number uniquely identifying the pull request within its repository."]
     pub number: i64,
     pub patch_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub rebaseable: ::std::option::Option<bool>,
     pub requested_reviewers: ::std::vec::Vec<PullRequestOpenedPullRequestRequestedReviewersItem>,
     pub requested_teams: ::std::vec::Vec<Team>,
@@ -28223,11 +28406,11 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestOpenedPullReq
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReadyForReview {
     pub action: PullRequestReadyForReviewAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     #[doc = "The pull request number."]
     pub number: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub pull_request: PullRequestReadyForReviewPullRequest,
     pub repository: Repository,
@@ -28284,14 +28467,17 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReadyForRevie
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReadyForReviewPullRequest {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub active_lock_reason:
         ::std::option::Option<PullRequestReadyForReviewPullRequestActiveLockReason>,
     pub additions: i64,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub assignee: ::std::option::Option<User>,
     pub assignees: ::std::vec::Vec<User>,
     pub author_association: AuthorAssociation,
     pub auto_merge: (),
     pub base: PullRequestReadyForReviewPullRequestBase,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub body: ::std::option::Option<::std::string::String>,
     pub changed_files: i64,
     pub closed_at: (),
@@ -28313,17 +28499,21 @@ pub struct PullRequestReadyForReviewPullRequest {
     pub locked: bool,
     #[doc = "Indicates whether maintainers can modify the pull request."]
     pub maintainer_can_modify: bool,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub merge_commit_sha: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub mergeable: ::std::option::Option<bool>,
     pub mergeable_state: ::std::string::String,
     pub merged: bool,
     pub merged_at: (),
     pub merged_by: (),
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub milestone: ::std::option::Option<Milestone>,
     pub node_id: ::std::string::String,
     #[doc = "Number uniquely identifying the pull request within its repository."]
     pub number: i64,
     pub patch_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub rebaseable: ::std::option::Option<bool>,
     pub requested_reviewers:
         ::std::vec::Vec<PullRequestReadyForReviewPullRequestRequestedReviewersItem>,
@@ -28505,11 +28695,11 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReadyForRevie
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReopened {
     pub action: PullRequestReopenedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     #[doc = "The pull request number."]
     pub number: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub pull_request: PullRequestReopenedPullRequest,
     pub repository: Repository,
@@ -28566,13 +28756,16 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReopenedActio
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReopenedPullRequest {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub active_lock_reason: ::std::option::Option<PullRequestReopenedPullRequestActiveLockReason>,
     pub additions: i64,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub assignee: ::std::option::Option<User>,
     pub assignees: ::std::vec::Vec<User>,
     pub author_association: AuthorAssociation,
     pub auto_merge: (),
     pub base: PullRequestReopenedPullRequestBase,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub body: ::std::option::Option<::std::string::String>,
     pub changed_files: i64,
     pub closed_at: (),
@@ -28596,16 +28789,19 @@ pub struct PullRequestReopenedPullRequest {
     #[doc = "Indicates whether maintainers can modify the pull request."]
     pub maintainer_can_modify: bool,
     pub merge_commit_sha: (),
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub mergeable: ::std::option::Option<bool>,
     pub mergeable_state: ::std::string::String,
     pub merged: bool,
     pub merged_at: (),
     pub merged_by: (),
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub milestone: ::std::option::Option<Milestone>,
     pub node_id: ::std::string::String,
     #[doc = "Number uniquely identifying the pull request within its repository."]
     pub number: i64,
     pub patch_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub rebaseable: ::std::option::Option<bool>,
     pub requested_reviewers: ::std::vec::Vec<PullRequestReopenedPullRequestRequestedReviewersItem>,
     pub requested_teams: ::std::vec::Vec<Team>,
@@ -28815,9 +29011,10 @@ pub struct PullRequestReviewComment {
     #[doc = "The ID of the pull request review comment."]
     pub id: i64,
     #[doc = "The comment ID to reply to."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub in_reply_to_id: ::std::option::Option<i64>,
     #[doc = "The line of the blob to which the comment applies. The last line of the range for a multi-line comment"]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub line: ::std::option::Option<i64>,
     #[serde(rename = "_links")]
     pub links: PullRequestReviewCommentLinks,
@@ -28830,10 +29027,12 @@ pub struct PullRequestReviewComment {
     #[doc = "The index of the original line in the diff to which the comment applies."]
     pub original_position: i64,
     #[doc = "The first line of the range for a multi-line comment."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub original_start_line: ::std::option::Option<i64>,
     #[doc = "The relative path of the file to which the comment applies."]
     pub path: ::std::string::String,
     #[doc = "The line index in the diff to which the comment applies."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub position: ::std::option::Option<i64>,
     #[doc = "The ID of the pull request review to which the comment belongs."]
     pub pull_request_review_id: i64,
@@ -28842,8 +29041,10 @@ pub struct PullRequestReviewComment {
     #[doc = "The side of the first line of the range for a multi-line comment."]
     pub side: PullRequestReviewCommentSide,
     #[doc = "The first line of the range for a multi-line comment."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub start_line: ::std::option::Option<i64>,
     #[doc = "The side of the first line of the range for a multi-line comment."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub start_side: ::std::option::Option<PullRequestReviewCommentStartSide>,
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
     #[doc = "URL for the pull request review comment"]
@@ -28856,9 +29057,9 @@ pub struct PullRequestReviewComment {
 pub struct PullRequestReviewCommentCreated {
     pub action: PullRequestReviewCommentCreatedAction,
     pub comment: PullRequestReviewComment,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub pull_request: PullRequestReviewCommentCreatedPullRequest,
     pub repository: Repository,
@@ -28915,8 +29116,10 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReviewComment
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentCreatedPullRequest {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub active_lock_reason:
         ::std::option::Option<PullRequestReviewCommentCreatedPullRequestActiveLockReason>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub assignee: ::std::option::Option<User>,
     pub assignees: ::std::vec::Vec<User>,
     pub author_association: AuthorAssociation,
@@ -28924,12 +29127,13 @@ pub struct PullRequestReviewCommentCreatedPullRequest {
     pub auto_merge: (),
     pub base: PullRequestReviewCommentCreatedPullRequestBase,
     pub body: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub closed_at: ::std::option::Option<::std::string::String>,
     pub comments_url: ::std::string::String,
     pub commits_url: ::std::string::String,
     pub created_at: ::std::string::String,
     pub diff_url: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub draft: ::std::option::Option<bool>,
     pub head: PullRequestReviewCommentCreatedPullRequestHead,
     pub html_url: ::std::string::String,
@@ -28939,8 +29143,11 @@ pub struct PullRequestReviewCommentCreatedPullRequest {
     #[serde(rename = "_links")]
     pub links: PullRequestReviewCommentCreatedPullRequestLinks,
     pub locked: bool,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub merge_commit_sha: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub merged_at: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub milestone: ::std::option::Option<Milestone>,
     pub node_id: ::std::string::String,
     pub number: i64,
@@ -29134,9 +29341,9 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub struct PullRequestReviewCommentDeleted {
     pub action: PullRequestReviewCommentDeletedAction,
     pub comment: PullRequestReviewComment,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub pull_request: PullRequestReviewCommentDeletedPullRequest,
     pub repository: Repository,
@@ -29193,8 +29400,10 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReviewComment
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentDeletedPullRequest {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub active_lock_reason:
         ::std::option::Option<PullRequestReviewCommentDeletedPullRequestActiveLockReason>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub assignee: ::std::option::Option<User>,
     pub assignees: ::std::vec::Vec<User>,
     pub author_association: AuthorAssociation,
@@ -29202,12 +29411,13 @@ pub struct PullRequestReviewCommentDeletedPullRequest {
     pub auto_merge: (),
     pub base: PullRequestReviewCommentDeletedPullRequestBase,
     pub body: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub closed_at: ::std::option::Option<::std::string::String>,
     pub comments_url: ::std::string::String,
     pub commits_url: ::std::string::String,
     pub created_at: ::std::string::String,
     pub diff_url: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub draft: ::std::option::Option<bool>,
     pub head: PullRequestReviewCommentDeletedPullRequestHead,
     pub html_url: ::std::string::String,
@@ -29217,8 +29427,11 @@ pub struct PullRequestReviewCommentDeletedPullRequest {
     #[serde(rename = "_links")]
     pub links: PullRequestReviewCommentDeletedPullRequestLinks,
     pub locked: bool,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub merge_commit_sha: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub merged_at: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub milestone: ::std::option::Option<Milestone>,
     pub node_id: ::std::string::String,
     pub number: i64,
@@ -29413,9 +29626,9 @@ pub struct PullRequestReviewCommentEdited {
     pub action: PullRequestReviewCommentEditedAction,
     pub changes: PullRequestReviewCommentEditedChanges,
     pub comment: PullRequestReviewComment,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub pull_request: PullRequestReviewCommentEditedPullRequest,
     pub repository: Repository,
@@ -29472,7 +29685,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReviewComment
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentEditedChanges {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub body: ::std::option::Option<PullRequestReviewCommentEditedChangesBody>,
 }
 #[doc = "`PullRequestReviewCommentEditedChangesBody`"]
@@ -29486,8 +29699,10 @@ pub struct PullRequestReviewCommentEditedChangesBody {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewCommentEditedPullRequest {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub active_lock_reason:
         ::std::option::Option<PullRequestReviewCommentEditedPullRequestActiveLockReason>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub assignee: ::std::option::Option<User>,
     pub assignees: ::std::vec::Vec<User>,
     pub author_association: AuthorAssociation,
@@ -29495,12 +29710,13 @@ pub struct PullRequestReviewCommentEditedPullRequest {
     pub auto_merge: (),
     pub base: PullRequestReviewCommentEditedPullRequestBase,
     pub body: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub closed_at: ::std::option::Option<::std::string::String>,
     pub comments_url: ::std::string::String,
     pub commits_url: ::std::string::String,
     pub created_at: ::std::string::String,
     pub diff_url: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub draft: ::std::option::Option<bool>,
     pub head: PullRequestReviewCommentEditedPullRequestHead,
     pub html_url: ::std::string::String,
@@ -29510,8 +29726,11 @@ pub struct PullRequestReviewCommentEditedPullRequest {
     #[serde(rename = "_links")]
     pub links: PullRequestReviewCommentEditedPullRequestLinks,
     pub locked: bool,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub merge_commit_sha: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub merged_at: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub milestone: ::std::option::Option<Milestone>,
     pub node_id: ::std::string::String,
     pub number: i64,
@@ -29838,9 +30057,9 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReviewComment
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewDismissed {
     pub action: PullRequestReviewDismissedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub pull_request: SimplePullRequest,
     pub repository: Repository,
@@ -29900,6 +30119,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReviewDismiss
 pub struct PullRequestReviewDismissedReview {
     pub author_association: AuthorAssociation,
     #[doc = "The text of the review."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub body: ::std::option::Option<::std::string::String>,
     #[doc = "A commit SHA for the review."]
     pub commit_id: ::std::string::String,
@@ -29974,9 +30194,9 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReviewDismiss
 pub struct PullRequestReviewEdited {
     pub action: PullRequestReviewEditedAction,
     pub changes: PullRequestReviewEditedChanges,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub pull_request: SimplePullRequest,
     pub repository: Repository,
@@ -30034,7 +30254,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReviewEditedA
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewEditedChanges {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub body: ::std::option::Option<PullRequestReviewEditedChangesBody>,
 }
 #[doc = "`PullRequestReviewEditedChangesBody`"]
@@ -30050,6 +30270,7 @@ pub struct PullRequestReviewEditedChangesBody {
 pub struct PullRequestReviewEditedReview {
     pub author_association: AuthorAssociation,
     #[doc = "The text of the review."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub body: ::std::option::Option<::std::string::String>,
     #[doc = "A commit SHA for the review."]
     pub commit_id: ::std::string::String,
@@ -30100,11 +30321,11 @@ impl ::std::convert::From<PullRequestReviewSubmitted> for PullRequestReviewEvent
 pub enum PullRequestReviewRequestRemoved {
     Variant0 {
         action: PullRequestReviewRequestRemovedVariant0Action,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         installation: ::std::option::Option<InstallationLite>,
         #[doc = "The pull request number."]
         number: i64,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         organization: ::std::option::Option<Organization>,
         pull_request: PullRequest,
         repository: Repository,
@@ -30113,11 +30334,11 @@ pub enum PullRequestReviewRequestRemoved {
     },
     Variant1 {
         action: PullRequestReviewRequestRemovedVariant1Action,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         installation: ::std::option::Option<InstallationLite>,
         #[doc = "The pull request number."]
         number: i64,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         organization: ::std::option::Option<Organization>,
         pull_request: PullRequest,
         repository: Repository,
@@ -30229,11 +30450,11 @@ impl ::std::convert::TryFrom<::std::string::String>
 pub enum PullRequestReviewRequested {
     Variant0 {
         action: PullRequestReviewRequestedVariant0Action,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         installation: ::std::option::Option<InstallationLite>,
         #[doc = "The pull request number."]
         number: i64,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         organization: ::std::option::Option<Organization>,
         pull_request: PullRequest,
         repository: Repository,
@@ -30242,11 +30463,11 @@ pub enum PullRequestReviewRequested {
     },
     Variant1 {
         action: PullRequestReviewRequestedVariant1Action,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         installation: ::std::option::Option<InstallationLite>,
         #[doc = "The pull request number."]
         number: i64,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         organization: ::std::option::Option<Organization>,
         pull_request: PullRequest,
         repository: Repository,
@@ -30353,9 +30574,9 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReviewRequest
 #[serde(deny_unknown_fields)]
 pub struct PullRequestReviewSubmitted {
     pub action: PullRequestReviewSubmittedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub pull_request: SimplePullRequest,
     pub repository: Repository,
@@ -30415,6 +30636,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestReviewSubmitt
 pub struct PullRequestReviewSubmittedReview {
     pub author_association: AuthorAssociation,
     #[doc = "The text of the review."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub body: ::std::option::Option<::std::string::String>,
     #[doc = "A commit SHA for the review."]
     pub commit_id: ::std::string::String,
@@ -30494,11 +30716,11 @@ pub struct PullRequestSynchronize {
     pub action: PullRequestSynchronizeAction,
     pub after: ::std::string::String,
     pub before: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     #[doc = "The pull request number."]
     pub number: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub pull_request: PullRequest,
     pub repository: Repository,
@@ -30557,11 +30779,11 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestSynchronizeAc
 pub struct PullRequestUnassigned {
     pub action: PullRequestUnassignedAction,
     pub assignee: User,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     #[doc = "The pull request number."]
     pub number: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub pull_request: PullRequest,
     pub repository: Repository,
@@ -30619,12 +30841,12 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestUnassignedAct
 #[serde(deny_unknown_fields)]
 pub struct PullRequestUnlabeled {
     pub action: PullRequestUnlabeledAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub label: Label,
     #[doc = "The pull request number."]
     pub number: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub pull_request: PullRequest,
     pub repository: Repository,
@@ -30682,11 +30904,11 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestUnlabeledActi
 #[serde(deny_unknown_fields)]
 pub struct PullRequestUnlocked {
     pub action: PullRequestUnlockedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     #[doc = "The pull request number."]
     pub number: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub pull_request: PullRequest,
     pub repository: Repository,
@@ -30745,6 +30967,7 @@ impl ::std::convert::TryFrom<::std::string::String> for PullRequestUnlockedActio
 pub struct PushEvent {
     #[doc = "The SHA of the most recent commit on `ref` after the push."]
     pub after: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub base_ref: ::std::option::Option<::std::string::String>,
     #[doc = "The SHA of the most recent commit on `ref` before the push."]
     pub before: ::std::string::String,
@@ -30754,10 +30977,11 @@ pub struct PushEvent {
     pub created: bool,
     pub deleted: bool,
     pub forced: bool,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub head_commit: ::std::option::Option<Commit>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub pusher: Committer,
     #[doc = "The full git ref that was pushed. Example: `refs/heads/main`."]
@@ -30774,6 +30998,7 @@ pub struct Release {
     pub assets_url: ::std::string::String,
     pub author: User,
     pub body: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub created_at: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
     #[doc = "Wether the release is a draft or published"]
     pub draft: bool,
@@ -30783,14 +31008,17 @@ pub struct Release {
     pub node_id: ::std::string::String,
     #[doc = "Whether the release is identified as a prerelease or a full release."]
     pub prerelease: bool,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub published_at: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
     #[doc = "The name of the tag."]
     pub tag_name: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub tarball_url: ::std::option::Option<::std::string::String>,
     #[doc = "Specifies the commitish value that determines where the Git tag is created from."]
     pub target_commitish: ::std::string::String,
     pub upload_url: ::std::string::String,
     pub url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub zipball_url: ::std::option::Option<::std::string::String>,
 }
 #[doc = "Data related to a release."]
@@ -30802,6 +31030,7 @@ pub struct ReleaseAsset {
     pub created_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub download_count: i64,
     pub id: i64,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub label: ::std::option::Option<::std::string::String>,
     #[doc = "The file name of the asset."]
     pub name: ::std::string::String,
@@ -30810,7 +31039,7 @@ pub struct ReleaseAsset {
     #[doc = "State of the release asset."]
     pub state: ReleaseAssetState,
     pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub uploader: ::std::option::Option<User>,
     pub url: ::std::string::String,
 }
@@ -30866,9 +31095,9 @@ impl ::std::convert::TryFrom<::std::string::String> for ReleaseAssetState {
 #[serde(deny_unknown_fields)]
 pub struct ReleaseCreated {
     pub action: ReleaseCreatedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub release: Release,
     pub repository: Repository,
@@ -30926,9 +31155,9 @@ impl ::std::convert::TryFrom<::std::string::String> for ReleaseCreatedAction {
 #[serde(deny_unknown_fields)]
 pub struct ReleaseDeleted {
     pub action: ReleaseDeletedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub release: Release,
     pub repository: Repository,
@@ -30987,9 +31216,9 @@ impl ::std::convert::TryFrom<::std::string::String> for ReleaseDeletedAction {
 pub struct ReleaseEdited {
     pub action: ReleaseEditedAction,
     pub changes: ReleaseEditedChanges,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub release: Release,
     pub repository: Repository,
@@ -31046,9 +31275,9 @@ impl ::std::convert::TryFrom<::std::string::String> for ReleaseEditedAction {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct ReleaseEditedChanges {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub body: ::std::option::Option<ReleaseEditedChangesBody>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<ReleaseEditedChangesName>,
 }
 #[doc = "`ReleaseEditedChangesBody`"]
@@ -31117,9 +31346,9 @@ impl ::std::convert::From<ReleaseUnpublished> for ReleaseEvent {
 #[serde(deny_unknown_fields)]
 pub struct ReleasePrereleased {
     pub action: ReleasePrereleasedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub release: ReleasePrereleasedRelease,
     pub repository: Repository,
@@ -31180,6 +31409,7 @@ pub struct ReleasePrereleasedRelease {
     pub assets_url: ::std::string::String,
     pub author: User,
     pub body: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub created_at: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
     #[doc = "Wether the release is a draft or published"]
     pub draft: bool,
@@ -31188,14 +31418,17 @@ pub struct ReleasePrereleasedRelease {
     pub name: ::std::string::String,
     pub node_id: ::std::string::String,
     pub prerelease: bool,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub published_at: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
     #[doc = "The name of the tag."]
     pub tag_name: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub tarball_url: ::std::option::Option<::std::string::String>,
     #[doc = "Specifies the commitish value that determines where the Git tag is created from."]
     pub target_commitish: ::std::string::String,
     pub upload_url: ::std::string::String,
     pub url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub zipball_url: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`ReleasePublished`"]
@@ -31203,9 +31436,9 @@ pub struct ReleasePrereleasedRelease {
 #[serde(deny_unknown_fields)]
 pub struct ReleasePublished {
     pub action: ReleasePublishedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub release: ReleasePublishedRelease,
     pub repository: Repository,
@@ -31266,6 +31499,7 @@ pub struct ReleasePublishedRelease {
     pub assets_url: ::std::string::String,
     pub author: User,
     pub body: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub created_at: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
     #[doc = "Wether the release is a draft or published"]
     pub draft: bool,
@@ -31278,11 +31512,13 @@ pub struct ReleasePublishedRelease {
     pub published_at: ::chrono::DateTime<::chrono::offset::Utc>,
     #[doc = "The name of the tag."]
     pub tag_name: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub tarball_url: ::std::option::Option<::std::string::String>,
     #[doc = "Specifies the commitish value that determines where the Git tag is created from."]
     pub target_commitish: ::std::string::String,
     pub upload_url: ::std::string::String,
     pub url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub zipball_url: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`ReleaseReleased`"]
@@ -31290,9 +31526,9 @@ pub struct ReleasePublishedRelease {
 #[serde(deny_unknown_fields)]
 pub struct ReleaseReleased {
     pub action: ReleaseReleasedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub release: Release,
     pub repository: Repository,
@@ -31350,9 +31586,9 @@ impl ::std::convert::TryFrom<::std::string::String> for ReleaseReleasedAction {
 #[serde(deny_unknown_fields)]
 pub struct ReleaseUnpublished {
     pub action: ReleaseUnpublishedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub release: ReleaseUnpublishedRelease,
     pub repository: Repository,
@@ -31413,6 +31649,7 @@ pub struct ReleaseUnpublishedRelease {
     pub assets_url: ::std::string::String,
     pub author: User,
     pub body: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub created_at: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
     #[doc = "Wether the release is a draft or published"]
     pub draft: bool,
@@ -31425,11 +31662,13 @@ pub struct ReleaseUnpublishedRelease {
     pub published_at: (),
     #[doc = "The name of the tag."]
     pub tag_name: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub tarball_url: ::std::option::Option<::std::string::String>,
     #[doc = "Specifies the commitish value that determines where the Git tag is created from."]
     pub target_commitish: ::std::string::String,
     pub upload_url: ::std::string::String,
     pub url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub zipball_url: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`RepoRef`"]
@@ -31448,7 +31687,7 @@ pub struct Repository {
     #[serde(default)]
     pub allow_auto_merge: bool,
     #[doc = "Whether to allow private forks"]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub allow_forking: ::std::option::Option<bool>,
     #[doc = "Whether to allow merge commits for pull requests."]
     #[serde(default = "defaults::default_bool::<true>")]
@@ -31479,9 +31718,10 @@ pub struct Repository {
     #[serde(default)]
     pub delete_branch_on_merge: bool,
     pub deployments_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub description: ::std::option::Option<::std::string::String>,
     #[doc = "Returns whether or not this repository is disabled."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub disabled: ::std::option::Option<bool>,
     pub downloads_url: ::std::string::String,
     pub events_url: ::std::string::String,
@@ -31503,6 +31743,7 @@ pub struct Repository {
     pub has_projects: bool,
     #[doc = "Whether the wiki is enabled."]
     pub has_wiki: bool,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub homepage: ::std::option::Option<::std::string::String>,
     pub hooks_url: ::std::string::String,
     pub html_url: ::std::string::String,
@@ -31513,13 +31754,16 @@ pub struct Repository {
     pub issues_url: ::std::string::String,
     pub keys_url: ::std::string::String,
     pub labels_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub language: ::std::option::Option<::std::string::String>,
     pub languages_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub license: ::std::option::Option<License>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub master_branch: ::std::option::Option<::std::string::String>,
     pub merges_url: ::std::string::String,
     pub milestones_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub mirror_url: ::std::option::Option<::std::string::String>,
     #[doc = "The name of the repository."]
     pub name: ::std::string::String,
@@ -31527,21 +31771,21 @@ pub struct Repository {
     pub notifications_url: ::std::string::String,
     pub open_issues: i64,
     pub open_issues_count: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<::std::string::String>,
     pub owner: User,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub permissions: ::std::option::Option<RepositoryPermissions>,
     #[doc = "Whether the repository is private or public."]
     pub private: bool,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub public: ::std::option::Option<bool>,
     pub pulls_url: ::std::string::String,
     pub pushed_at: RepositoryPushedAt,
     pub releases_url: ::std::string::String,
     pub size: i64,
     pub ssh_url: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub stargazers: ::std::option::Option<i64>,
     pub stargazers_count: i64,
     pub stargazers_url: ::std::string::String,
@@ -31562,9 +31806,9 @@ pub struct Repository {
 #[serde(deny_unknown_fields)]
 pub struct RepositoryArchived {
     pub action: RepositoryArchivedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: RepositoryArchivedRepository,
     pub sender: User,
@@ -31624,7 +31868,7 @@ pub struct RepositoryArchivedRepository {
     #[serde(default)]
     pub allow_auto_merge: bool,
     #[doc = "Whether to allow private forks"]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub allow_forking: ::std::option::Option<bool>,
     #[doc = "Whether to allow merge commits for pull requests."]
     #[serde(default = "defaults::default_bool::<true>")]
@@ -31654,9 +31898,10 @@ pub struct RepositoryArchivedRepository {
     #[serde(default)]
     pub delete_branch_on_merge: bool,
     pub deployments_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub description: ::std::option::Option<::std::string::String>,
     #[doc = "Returns whether or not this repository is disabled."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub disabled: ::std::option::Option<bool>,
     pub downloads_url: ::std::string::String,
     pub events_url: ::std::string::String,
@@ -31678,6 +31923,7 @@ pub struct RepositoryArchivedRepository {
     pub has_projects: bool,
     #[doc = "Whether the wiki is enabled."]
     pub has_wiki: bool,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub homepage: ::std::option::Option<::std::string::String>,
     pub hooks_url: ::std::string::String,
     pub html_url: ::std::string::String,
@@ -31688,13 +31934,16 @@ pub struct RepositoryArchivedRepository {
     pub issues_url: ::std::string::String,
     pub keys_url: ::std::string::String,
     pub labels_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub language: ::std::option::Option<::std::string::String>,
     pub languages_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub license: ::std::option::Option<License>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub master_branch: ::std::option::Option<::std::string::String>,
     pub merges_url: ::std::string::String,
     pub milestones_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub mirror_url: ::std::option::Option<::std::string::String>,
     #[doc = "The name of the repository."]
     pub name: ::std::string::String,
@@ -31702,21 +31951,21 @@ pub struct RepositoryArchivedRepository {
     pub notifications_url: ::std::string::String,
     pub open_issues: i64,
     pub open_issues_count: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<::std::string::String>,
     pub owner: User,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub permissions: ::std::option::Option<RepositoryArchivedRepositoryPermissions>,
     #[doc = "Whether the repository is private or public."]
     pub private: bool,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub public: ::std::option::Option<bool>,
     pub pulls_url: ::std::string::String,
     pub pushed_at: RepositoryArchivedRepositoryPushedAt,
     pub releases_url: ::std::string::String,
     pub size: i64,
     pub ssh_url: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub stargazers: ::std::option::Option<i64>,
     pub stargazers_count: i64,
     pub stargazers_url: ::std::string::String,
@@ -31738,6 +31987,14 @@ pub struct RepositoryArchivedRepository {
 pub enum RepositoryArchivedRepositoryCreatedAt {
     Integer(i64),
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
+}
+impl ::std::fmt::Display for RepositoryArchivedRepositoryCreatedAt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Integer(x) => x.fmt(f),
+            Self::DateTime(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for RepositoryArchivedRepositoryCreatedAt {
     type Err = self::error::ConversionError;
@@ -31765,14 +32022,6 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryArchivedReposi
         value.parse()
     }
 }
-impl ::std::fmt::Display for RepositoryArchivedRepositoryCreatedAt {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Integer(x) => x.fmt(f),
-            Self::DateTime(x) => x.fmt(f),
-        }
-    }
-}
 impl ::std::convert::From<i64> for RepositoryArchivedRepositoryCreatedAt {
     fn from(value: i64) -> Self {
         Self::Integer(value)
@@ -31790,11 +32039,11 @@ impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
 #[serde(deny_unknown_fields)]
 pub struct RepositoryArchivedRepositoryPermissions {
     pub admin: bool,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub maintain: ::std::option::Option<bool>,
     pub pull: bool,
     pub push: bool,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub triage: ::std::option::Option<bool>,
 }
 #[doc = "`RepositoryArchivedRepositoryPushedAt`"]
@@ -31822,9 +32071,9 @@ impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
 #[serde(deny_unknown_fields)]
 pub struct RepositoryCreated {
     pub action: RepositoryCreatedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -31883,6 +32132,14 @@ pub enum RepositoryCreatedAt {
     Integer(i64),
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
 }
+impl ::std::fmt::Display for RepositoryCreatedAt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Integer(x) => x.fmt(f),
+            Self::DateTime(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for RepositoryCreatedAt {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -31909,14 +32166,6 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryCreatedAt {
         value.parse()
     }
 }
-impl ::std::fmt::Display for RepositoryCreatedAt {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Integer(x) => x.fmt(f),
-            Self::DateTime(x) => x.fmt(f),
-        }
-    }
-}
 impl ::std::convert::From<i64> for RepositoryCreatedAt {
     fn from(value: i64) -> Self {
         Self::Integer(value)
@@ -31932,9 +32181,9 @@ impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>> for Reposit
 #[serde(deny_unknown_fields)]
 pub struct RepositoryDeleted {
     pub action: RepositoryDeletedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -32014,7 +32263,7 @@ pub struct RepositoryDispatchOnDemandTest {
     pub branch: ::std::string::String,
     pub client_payload: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
     pub installation: InstallationLite,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -32072,9 +32321,9 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryDispatchOnDema
 pub struct RepositoryEdited {
     pub action: RepositoryEditedAction,
     pub changes: RepositoryEditedChanges,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -32130,11 +32379,11 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryEditedAction {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryEditedChanges {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub default_branch: ::std::option::Option<RepositoryEditedChangesDefaultBranch>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub description: ::std::option::Option<RepositoryEditedChangesDescription>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub homepage: ::std::option::Option<RepositoryEditedChangesHomepage>,
 }
 #[doc = "`RepositoryEditedChangesDefaultBranch`"]
@@ -32147,12 +32396,14 @@ pub struct RepositoryEditedChangesDefaultBranch {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryEditedChangesDescription {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub from: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`RepositoryEditedChangesHomepage`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryEditedChangesHomepage {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub from: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`RepositoryEvent`"]
@@ -32218,9 +32469,9 @@ impl ::std::convert::From<RepositoryUnarchived> for RepositoryEvent {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryImportEvent {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -32296,6 +32547,7 @@ pub struct RepositoryLite {
     pub contents_url: ::std::string::String,
     pub contributors_url: ::std::string::String,
     pub deployments_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub description: ::std::option::Option<::std::string::String>,
     pub downloads_url: ::std::string::String,
     pub events_url: ::std::string::String,
@@ -32340,11 +32592,11 @@ pub struct RepositoryLite {
 #[serde(deny_unknown_fields)]
 pub struct RepositoryPermissions {
     pub admin: bool,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub maintain: ::std::option::Option<bool>,
     pub pull: bool,
     pub push: bool,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub triage: ::std::option::Option<bool>,
 }
 #[doc = "`RepositoryPrivatized`"]
@@ -32352,9 +32604,9 @@ pub struct RepositoryPermissions {
 #[serde(deny_unknown_fields)]
 pub struct RepositoryPrivatized {
     pub action: RepositoryPrivatizedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: RepositoryPrivatizedRepository,
     pub sender: User,
@@ -32414,7 +32666,7 @@ pub struct RepositoryPrivatizedRepository {
     #[serde(default)]
     pub allow_auto_merge: bool,
     #[doc = "Whether to allow private forks"]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub allow_forking: ::std::option::Option<bool>,
     #[doc = "Whether to allow merge commits for pull requests."]
     #[serde(default = "defaults::default_bool::<true>")]
@@ -32445,9 +32697,10 @@ pub struct RepositoryPrivatizedRepository {
     #[serde(default)]
     pub delete_branch_on_merge: bool,
     pub deployments_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub description: ::std::option::Option<::std::string::String>,
     #[doc = "Returns whether or not this repository is disabled."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub disabled: ::std::option::Option<bool>,
     pub downloads_url: ::std::string::String,
     pub events_url: ::std::string::String,
@@ -32469,6 +32722,7 @@ pub struct RepositoryPrivatizedRepository {
     pub has_projects: bool,
     #[doc = "Whether the wiki is enabled."]
     pub has_wiki: bool,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub homepage: ::std::option::Option<::std::string::String>,
     pub hooks_url: ::std::string::String,
     pub html_url: ::std::string::String,
@@ -32479,13 +32733,16 @@ pub struct RepositoryPrivatizedRepository {
     pub issues_url: ::std::string::String,
     pub keys_url: ::std::string::String,
     pub labels_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub language: ::std::option::Option<::std::string::String>,
     pub languages_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub license: ::std::option::Option<License>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub master_branch: ::std::option::Option<::std::string::String>,
     pub merges_url: ::std::string::String,
     pub milestones_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub mirror_url: ::std::option::Option<::std::string::String>,
     #[doc = "The name of the repository."]
     pub name: ::std::string::String,
@@ -32493,20 +32750,20 @@ pub struct RepositoryPrivatizedRepository {
     pub notifications_url: ::std::string::String,
     pub open_issues: i64,
     pub open_issues_count: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<::std::string::String>,
     pub owner: User,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub permissions: ::std::option::Option<RepositoryPrivatizedRepositoryPermissions>,
     pub private: bool,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub public: ::std::option::Option<bool>,
     pub pulls_url: ::std::string::String,
     pub pushed_at: RepositoryPrivatizedRepositoryPushedAt,
     pub releases_url: ::std::string::String,
     pub size: i64,
     pub ssh_url: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub stargazers: ::std::option::Option<i64>,
     pub stargazers_count: i64,
     pub stargazers_url: ::std::string::String,
@@ -32528,6 +32785,14 @@ pub struct RepositoryPrivatizedRepository {
 pub enum RepositoryPrivatizedRepositoryCreatedAt {
     Integer(i64),
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
+}
+impl ::std::fmt::Display for RepositoryPrivatizedRepositoryCreatedAt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Integer(x) => x.fmt(f),
+            Self::DateTime(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for RepositoryPrivatizedRepositoryCreatedAt {
     type Err = self::error::ConversionError;
@@ -32555,14 +32820,6 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryPrivatizedRepo
         value.parse()
     }
 }
-impl ::std::fmt::Display for RepositoryPrivatizedRepositoryCreatedAt {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Integer(x) => x.fmt(f),
-            Self::DateTime(x) => x.fmt(f),
-        }
-    }
-}
 impl ::std::convert::From<i64> for RepositoryPrivatizedRepositoryCreatedAt {
     fn from(value: i64) -> Self {
         Self::Integer(value)
@@ -32580,11 +32837,11 @@ impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
 #[serde(deny_unknown_fields)]
 pub struct RepositoryPrivatizedRepositoryPermissions {
     pub admin: bool,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub maintain: ::std::option::Option<bool>,
     pub pull: bool,
     pub push: bool,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub triage: ::std::option::Option<bool>,
 }
 #[doc = "`RepositoryPrivatizedRepositoryPushedAt`"]
@@ -32612,9 +32869,9 @@ impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
 #[serde(deny_unknown_fields)]
 pub struct RepositoryPublicized {
     pub action: RepositoryPublicizedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: RepositoryPublicizedRepository,
     pub sender: User,
@@ -32674,7 +32931,7 @@ pub struct RepositoryPublicizedRepository {
     #[serde(default)]
     pub allow_auto_merge: bool,
     #[doc = "Whether to allow private forks"]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub allow_forking: ::std::option::Option<bool>,
     #[doc = "Whether to allow merge commits for pull requests."]
     #[serde(default = "defaults::default_bool::<true>")]
@@ -32705,9 +32962,10 @@ pub struct RepositoryPublicizedRepository {
     #[serde(default)]
     pub delete_branch_on_merge: bool,
     pub deployments_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub description: ::std::option::Option<::std::string::String>,
     #[doc = "Returns whether or not this repository is disabled."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub disabled: ::std::option::Option<bool>,
     pub downloads_url: ::std::string::String,
     pub events_url: ::std::string::String,
@@ -32729,6 +32987,7 @@ pub struct RepositoryPublicizedRepository {
     pub has_projects: bool,
     #[doc = "Whether the wiki is enabled."]
     pub has_wiki: bool,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub homepage: ::std::option::Option<::std::string::String>,
     pub hooks_url: ::std::string::String,
     pub html_url: ::std::string::String,
@@ -32739,13 +32998,16 @@ pub struct RepositoryPublicizedRepository {
     pub issues_url: ::std::string::String,
     pub keys_url: ::std::string::String,
     pub labels_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub language: ::std::option::Option<::std::string::String>,
     pub languages_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub license: ::std::option::Option<License>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub master_branch: ::std::option::Option<::std::string::String>,
     pub merges_url: ::std::string::String,
     pub milestones_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub mirror_url: ::std::option::Option<::std::string::String>,
     #[doc = "The name of the repository."]
     pub name: ::std::string::String,
@@ -32753,20 +33015,20 @@ pub struct RepositoryPublicizedRepository {
     pub notifications_url: ::std::string::String,
     pub open_issues: i64,
     pub open_issues_count: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<::std::string::String>,
     pub owner: User,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub permissions: ::std::option::Option<RepositoryPublicizedRepositoryPermissions>,
     pub private: bool,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub public: ::std::option::Option<bool>,
     pub pulls_url: ::std::string::String,
     pub pushed_at: RepositoryPublicizedRepositoryPushedAt,
     pub releases_url: ::std::string::String,
     pub size: i64,
     pub ssh_url: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub stargazers: ::std::option::Option<i64>,
     pub stargazers_count: i64,
     pub stargazers_url: ::std::string::String,
@@ -32788,6 +33050,14 @@ pub struct RepositoryPublicizedRepository {
 pub enum RepositoryPublicizedRepositoryCreatedAt {
     Integer(i64),
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
+}
+impl ::std::fmt::Display for RepositoryPublicizedRepositoryCreatedAt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Integer(x) => x.fmt(f),
+            Self::DateTime(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for RepositoryPublicizedRepositoryCreatedAt {
     type Err = self::error::ConversionError;
@@ -32815,14 +33085,6 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryPublicizedRepo
         value.parse()
     }
 }
-impl ::std::fmt::Display for RepositoryPublicizedRepositoryCreatedAt {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Integer(x) => x.fmt(f),
-            Self::DateTime(x) => x.fmt(f),
-        }
-    }
-}
 impl ::std::convert::From<i64> for RepositoryPublicizedRepositoryCreatedAt {
     fn from(value: i64) -> Self {
         Self::Integer(value)
@@ -32840,11 +33102,11 @@ impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
 #[serde(deny_unknown_fields)]
 pub struct RepositoryPublicizedRepositoryPermissions {
     pub admin: bool,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub maintain: ::std::option::Option<bool>,
     pub pull: bool,
     pub push: bool,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub triage: ::std::option::Option<bool>,
 }
 #[doc = "`RepositoryPublicizedRepositoryPushedAt`"]
@@ -32891,9 +33153,9 @@ impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>> for Reposit
 pub struct RepositoryRenamed {
     pub action: RepositoryRenamedAction,
     pub changes: RepositoryRenamedChanges,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -32969,9 +33231,9 @@ pub struct RepositoryRenamedChangesRepositoryName {
 pub struct RepositoryTransferred {
     pub action: RepositoryTransferredAction,
     pub changes: RepositoryTransferredChanges,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -33039,7 +33301,7 @@ pub struct RepositoryTransferredChangesOwner {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryTransferredChangesOwnerFrom {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub user: ::std::option::Option<User>,
 }
 #[doc = "`RepositoryUnarchived`"]
@@ -33047,9 +33309,9 @@ pub struct RepositoryTransferredChangesOwnerFrom {
 #[serde(deny_unknown_fields)]
 pub struct RepositoryUnarchived {
     pub action: RepositoryUnarchivedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: RepositoryUnarchivedRepository,
     pub sender: User,
@@ -33109,7 +33371,7 @@ pub struct RepositoryUnarchivedRepository {
     #[serde(default)]
     pub allow_auto_merge: bool,
     #[doc = "Whether to allow private forks"]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub allow_forking: ::std::option::Option<bool>,
     #[doc = "Whether to allow merge commits for pull requests."]
     #[serde(default = "defaults::default_bool::<true>")]
@@ -33139,9 +33401,10 @@ pub struct RepositoryUnarchivedRepository {
     #[serde(default)]
     pub delete_branch_on_merge: bool,
     pub deployments_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub description: ::std::option::Option<::std::string::String>,
     #[doc = "Returns whether or not this repository is disabled."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub disabled: ::std::option::Option<bool>,
     pub downloads_url: ::std::string::String,
     pub events_url: ::std::string::String,
@@ -33163,6 +33426,7 @@ pub struct RepositoryUnarchivedRepository {
     pub has_projects: bool,
     #[doc = "Whether the wiki is enabled."]
     pub has_wiki: bool,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub homepage: ::std::option::Option<::std::string::String>,
     pub hooks_url: ::std::string::String,
     pub html_url: ::std::string::String,
@@ -33173,13 +33437,16 @@ pub struct RepositoryUnarchivedRepository {
     pub issues_url: ::std::string::String,
     pub keys_url: ::std::string::String,
     pub labels_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub language: ::std::option::Option<::std::string::String>,
     pub languages_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub license: ::std::option::Option<License>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub master_branch: ::std::option::Option<::std::string::String>,
     pub merges_url: ::std::string::String,
     pub milestones_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub mirror_url: ::std::option::Option<::std::string::String>,
     #[doc = "The name of the repository."]
     pub name: ::std::string::String,
@@ -33187,21 +33454,21 @@ pub struct RepositoryUnarchivedRepository {
     pub notifications_url: ::std::string::String,
     pub open_issues: i64,
     pub open_issues_count: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<::std::string::String>,
     pub owner: User,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub permissions: ::std::option::Option<RepositoryUnarchivedRepositoryPermissions>,
     #[doc = "Whether the repository is private or public."]
     pub private: bool,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub public: ::std::option::Option<bool>,
     pub pulls_url: ::std::string::String,
     pub pushed_at: RepositoryUnarchivedRepositoryPushedAt,
     pub releases_url: ::std::string::String,
     pub size: i64,
     pub ssh_url: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub stargazers: ::std::option::Option<i64>,
     pub stargazers_count: i64,
     pub stargazers_url: ::std::string::String,
@@ -33223,6 +33490,14 @@ pub struct RepositoryUnarchivedRepository {
 pub enum RepositoryUnarchivedRepositoryCreatedAt {
     Integer(i64),
     DateTime(::chrono::DateTime<::chrono::offset::Utc>),
+}
+impl ::std::fmt::Display for RepositoryUnarchivedRepositoryCreatedAt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Integer(x) => x.fmt(f),
+            Self::DateTime(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for RepositoryUnarchivedRepositoryCreatedAt {
     type Err = self::error::ConversionError;
@@ -33250,14 +33525,6 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryUnarchivedRepo
         value.parse()
     }
 }
-impl ::std::fmt::Display for RepositoryUnarchivedRepositoryCreatedAt {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Integer(x) => x.fmt(f),
-            Self::DateTime(x) => x.fmt(f),
-        }
-    }
-}
 impl ::std::convert::From<i64> for RepositoryUnarchivedRepositoryCreatedAt {
     fn from(value: i64) -> Self {
         Self::Integer(value)
@@ -33275,11 +33542,11 @@ impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
 #[serde(deny_unknown_fields)]
 pub struct RepositoryUnarchivedRepositoryPermissions {
     pub admin: bool,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub maintain: ::std::option::Option<bool>,
     pub pull: bool,
     pub push: bool,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub triage: ::std::option::Option<bool>,
 }
 #[doc = "`RepositoryUnarchivedRepositoryPushedAt`"]
@@ -33308,7 +33575,7 @@ impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>>
 pub struct RepositoryVulnerabilityAlertCreate {
     pub action: RepositoryVulnerabilityAlertCreateAction,
     pub alert: RepositoryVulnerabilityAlertCreateAlert,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -33366,21 +33633,21 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryVulnerabilityA
 pub struct RepositoryVulnerabilityAlertCreateAlert {
     pub affected_package_name: ::std::string::String,
     pub affected_range: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub created_at: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub dismiss_reason: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub dismissed_at: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub dismisser: ::std::option::Option<User>,
     pub external_identifier: ::std::string::String,
     pub external_reference: ::std::string::String,
     pub fixed_in: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub ghsa_id: ::std::option::Option<::std::string::String>,
     pub id: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub severity: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`RepositoryVulnerabilityAlertDismiss`"]
@@ -33389,7 +33656,7 @@ pub struct RepositoryVulnerabilityAlertCreateAlert {
 pub struct RepositoryVulnerabilityAlertDismiss {
     pub action: RepositoryVulnerabilityAlertDismissAction,
     pub alert: RepositoryVulnerabilityAlertDismissAlert,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -33447,7 +33714,7 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryVulnerabilityA
 pub struct RepositoryVulnerabilityAlertDismissAlert {
     pub affected_package_name: ::std::string::String,
     pub affected_range: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub created_at: ::std::option::Option<::std::string::String>,
     pub dismiss_reason: ::std::string::String,
     pub dismissed_at: ::std::string::String,
@@ -33455,10 +33722,10 @@ pub struct RepositoryVulnerabilityAlertDismissAlert {
     pub external_identifier: ::std::string::String,
     pub external_reference: ::std::string::String,
     pub fixed_in: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub ghsa_id: ::std::option::Option<::std::string::String>,
     pub id: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub severity: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`RepositoryVulnerabilityAlertEvent`"]
@@ -33496,7 +33763,7 @@ impl ::std::convert::From<RepositoryVulnerabilityAlertResolve>
 pub struct RepositoryVulnerabilityAlertResolve {
     pub action: RepositoryVulnerabilityAlertResolveAction,
     pub alert: RepositoryVulnerabilityAlertResolveAlert,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -33554,21 +33821,21 @@ impl ::std::convert::TryFrom<::std::string::String> for RepositoryVulnerabilityA
 pub struct RepositoryVulnerabilityAlertResolveAlert {
     pub affected_package_name: ::std::string::String,
     pub affected_range: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub created_at: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub dismiss_reason: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub dismissed_at: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub dismisser: ::std::option::Option<User>,
     pub external_identifier: ::std::string::String,
     pub external_reference: ::std::string::String,
     pub fixed_in: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub ghsa_id: ::std::option::Option<::std::string::String>,
     pub id: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub severity: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`SecretScanningAlertCreated`"]
@@ -33577,9 +33844,9 @@ pub struct RepositoryVulnerabilityAlertResolveAlert {
 pub struct SecretScanningAlertCreated {
     pub action: SecretScanningAlertCreatedAction,
     pub alert: SecretScanningAlertCreatedAlert,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
 }
@@ -33669,9 +33936,9 @@ impl ::std::convert::From<SecretScanningAlertResolved> for SecretScanningAlertEv
 pub struct SecretScanningAlertReopened {
     pub action: SecretScanningAlertReopenedAction,
     pub alert: SecretScanningAlertReopenedAlert,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -33739,9 +34006,9 @@ pub struct SecretScanningAlertReopenedAlert {
 pub struct SecretScanningAlertResolved {
     pub action: SecretScanningAlertResolvedAction,
     pub alert: SecretScanningAlertResolvedAlert,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -33961,6 +34228,7 @@ pub struct SecurityAdvisoryPerformedSecurityAdvisory {
     pub updated_at: ::std::string::String,
     pub vulnerabilities:
         ::std::vec::Vec<SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItem>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub withdrawn_at: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`SecurityAdvisoryPerformedSecurityAdvisoryCvss`"]
@@ -33968,6 +34236,7 @@ pub struct SecurityAdvisoryPerformedSecurityAdvisory {
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPerformedSecurityAdvisoryCvss {
     pub score: f64,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub vector_string: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`SecurityAdvisoryPerformedSecurityAdvisoryCwesItem`"]
@@ -33995,6 +34264,7 @@ pub struct SecurityAdvisoryPerformedSecurityAdvisoryReferencesItem {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItem {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub first_patched_version: ::std::option::Option<
         SecurityAdvisoryPerformedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion,
     >,
@@ -34085,6 +34355,7 @@ pub struct SecurityAdvisoryPublishedSecurityAdvisory {
     pub updated_at: ::std::string::String,
     pub vulnerabilities:
         ::std::vec::Vec<SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItem>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub withdrawn_at: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`SecurityAdvisoryPublishedSecurityAdvisoryCvss`"]
@@ -34092,6 +34363,7 @@ pub struct SecurityAdvisoryPublishedSecurityAdvisory {
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPublishedSecurityAdvisoryCvss {
     pub score: f64,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub vector_string: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`SecurityAdvisoryPublishedSecurityAdvisoryCwesItem`"]
@@ -34119,6 +34391,7 @@ pub struct SecurityAdvisoryPublishedSecurityAdvisoryReferencesItem {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItem {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub first_patched_version: ::std::option::Option<
         SecurityAdvisoryPublishedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion,
     >,
@@ -34209,6 +34482,7 @@ pub struct SecurityAdvisoryUpdatedSecurityAdvisory {
     pub updated_at: ::std::string::String,
     pub vulnerabilities:
         ::std::vec::Vec<SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItem>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub withdrawn_at: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`SecurityAdvisoryUpdatedSecurityAdvisoryCvss`"]
@@ -34216,6 +34490,7 @@ pub struct SecurityAdvisoryUpdatedSecurityAdvisory {
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryUpdatedSecurityAdvisoryCvss {
     pub score: f64,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub vector_string: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`SecurityAdvisoryUpdatedSecurityAdvisoryCwesItem`"]
@@ -34243,6 +34518,7 @@ pub struct SecurityAdvisoryUpdatedSecurityAdvisoryReferencesItem {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItem {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub first_patched_version: ::std::option::Option<
         SecurityAdvisoryUpdatedSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion,
     >,
@@ -34340,6 +34616,7 @@ pub struct SecurityAdvisoryWithdrawnSecurityAdvisory {
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryCvss {
     pub score: f64,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub vector_string: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`SecurityAdvisoryWithdrawnSecurityAdvisoryCwesItem`"]
@@ -34367,6 +34644,7 @@ pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryReferencesItem {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItem {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub first_patched_version: ::std::option::Option<
         SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemFirstPatchedVersion,
     >,
@@ -34391,13 +34669,16 @@ pub struct SecurityAdvisoryWithdrawnSecurityAdvisoryVulnerabilitiesItemPackage {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct SimplePullRequest {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub active_lock_reason: ::std::option::Option<SimplePullRequestActiveLockReason>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub assignee: ::std::option::Option<User>,
     pub assignees: ::std::vec::Vec<User>,
     pub author_association: AuthorAssociation,
     pub auto_merge: (),
     pub base: SimplePullRequestBase,
     pub body: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub closed_at: ::std::option::Option<::std::string::String>,
     pub comments_url: ::std::string::String,
     pub commits_url: ::std::string::String,
@@ -34412,8 +34693,11 @@ pub struct SimplePullRequest {
     #[serde(rename = "_links")]
     pub links: SimplePullRequestLinks,
     pub locked: bool,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub merge_commit_sha: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub merged_at: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub milestone: ::std::option::Option<Milestone>,
     pub node_id: ::std::string::String,
     pub number: i64,
@@ -34784,7 +35068,7 @@ impl ::std::convert::TryFrom<::std::string::String> for SponsorshipEditedAction 
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct SponsorshipEditedChanges {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub privacy_level: ::std::option::Option<SponsorshipEditedChangesPrivacyLevel>,
 }
 #[doc = "`SponsorshipEditedChangesPrivacyLevel`"]
@@ -34852,7 +35136,7 @@ impl ::std::convert::From<SponsorshipTierChanged> for SponsorshipEvent {
 pub struct SponsorshipPendingCancellation {
     pub action: SponsorshipPendingCancellationAction,
     #[doc = "The `pending_cancellation` and `pending_tier_change` event types will include the date the cancellation or tier change will take effect."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub effective_date: ::std::option::Option<::std::string::String>,
     pub sender: User,
     pub sponsorship: SponsorshipPendingCancellationSponsorship,
@@ -34922,7 +35206,7 @@ pub struct SponsorshipPendingTierChange {
     pub action: SponsorshipPendingTierChangeAction,
     pub changes: SponsorshipPendingTierChangeChanges,
     #[doc = "The `pending_cancellation` and `pending_tier_change` event types will include the date the cancellation or tier change will take effect."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub effective_date: ::std::option::Option<::std::string::String>,
     pub sender: User,
     pub sponsorship: SponsorshipPendingTierChangeSponsorship,
@@ -35094,9 +35378,9 @@ pub struct SponsorshipTierChangedSponsorship {
 #[serde(deny_unknown_fields)]
 pub struct StarCreated {
     pub action: StarCreatedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -35155,9 +35439,9 @@ impl ::std::convert::TryFrom<::std::string::String> for StarCreatedAction {
 #[serde(deny_unknown_fields)]
 pub struct StarDeleted {
     pub action: StarDeletedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -35232,7 +35516,7 @@ impl ::std::convert::From<StarDeleted> for StarEvent {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct StatusEvent {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub avatar_url: ::std::option::Option<::std::string::String>,
     #[doc = "An array of branch objects containing the status' SHA. Each branch contains the given SHA, but the SHA may or may not be the head of the branch. The array includes a maximum of 10 branches."]
     pub branches: ::std::vec::Vec<StatusEventBranchesItem>,
@@ -35240,13 +35524,14 @@ pub struct StatusEvent {
     pub context: ::std::string::String,
     pub created_at: ::std::string::String,
     #[doc = "The optional human-readable description added to the status."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub description: ::std::option::Option<::std::string::String>,
     #[doc = "The unique identifier of the status."]
     pub id: i64,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub name: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -35255,6 +35540,7 @@ pub struct StatusEvent {
     #[doc = "The new state. Can be `pending`, `success`, `failure`, or `error`."]
     pub state: StatusEventState,
     #[doc = "The optional link added to the status."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub target_url: ::std::option::Option<::std::string::String>,
     pub updated_at: ::std::string::String,
 }
@@ -35277,9 +35563,11 @@ pub struct StatusEventBranchesItemCommit {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct StatusEventCommit {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub author: ::std::option::Option<User>,
     pub comments_url: ::std::string::String,
     pub commit: StatusEventCommitCommit,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub committer: ::std::option::Option<User>,
     pub html_url: ::std::string::String,
     pub node_id: ::std::string::String,
@@ -35305,10 +35593,11 @@ pub struct StatusEventCommitCommit {
 pub struct StatusEventCommitCommitAuthor {
     pub date: ::chrono::DateTime<::chrono::offset::Utc>,
     #[doc = "The git author's email address."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub email: ::std::option::Option<::std::string::String>,
     #[doc = "The git author's name."]
     pub name: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub username: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`StatusEventCommitCommitCommitter`"]
@@ -35317,10 +35606,11 @@ pub struct StatusEventCommitCommitAuthor {
 pub struct StatusEventCommitCommitCommitter {
     pub date: ::chrono::DateTime<::chrono::offset::Utc>,
     #[doc = "The git author's email address."]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub email: ::std::option::Option<::std::string::String>,
     #[doc = "The git author's name."]
     pub name: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub username: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`StatusEventCommitCommitTree`"]
@@ -35334,8 +35624,10 @@ pub struct StatusEventCommitCommitTree {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct StatusEventCommitCommitVerification {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub payload: ::std::option::Option<::std::string::String>,
     pub reason: StatusEventCommitCommitVerificationReason,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub signature: ::std::option::Option<::std::string::String>,
     pub verified: bool,
 }
@@ -35506,6 +35798,7 @@ impl ::std::convert::TryFrom<::std::string::String> for StatusEventState {
 #[serde(deny_unknown_fields)]
 pub struct Team {
     #[doc = "Description of the team"]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub description: ::std::option::Option<::std::string::String>,
     pub html_url: ::std::string::String,
     #[doc = "Unique identifier of the team"]
@@ -35514,7 +35807,7 @@ pub struct Team {
     #[doc = "Name of the team"]
     pub name: ::std::string::String,
     pub node_id: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub parent: ::std::option::Option<TeamParent>,
     #[doc = "Permission that the team will have for its repositories"]
     pub permission: ::std::string::String,
@@ -35528,7 +35821,7 @@ pub struct Team {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct TeamAddEvent {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub organization: Organization,
     pub repository: Repository,
@@ -35540,10 +35833,10 @@ pub struct TeamAddEvent {
 #[serde(deny_unknown_fields)]
 pub struct TeamAddedToRepository {
     pub action: TeamAddedToRepositoryAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub organization: Organization,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub repository: ::std::option::Option<Repository>,
     pub sender: User,
     pub team: Team,
@@ -35600,10 +35893,10 @@ impl ::std::convert::TryFrom<::std::string::String> for TeamAddedToRepositoryAct
 #[serde(deny_unknown_fields)]
 pub struct TeamCreated {
     pub action: TeamCreatedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub organization: Organization,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub repository: ::std::option::Option<Repository>,
     pub sender: User,
     pub team: Team,
@@ -35660,10 +35953,10 @@ impl ::std::convert::TryFrom<::std::string::String> for TeamCreatedAction {
 #[serde(deny_unknown_fields)]
 pub struct TeamDeleted {
     pub action: TeamDeletedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub organization: Organization,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub repository: ::std::option::Option<Repository>,
     pub sender: User,
     pub team: Team,
@@ -35721,10 +36014,10 @@ impl ::std::convert::TryFrom<::std::string::String> for TeamDeletedAction {
 pub struct TeamEdited {
     pub action: TeamEditedAction,
     pub changes: TeamEditedChanges,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub organization: Organization,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub repository: ::std::option::Option<Repository>,
     pub sender: User,
     pub team: Team,
@@ -35780,13 +36073,13 @@ impl ::std::convert::TryFrom<::std::string::String> for TeamEditedAction {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct TeamEditedChanges {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub description: ::std::option::Option<TeamEditedChangesDescription>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<TeamEditedChangesName>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub privacy: ::std::option::Option<TeamEditedChangesPrivacy>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub repository: ::std::option::Option<TeamEditedChangesRepository>,
 }
 #[doc = "`TeamEditedChangesDescription`"]
@@ -35827,13 +36120,13 @@ pub struct TeamEditedChangesRepositoryPermissions {
 #[serde(deny_unknown_fields)]
 pub struct TeamEditedChangesRepositoryPermissionsFrom {
     #[doc = "The previous version of the team member's `admin` permission on a repository, if the action was `edited`."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub admin: ::std::option::Option<bool>,
     #[doc = "The previous version of the team member's `pull` permission on a repository, if the action was `edited`."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub pull: ::std::option::Option<bool>,
     #[doc = "The previous version of the team member's `push` permission on a repository, if the action was `edited`."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub push: ::std::option::Option<bool>,
 }
 #[doc = "`TeamEvent`"]
@@ -35876,6 +36169,7 @@ impl ::std::convert::From<TeamRemovedFromRepository> for TeamEvent {
 #[serde(deny_unknown_fields)]
 pub struct TeamParent {
     #[doc = "Description of the team"]
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub description: ::std::option::Option<::std::string::String>,
     pub html_url: ::std::string::String,
     #[doc = "Unique identifier of the team"]
@@ -36007,10 +36301,10 @@ impl ::std::convert::TryFrom<::std::string::String> for TeamPrivacy {
 #[serde(deny_unknown_fields)]
 pub struct TeamRemovedFromRepository {
     pub action: TeamRemovedFromRepositoryAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
     pub organization: Organization,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub repository: ::std::option::Option<Repository>,
     pub sender: User,
     pub team: Team,
@@ -36067,7 +36361,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TeamRemovedFromRepositor
 #[serde(deny_unknown_fields)]
 pub struct User {
     pub avatar_url: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub email: ::std::option::Option<::std::string::String>,
     pub events_url: ::std::string::String,
     pub followers_url: ::std::string::String,
@@ -36077,7 +36371,7 @@ pub struct User {
     pub html_url: ::std::string::String,
     pub id: i64,
     pub login: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<::std::string::String>,
     pub node_id: ::std::string::String,
     pub organizations_url: ::std::string::String,
@@ -36167,9 +36461,9 @@ impl ::std::convert::From<WatchStarted> for WatchEvent {
 #[serde(deny_unknown_fields)]
 pub struct WatchStarted {
     pub action: WatchStartedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -36488,11 +36782,12 @@ pub struct Workflow {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowDispatchEvent {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub inputs:
         ::std::option::Option<::serde_json::Map<::std::string::String, ::serde_json::Value>>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     #[serde(rename = "ref")]
     pub ref_: ::std::string::String,
@@ -36505,7 +36800,9 @@ pub struct WorkflowDispatchEvent {
 #[serde(deny_unknown_fields)]
 pub struct WorkflowJob {
     pub check_run_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub completed_at: ::std::option::Option<::std::string::String>,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub conclusion: ::std::option::Option<WorkflowJobConclusion>,
     pub head_sha: ::std::string::String,
     pub html_url: ::std::string::String,
@@ -36525,9 +36822,9 @@ pub struct WorkflowJob {
 #[serde(deny_unknown_fields)]
 pub struct WorkflowJobCompleted {
     pub action: WorkflowJobCompletedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -36585,6 +36882,7 @@ impl ::std::convert::TryFrom<::std::string::String> for WorkflowJobCompletedActi
 #[serde(deny_unknown_fields)]
 pub struct WorkflowJobCompletedWorkflowJob {
     pub check_run_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub completed_at: ::std::option::Option<::std::string::String>,
     pub conclusion: WorkflowJobCompletedWorkflowJobConclusion,
     pub head_sha: ::std::string::String,
@@ -36785,9 +37083,9 @@ impl ::std::convert::From<WorkflowJobStarted> for WorkflowJobEvent {
 #[serde(deny_unknown_fields)]
 pub struct WorkflowJobQueued {
     pub action: WorkflowJobQueuedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -36912,9 +37210,9 @@ impl ::std::convert::TryFrom<::std::string::String> for WorkflowJobQueuedWorkflo
 #[serde(deny_unknown_fields)]
 pub struct WorkflowJobStarted {
     pub action: WorkflowJobStartedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -37140,6 +37438,7 @@ pub struct WorkflowRun {
     pub check_suite_id: i64,
     pub check_suite_node_id: ::std::string::String,
     pub check_suite_url: ::std::string::String,
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub conclusion: ::std::option::Option<WorkflowRunConclusion>,
     pub created_at: ::chrono::DateTime<::chrono::offset::Utc>,
     pub event: ::std::string::String,
@@ -37168,9 +37467,9 @@ pub struct WorkflowRun {
 #[serde(deny_unknown_fields)]
 pub struct WorkflowRunCompleted {
     pub action: WorkflowRunCompletedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -37535,9 +37834,9 @@ pub struct WorkflowRunPullRequestsItemHead {
 #[serde(deny_unknown_fields)]
 pub struct WorkflowRunRequested {
     pub action: WorkflowRunRequestedAction,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub installation: ::std::option::Option<InstallationLite>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub organization: ::std::option::Option<Organization>,
     pub repository: Repository,
     pub sender: User,
@@ -37838,9 +38137,35 @@ impl ::std::convert::TryFrom<::std::string::String> for WorkflowStepInProgressSt
         value.parse()
     }
 }
-#[doc = r" Generation of default values for serde."]
+#[doc = " Generation of default values for serde."]
 pub mod defaults {
     pub(super) fn default_bool<const V: bool>() -> bool {
         V
+    }
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
     }
 }

--- a/typify-impl/tests/vega.out
+++ b/typify-impl/tests/vega.out
@@ -1,52 +1,22 @@
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`AggregateTransform`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct AggregateTransform {
-    #[serde(
-        rename = "as",
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
+    #[serde(rename = "as", skip_serializing_if = "::std::option::Option::is_none")]
     pub as_: ::std::option::Option<AggregateTransformAs>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub cross: ::std::option::Option<AggregateTransformCross>,
     #[serde(default = "defaults::aggregate_transform_drop")]
     pub drop: AggregateTransformDrop,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub fields: ::std::option::Option<AggregateTransformFields>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub groupby: ::std::option::Option<AggregateTransformGroupby>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub key: ::std::option::Option<AggregateTransformKey>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub ops: ::std::option::Option<AggregateTransformOps>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]
     pub type_: AggregateTransformType,
@@ -478,7 +448,7 @@ pub enum AlignValueVariant0Item {
     Variant2(AlignValueVariant0ItemVariant2),
     Variant3 {
         offset: ::serde_json::Value,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -502,31 +472,31 @@ impl ::std::convert::From<AlignValueVariant0ItemVariant2> for AlignValueVariant0
 #[serde(untagged)]
 pub enum AlignValueVariant0ItemVariant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
         value: AlignValueVariant0ItemVariant0Variant1Value,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant3 {
         range: AlignValueVariant0ItemVariant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -594,6 +564,14 @@ pub enum AlignValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
 }
+impl ::std::fmt::Display for AlignValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for AlignValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -620,14 +598,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for AlignValueVariant0ItemVariant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for AlignValueVariant0ItemVariant0Variant3Range {
@@ -699,23 +669,23 @@ impl ::std::convert::From<AlignValueVariant1Variant2> for AlignValueVariant1 {
 #[serde(untagged)]
 pub enum AlignValueVariant1Variant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         value: AlignValueVariant1Variant0Variant1Value,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
     Variant3 {
         range: AlignValueVariant1Variant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
 }
@@ -781,6 +751,14 @@ pub enum AlignValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
 }
+impl ::std::fmt::Display for AlignValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for AlignValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -805,14 +783,6 @@ impl ::std::convert::TryFrom<::std::string::String> for AlignValueVariant1Varian
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for AlignValueVariant1Variant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for AlignValueVariant1Variant0Variant3Range {
@@ -881,7 +851,7 @@ pub enum AnchorValueVariant0Item {
     Variant2(AnchorValueVariant0ItemVariant2),
     Variant3 {
         offset: ::serde_json::Value,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -905,31 +875,31 @@ impl ::std::convert::From<AnchorValueVariant0ItemVariant2> for AnchorValueVarian
 #[serde(untagged)]
 pub enum AnchorValueVariant0ItemVariant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
         value: AnchorValueVariant0ItemVariant0Variant1Value,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant3 {
         range: AnchorValueVariant0ItemVariant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -997,6 +967,14 @@ pub enum AnchorValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
 }
+impl ::std::fmt::Display for AnchorValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for AnchorValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -1023,14 +1001,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for AnchorValueVariant0ItemVariant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for AnchorValueVariant0ItemVariant0Variant3Range {
@@ -1102,23 +1072,23 @@ impl ::std::convert::From<AnchorValueVariant1Variant2> for AnchorValueVariant1 {
 #[serde(untagged)]
 pub enum AnchorValueVariant1Variant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         value: AnchorValueVariant1Variant0Variant1Value,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
     Variant3 {
         range: AnchorValueVariant1Variant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
 }
@@ -1184,6 +1154,14 @@ pub enum AnchorValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
 }
+impl ::std::fmt::Display for AnchorValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for AnchorValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -1208,14 +1186,6 @@ impl ::std::convert::TryFrom<::std::string::String> for AnchorValueVariant1Varia
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for AnchorValueVariant1Variant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for AnchorValueVariant1Variant0Variant3Range {
@@ -1284,7 +1254,7 @@ pub enum AnyValueVariant0Item {
     Variant2(AnyValueVariant0ItemVariant2),
     Variant3 {
         offset: ::serde_json::Value,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -1308,31 +1278,31 @@ impl ::std::convert::From<AnyValueVariant0ItemVariant2> for AnyValueVariant0Item
 #[serde(untagged)]
 pub enum AnyValueVariant0ItemVariant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
         value: ::serde_json::Value,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant3 {
         range: AnyValueVariant0ItemVariant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -1342,6 +1312,14 @@ pub enum AnyValueVariant0ItemVariant0 {
 pub enum AnyValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
+}
+impl ::std::fmt::Display for AnyValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for AnyValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -1367,14 +1345,6 @@ impl ::std::convert::TryFrom<::std::string::String> for AnyValueVariant0ItemVari
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for AnyValueVariant0ItemVariant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for AnyValueVariant0ItemVariant0Variant3Range {
@@ -1446,23 +1416,23 @@ impl ::std::convert::From<AnyValueVariant1Variant2> for AnyValueVariant1 {
 #[serde(untagged)]
 pub enum AnyValueVariant1Variant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         value: ::serde_json::Value,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
     Variant3 {
         range: AnyValueVariant1Variant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
 }
@@ -1472,6 +1442,14 @@ pub enum AnyValueVariant1Variant0 {
 pub enum AnyValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
+}
+impl ::std::fmt::Display for AnyValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for AnyValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -1497,14 +1475,6 @@ impl ::std::convert::TryFrom<::std::string::String> for AnyValueVariant1Variant0
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for AnyValueVariant1Variant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for AnyValueVariant1Variant0Variant3Range {
@@ -1590,7 +1560,7 @@ pub enum ArrayValueVariant0Item {
     Variant2(ArrayValueVariant0ItemVariant2),
     Variant3 {
         offset: ::serde_json::Value,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -1614,31 +1584,31 @@ impl ::std::convert::From<ArrayValueVariant0ItemVariant2> for ArrayValueVariant0
 #[serde(untagged)]
 pub enum ArrayValueVariant0ItemVariant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
         value: ::std::vec::Vec<::serde_json::Value>,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant3 {
         range: ArrayValueVariant0ItemVariant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -1648,6 +1618,14 @@ pub enum ArrayValueVariant0ItemVariant0 {
 pub enum ArrayValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
+}
+impl ::std::fmt::Display for ArrayValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for ArrayValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -1675,14 +1653,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for ArrayValueVariant0ItemVariant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for ArrayValueVariant0ItemVariant0Variant3Range {
@@ -1754,23 +1724,23 @@ impl ::std::convert::From<ArrayValueVariant1Variant2> for ArrayValueVariant1 {
 #[serde(untagged)]
 pub enum ArrayValueVariant1Variant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         value: ::std::vec::Vec<::serde_json::Value>,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
     Variant3 {
         range: ArrayValueVariant1Variant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
 }
@@ -1780,6 +1750,14 @@ pub enum ArrayValueVariant1Variant0 {
 pub enum ArrayValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
+}
+impl ::std::fmt::Display for ArrayValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for ArrayValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -1805,14 +1783,6 @@ impl ::std::convert::TryFrom<::std::string::String> for ArrayValueVariant1Varian
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for ArrayValueVariant1Variant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for ArrayValueVariant1Variant0Variant3Range {
@@ -1861,9 +1831,9 @@ pub enum ArrayValueVariant1Variant2 {}
 pub enum Autosize {
     Variant0(AutosizeVariant0),
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         contains: ::std::option::Option<AutosizeVariant1Contains>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         resize: ::std::option::Option<bool>,
         #[serde(rename = "type")]
         type_: AutosizeVariant1Type,
@@ -2066,413 +2036,350 @@ impl ::std::default::Default for AutosizeVariant1Type {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct Axis {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub aria: ::std::option::Option<bool>,
     #[serde(
         rename = "bandPosition",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub band_position: ::std::option::Option<AxisBandPosition>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub description: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub domain: ::std::option::Option<bool>,
     #[serde(
         rename = "domainCap",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub domain_cap: ::std::option::Option<AxisDomainCap>,
     #[serde(
         rename = "domainColor",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub domain_color: ::std::option::Option<AxisDomainColor>,
     #[serde(
         rename = "domainDash",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub domain_dash: ::std::option::Option<AxisDomainDash>,
     #[serde(
         rename = "domainDashOffset",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub domain_dash_offset: ::std::option::Option<AxisDomainDashOffset>,
     #[serde(
         rename = "domainOpacity",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub domain_opacity: ::std::option::Option<AxisDomainOpacity>,
     #[serde(
         rename = "domainWidth",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub domain_width: ::std::option::Option<AxisDomainWidth>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub encode: ::std::option::Option<AxisEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub format: ::std::option::Option<AxisFormat>,
     #[serde(
         rename = "formatType",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub format_type: ::std::option::Option<AxisFormatType>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub grid: ::std::option::Option<bool>,
     #[serde(
         rename = "gridCap",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub grid_cap: ::std::option::Option<AxisGridCap>,
     #[serde(
         rename = "gridColor",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub grid_color: ::std::option::Option<AxisGridColor>,
     #[serde(
         rename = "gridDash",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub grid_dash: ::std::option::Option<AxisGridDash>,
     #[serde(
         rename = "gridDashOffset",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub grid_dash_offset: ::std::option::Option<AxisGridDashOffset>,
     #[serde(
         rename = "gridOpacity",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub grid_opacity: ::std::option::Option<AxisGridOpacity>,
     #[serde(
         rename = "gridScale",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub grid_scale: ::std::option::Option<::std::string::String>,
     #[serde(
         rename = "gridWidth",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub grid_width: ::std::option::Option<AxisGridWidth>,
     #[serde(
         rename = "labelAlign",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub label_align: ::std::option::Option<AxisLabelAlign>,
     #[serde(
         rename = "labelAngle",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub label_angle: ::std::option::Option<AxisLabelAngle>,
     #[serde(
         rename = "labelBaseline",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub label_baseline: ::std::option::Option<AxisLabelBaseline>,
     #[serde(
         rename = "labelBound",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub label_bound: ::std::option::Option<AxisLabelBound>,
     #[serde(
         rename = "labelColor",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub label_color: ::std::option::Option<AxisLabelColor>,
     #[serde(
         rename = "labelFlush",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub label_flush: ::std::option::Option<AxisLabelFlush>,
     #[serde(
         rename = "labelFlushOffset",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub label_flush_offset: ::std::option::Option<NumberOrSignal>,
     #[serde(
         rename = "labelFont",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub label_font: ::std::option::Option<AxisLabelFont>,
     #[serde(
         rename = "labelFontSize",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub label_font_size: ::std::option::Option<AxisLabelFontSize>,
     #[serde(
         rename = "labelFontStyle",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub label_font_style: ::std::option::Option<AxisLabelFontStyle>,
     #[serde(
         rename = "labelFontWeight",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub label_font_weight: ::std::option::Option<AxisLabelFontWeight>,
     #[serde(
         rename = "labelLimit",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub label_limit: ::std::option::Option<AxisLabelLimit>,
     #[serde(
         rename = "labelLineHeight",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub label_line_height: ::std::option::Option<AxisLabelLineHeight>,
     #[serde(
         rename = "labelOffset",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub label_offset: ::std::option::Option<AxisLabelOffset>,
     #[serde(
         rename = "labelOpacity",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub label_opacity: ::std::option::Option<AxisLabelOpacity>,
     #[serde(
         rename = "labelOverlap",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub label_overlap: ::std::option::Option<LabelOverlap>,
     #[serde(
         rename = "labelPadding",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub label_padding: ::std::option::Option<AxisLabelPadding>,
     #[serde(
         rename = "labelSeparation",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub label_separation: ::std::option::Option<NumberOrSignal>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub labels: ::std::option::Option<bool>,
     #[serde(
         rename = "maxExtent",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub max_extent: ::std::option::Option<AxisMaxExtent>,
     #[serde(
         rename = "minExtent",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub min_extent: ::std::option::Option<AxisMinExtent>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub offset: ::std::option::Option<AxisOffset>,
     pub orient: AxisOrient,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub position: ::std::option::Option<AxisPosition>,
     pub scale: ::std::string::String,
     #[serde(
         rename = "tickBand",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub tick_band: ::std::option::Option<TickBand>,
     #[serde(
         rename = "tickCap",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub tick_cap: ::std::option::Option<AxisTickCap>,
     #[serde(
         rename = "tickColor",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub tick_color: ::std::option::Option<AxisTickColor>,
     #[serde(
         rename = "tickCount",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub tick_count: ::std::option::Option<TickCount>,
     #[serde(
         rename = "tickDash",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub tick_dash: ::std::option::Option<AxisTickDash>,
     #[serde(
         rename = "tickDashOffset",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub tick_dash_offset: ::std::option::Option<AxisTickDashOffset>,
     #[serde(
         rename = "tickExtra",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub tick_extra: ::std::option::Option<BooleanOrSignal>,
     #[serde(
         rename = "tickMinStep",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub tick_min_step: ::std::option::Option<NumberOrSignal>,
     #[serde(
         rename = "tickOffset",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub tick_offset: ::std::option::Option<AxisTickOffset>,
     #[serde(
         rename = "tickOpacity",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub tick_opacity: ::std::option::Option<AxisTickOpacity>,
     #[serde(
         rename = "tickRound",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub tick_round: ::std::option::Option<AxisTickRound>,
     #[serde(
         rename = "tickSize",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub tick_size: ::std::option::Option<AxisTickSize>,
     #[serde(
         rename = "tickWidth",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub tick_width: ::std::option::Option<AxisTickWidth>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub ticks: ::std::option::Option<bool>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<TextOrSignal>,
     #[serde(
         rename = "titleAlign",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub title_align: ::std::option::Option<AxisTitleAlign>,
     #[serde(
         rename = "titleAnchor",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub title_anchor: ::std::option::Option<AxisTitleAnchor>,
     #[serde(
         rename = "titleAngle",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub title_angle: ::std::option::Option<AxisTitleAngle>,
     #[serde(
         rename = "titleBaseline",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub title_baseline: ::std::option::Option<AxisTitleBaseline>,
     #[serde(
         rename = "titleColor",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub title_color: ::std::option::Option<AxisTitleColor>,
     #[serde(
         rename = "titleFont",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub title_font: ::std::option::Option<AxisTitleFont>,
     #[serde(
         rename = "titleFontSize",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub title_font_size: ::std::option::Option<AxisTitleFontSize>,
     #[serde(
         rename = "titleFontStyle",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub title_font_style: ::std::option::Option<AxisTitleFontStyle>,
     #[serde(
         rename = "titleFontWeight",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub title_font_weight: ::std::option::Option<AxisTitleFontWeight>,
     #[serde(
         rename = "titleLimit",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub title_limit: ::std::option::Option<AxisTitleLimit>,
     #[serde(
         rename = "titleLineHeight",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub title_line_height: ::std::option::Option<AxisTitleLineHeight>,
     #[serde(
         rename = "titleOpacity",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub title_opacity: ::std::option::Option<AxisTitleOpacity>,
     #[serde(
         rename = "titlePadding",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub title_padding: ::std::option::Option<AxisTitlePadding>,
     #[serde(
         rename = "titleX",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub title_x: ::std::option::Option<AxisTitleX>,
     #[serde(
         rename = "titleY",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub title_y: ::std::option::Option<AxisTitleY>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub translate: ::std::option::Option<AxisTranslate>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub values: ::std::option::Option<ArrayOrSignal>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub zindex: ::std::option::Option<f64>,
 }
 #[doc = "`AxisBandPosition`"]
@@ -2589,17 +2496,17 @@ impl ::std::convert::From<NumberValue> for AxisDomainWidth {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct AxisEncode {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub axis: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub domain: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub grid: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub labels: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub ticks: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
 }
 #[doc = "`AxisFormat`"]
@@ -2608,25 +2515,25 @@ pub struct AxisEncode {
 pub enum AxisFormat {
     String(::std::string::String),
     Object {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         date: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         day: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         hours: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         milliseconds: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         minutes: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         month: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         quarter: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         seconds: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         week: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         year: ::std::option::Option<::std::string::String>,
     },
     SignalRef(SignalRef),
@@ -3931,12 +3838,12 @@ pub enum BaseColorValue {
         value: RadialGradient,
     },
     Variant3 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         count: ::std::option::Option<f64>,
         gradient: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         start: ::std::option::Option<[f64; 2usize]>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         stop: ::std::option::Option<[f64; 2usize]>,
     },
     Variant4 {
@@ -3977,23 +3884,24 @@ impl ::std::convert::From<BaseColorValueVariant0Variant2> for BaseColorValueVari
 #[serde(untagged)]
 pub enum BaseColorValueVariant0Variant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
+        #[serde(deserialize_with = "::std::option::Option::deserialize")]
         value: ::std::option::Option<::std::string::String>,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
     Variant3 {
         range: BaseColorValueVariant0Variant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
 }
@@ -4003,6 +3911,14 @@ pub enum BaseColorValueVariant0Variant0 {
 pub enum BaseColorValueVariant0Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
+}
+impl ::std::fmt::Display for BaseColorValueVariant0Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for BaseColorValueVariant0Variant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -4030,14 +3946,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for BaseColorValueVariant0Variant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for BaseColorValueVariant0Variant0Variant3Range {
@@ -4135,7 +4043,7 @@ pub enum BaselineValueVariant0Item {
     Variant2(BaselineValueVariant0ItemVariant2),
     Variant3 {
         offset: ::serde_json::Value,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -4159,31 +4067,31 @@ impl ::std::convert::From<BaselineValueVariant0ItemVariant2> for BaselineValueVa
 #[serde(untagged)]
 pub enum BaselineValueVariant0ItemVariant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
         value: BaselineValueVariant0ItemVariant0Variant1Value,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant3 {
         range: BaselineValueVariant0ItemVariant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -4255,6 +4163,14 @@ pub enum BaselineValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
 }
+impl ::std::fmt::Display for BaselineValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for BaselineValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -4281,14 +4197,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for BaselineValueVariant0ItemVariant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for BaselineValueVariant0ItemVariant0Variant3Range {
@@ -4360,23 +4268,23 @@ impl ::std::convert::From<BaselineValueVariant1Variant2> for BaselineValueVarian
 #[serde(untagged)]
 pub enum BaselineValueVariant1Variant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         value: BaselineValueVariant1Variant0Variant1Value,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
     Variant3 {
         range: BaselineValueVariant1Variant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
 }
@@ -4446,6 +4354,14 @@ pub enum BaselineValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
 }
+impl ::std::fmt::Display for BaselineValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for BaselineValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -4470,14 +4386,6 @@ impl ::std::convert::TryFrom<::std::string::String> for BaselineValueVariant1Var
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for BaselineValueVariant1Variant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for BaselineValueVariant1Variant0Variant3Range {
@@ -4524,7 +4432,7 @@ pub enum BaselineValueVariant1Variant2 {}
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct BinTransform {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub anchor: ::std::option::Option<BinTransformAnchor>,
     #[serde(rename = "as", default = "defaults::bin_transform_as")]
     pub as_: BinTransformAs,
@@ -4538,19 +4446,19 @@ pub struct BinTransform {
     pub interval: BinTransformInterval,
     #[serde(default = "defaults::bin_transform_maxbins")]
     pub maxbins: BinTransformMaxbins,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub minstep: ::std::option::Option<BinTransformMinstep>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<BinTransformName>,
     #[serde(default = "defaults::bin_transform_nice")]
     pub nice: BinTransformNice,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub span: ::std::option::Option<BinTransformSpan>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub step: ::std::option::Option<BinTransformStep>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub steps: ::std::option::Option<BinTransformSteps>,
     #[serde(rename = "type")]
     pub type_: BinTransformType,
@@ -4945,55 +4853,55 @@ impl ::std::convert::TryFrom<::std::string::String> for BinTransformType {
 #[serde(untagged, deny_unknown_fields)]
 pub enum Bind {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         debounce: ::std::option::Option<f64>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         element: ::std::option::Option<Element>,
         input: BindVariant0Input,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         name: ::std::option::Option<::std::string::String>,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         debounce: ::std::option::Option<f64>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         element: ::std::option::Option<Element>,
         input: BindVariant1Input,
         #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
         labels: ::std::vec::Vec<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         name: ::std::option::Option<::std::string::String>,
         options: ::std::vec::Vec<::serde_json::Value>,
     },
     Variant2 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         debounce: ::std::option::Option<f64>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         element: ::std::option::Option<Element>,
         input: BindVariant2Input,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         max: ::std::option::Option<f64>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         min: ::std::option::Option<f64>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         name: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         step: ::std::option::Option<f64>,
     },
     Variant3 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         debounce: ::std::option::Option<f64>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         element: ::std::option::Option<Element>,
         input: BindVariant3Input,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         name: ::std::option::Option<::std::string::String>,
     },
     Variant4 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         debounce: ::std::option::Option<f64>,
         element: Element,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         event: ::std::option::Option<::std::string::String>,
     },
 }
@@ -5211,7 +5119,7 @@ pub enum BlendValueVariant0Item {
     Variant2(BlendValueVariant0ItemVariant2),
     Variant3 {
         offset: ::serde_json::Value,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -5235,31 +5143,32 @@ impl ::std::convert::From<BlendValueVariant0ItemVariant2> for BlendValueVariant0
 #[serde(untagged)]
 pub enum BlendValueVariant0ItemVariant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
+        #[serde(deserialize_with = "::std::option::Option::deserialize")]
         value: ::std::option::Option<BlendValueVariant0ItemVariant0Variant1Value>,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant3 {
         range: BlendValueVariant0ItemVariant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -5375,6 +5284,14 @@ pub enum BlendValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
 }
+impl ::std::fmt::Display for BlendValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for BlendValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -5401,14 +5318,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for BlendValueVariant0ItemVariant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for BlendValueVariant0ItemVariant0Variant3Range {
@@ -5480,23 +5389,24 @@ impl ::std::convert::From<BlendValueVariant1Variant2> for BlendValueVariant1 {
 #[serde(untagged)]
 pub enum BlendValueVariant1Variant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
+        #[serde(deserialize_with = "::std::option::Option::deserialize")]
         value: ::std::option::Option<BlendValueVariant1Variant0Variant1Value>,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
     Variant3 {
         range: BlendValueVariant1Variant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
 }
@@ -5610,6 +5520,14 @@ pub enum BlendValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
 }
+impl ::std::fmt::Display for BlendValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for BlendValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -5634,14 +5552,6 @@ impl ::std::convert::TryFrom<::std::string::String> for BlendValueVariant1Varian
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for BlendValueVariant1Variant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for BlendValueVariant1Variant0Variant3Range {
@@ -5727,7 +5637,7 @@ pub enum BooleanValueVariant0Item {
     Variant2(BooleanValueVariant0ItemVariant2),
     Variant3 {
         offset: ::serde_json::Value,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -5751,31 +5661,31 @@ impl ::std::convert::From<BooleanValueVariant0ItemVariant2> for BooleanValueVari
 #[serde(untagged)]
 pub enum BooleanValueVariant0ItemVariant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
         value: bool,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant3 {
         range: BooleanValueVariant0ItemVariant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -5785,6 +5695,14 @@ pub enum BooleanValueVariant0ItemVariant0 {
 pub enum BooleanValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
+}
+impl ::std::fmt::Display for BooleanValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for BooleanValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -5812,14 +5730,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for BooleanValueVariant0ItemVariant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for BooleanValueVariant0ItemVariant0Variant3Range {
@@ -5891,23 +5801,23 @@ impl ::std::convert::From<BooleanValueVariant1Variant2> for BooleanValueVariant1
 #[serde(untagged)]
 pub enum BooleanValueVariant1Variant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         value: bool,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
     Variant3 {
         range: BooleanValueVariant1Variant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
 }
@@ -5917,6 +5827,14 @@ pub enum BooleanValueVariant1Variant0 {
 pub enum BooleanValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
+}
+impl ::std::fmt::Display for BooleanValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for BooleanValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -5942,14 +5860,6 @@ impl ::std::convert::TryFrom<::std::string::String> for BooleanValueVariant1Vari
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for BooleanValueVariant1Variant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for BooleanValueVariant1Variant0Variant3Range {
@@ -5996,9 +5906,9 @@ pub enum BooleanValueVariant1Variant2 {}
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct CollectTransform {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub sort: ::std::option::Option<Compare>,
     #[serde(rename = "type")]
     pub type_: CollectTransformType,
@@ -6083,9 +5993,9 @@ pub struct ColorRgb {
 #[serde(untagged, deny_unknown_fields)]
 pub enum Compare {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         field: ::std::option::Option<CompareVariant0Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         order: ::std::option::Option<SortOrder>,
     },
     Variant1 {
@@ -6133,34 +6043,33 @@ impl ::std::convert::From<Expr> for CompareVariant1FieldItem {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct ContourTransform {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub bandwidth: ::std::option::Option<ContourTransformBandwidth>,
     #[serde(
         rename = "cellSize",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub cell_size: ::std::option::Option<ContourTransformCellSize>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub count: ::std::option::Option<ContourTransformCount>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub nice: ::std::option::Option<ContourTransformNice>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     pub size: ContourTransformSize,
     #[serde(default = "defaults::contour_transform_smooth")]
     pub smooth: ContourTransformSmooth,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub thresholds: ::std::option::Option<ContourTransformThresholds>,
     #[serde(rename = "type")]
     pub type_: ContourTransformType,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub values: ::std::option::Option<ContourTransformValues>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub weight: ::std::option::Option<ContourTransformWeight>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub x: ::std::option::Option<ContourTransformX>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub y: ::std::option::Option<ContourTransformY>,
 }
 #[doc = "`ContourTransformBandwidth`"]
@@ -6486,9 +6395,9 @@ pub struct CountpatternTransform {
     pub field: CountpatternTransformField,
     #[serde(default = "defaults::countpattern_transform_pattern")]
     pub pattern: CountpatternTransformPattern,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub stopwords: ::std::option::Option<CountpatternTransformStopwords>,
     #[serde(rename = "type")]
     pub type_: CountpatternTransformType,
@@ -6712,9 +6621,9 @@ impl ::std::convert::TryFrom<::std::string::String> for CountpatternTransformTyp
 pub struct CrossTransform {
     #[serde(rename = "as", default = "defaults::cross_transform_as")]
     pub as_: CrossTransformAs,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub filter: ::std::option::Option<ExprString>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]
     pub type_: CrossTransformType,
@@ -6809,7 +6718,7 @@ impl ::std::convert::TryFrom<::std::string::String> for CrossTransformType {
 pub struct CrossfilterTransform {
     pub fields: CrossfilterTransformFields,
     pub query: CrossfilterTransformQuery,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]
     pub type_: CrossfilterTransformType,
@@ -6926,14 +6835,14 @@ impl ::std::convert::TryFrom<::std::string::String> for CrossfilterTransformType
 pub enum Data {
     Variant0 {
         name: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         on: ::std::option::Option<OnTrigger>,
         #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
         transform: ::std::vec::Vec<Transform>,
     },
     Variant1 {
         name: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         on: ::std::option::Option<OnTrigger>,
         source: DataVariant1Source,
         #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
@@ -6942,14 +6851,13 @@ pub enum Data {
     Variant2 {
         #[serde(
             rename = "async",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         async_: ::std::option::Option<BooleanOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         format: ::std::option::Option<DataVariant2Format>,
         name: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         on: ::std::option::Option<OnTrigger>,
         #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
         transform: ::std::vec::Vec<Transform>,
@@ -6958,14 +6866,13 @@ pub enum Data {
     Variant3 {
         #[serde(
             rename = "async",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         async_: ::std::option::Option<BooleanOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         format: ::std::option::Option<DataVariant3Format>,
         name: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         on: ::std::option::Option<OnTrigger>,
         #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
         transform: ::std::vec::Vec<Transform>,
@@ -6989,35 +6896,15 @@ impl ::std::convert::From<::std::vec::Vec<::std::string::String>> for DataVarian
 #[serde(untagged)]
 pub enum DataVariant2Format {
     Variant0 {
-        #[serde(
-            flatten,
-            default,
-            skip_serializing_if = "::std::option::Option::is_none"
-        )]
+        #[serde(flatten, skip_serializing_if = "::std::option::Option::is_none")]
         subtype_0: ::std::option::Option<DataVariant2FormatVariant0Subtype0>,
-        #[serde(
-            flatten,
-            default,
-            skip_serializing_if = "::std::option::Option::is_none"
-        )]
+        #[serde(flatten, skip_serializing_if = "::std::option::Option::is_none")]
         subtype_1: ::std::option::Option<DataVariant2FormatVariant0Subtype1>,
-        #[serde(
-            flatten,
-            default,
-            skip_serializing_if = "::std::option::Option::is_none"
-        )]
+        #[serde(flatten, skip_serializing_if = "::std::option::Option::is_none")]
         subtype_2: ::std::option::Option<DataVariant2FormatVariant0Subtype2>,
-        #[serde(
-            flatten,
-            default,
-            skip_serializing_if = "::std::option::Option::is_none"
-        )]
+        #[serde(flatten, skip_serializing_if = "::std::option::Option::is_none")]
         subtype_3: ::std::option::Option<DataVariant2FormatVariant0Subtype3>,
-        #[serde(
-            flatten,
-            default,
-            skip_serializing_if = "::std::option::Option::is_none"
-        )]
+        #[serde(flatten, skip_serializing_if = "::std::option::Option::is_none")]
         subtype_4: ::std::option::Option<DataVariant2FormatVariant0Subtype4>,
     },
     Variant1(SignalRef),
@@ -7030,11 +6917,10 @@ impl ::std::convert::From<SignalRef> for DataVariant2Format {
 #[doc = "`DataVariant2FormatVariant0Subtype0`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct DataVariant2FormatVariant0Subtype0 {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub parse: ::std::option::Option<DataVariant2FormatVariant0Subtype0Parse>,
     #[serde(
         rename = "type",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub type_: ::std::option::Option<StringOrSignal>,
@@ -7137,6 +7023,14 @@ pub enum DataVariant2FormatVariant0Subtype0ParseVariant1Value {
     Variant0(DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0),
     Variant1(DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant1),
 }
+impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype0ParseVariant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for DataVariant2FormatVariant0Subtype0ParseVariant1Value {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -7163,14 +7057,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype0ParseVariant1Value {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<DataVariant2FormatVariant0Subtype0ParseVariant1ValueVariant0>
@@ -7314,15 +7200,14 @@ impl<'de> ::serde::Deserialize<'de>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct DataVariant2FormatVariant0Subtype1 {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub copy: ::std::option::Option<BooleanOrSignal>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub parse: ::std::option::Option<DataVariant2FormatVariant0Subtype1Parse>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub property: ::std::option::Option<StringOrSignal>,
     #[serde(
         rename = "type",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub type_: ::std::option::Option<DataVariant2FormatVariant0Subtype1Type>,
@@ -7425,6 +7310,14 @@ pub enum DataVariant2FormatVariant0Subtype1ParseVariant1Value {
     Variant0(DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0),
     Variant1(DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant1),
 }
+impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype1ParseVariant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for DataVariant2FormatVariant0Subtype1ParseVariant1Value {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -7451,14 +7344,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype1ParseVariant1Value {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<DataVariant2FormatVariant0Subtype1ParseVariant1ValueVariant0>
@@ -7651,7 +7536,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DataVariant2FormatVarian
 pub struct DataVariant2FormatVariant0Subtype2 {
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub header: ::std::vec::Vec<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub parse: ::std::option::Option<DataVariant2FormatVariant0Subtype2Parse>,
     #[serde(rename = "type")]
     pub type_: DataVariant2FormatVariant0Subtype2Type,
@@ -7754,6 +7639,14 @@ pub enum DataVariant2FormatVariant0Subtype2ParseVariant1Value {
     Variant0(DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0),
     Variant1(DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant1),
 }
+impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype2ParseVariant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for DataVariant2FormatVariant0Subtype2ParseVariant1Value {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -7780,14 +7673,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype2ParseVariant1Value {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<DataVariant2FormatVariant0Subtype2ParseVariant1ValueVariant0>
@@ -7985,7 +7870,7 @@ pub struct DataVariant2FormatVariant0Subtype3 {
     pub delimiter: ::std::string::String,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub header: ::std::vec::Vec<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub parse: ::std::option::Option<DataVariant2FormatVariant0Subtype3Parse>,
     #[serde(rename = "type")]
     pub type_: DataVariant2FormatVariant0Subtype3Type,
@@ -8088,6 +7973,14 @@ pub enum DataVariant2FormatVariant0Subtype3ParseVariant1Value {
     Variant0(DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0),
     Variant1(DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant1),
 }
+impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype3ParseVariant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for DataVariant2FormatVariant0Subtype3ParseVariant1Value {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -8114,14 +8007,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for DataVariant2FormatVariant0Subtype3ParseVariant1Value {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<DataVariant2FormatVariant0Subtype3ParseVariant1ValueVariant0>
@@ -8314,16 +8199,16 @@ impl ::std::convert::TryFrom<::std::string::String> for DataVariant2FormatVarian
 pub enum DataVariant2FormatVariant0Subtype4 {
     Variant0 {
         feature: StringOrSignal,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         property: ::std::option::Option<StringOrSignal>,
         #[serde(rename = "type")]
         type_: DataVariant2FormatVariant0Subtype4Variant0Type,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         filter: ::std::option::Option<DataVariant2FormatVariant0Subtype4Variant1Filter>,
         mesh: StringOrSignal,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         property: ::std::option::Option<StringOrSignal>,
         #[serde(rename = "type")]
         type_: DataVariant2FormatVariant0Subtype4Variant1Type,
@@ -8485,35 +8370,15 @@ impl ::std::convert::TryFrom<::std::string::String>
 #[serde(untagged)]
 pub enum DataVariant3Format {
     Variant0 {
-        #[serde(
-            flatten,
-            default,
-            skip_serializing_if = "::std::option::Option::is_none"
-        )]
+        #[serde(flatten, skip_serializing_if = "::std::option::Option::is_none")]
         subtype_0: ::std::option::Option<DataVariant3FormatVariant0Subtype0>,
-        #[serde(
-            flatten,
-            default,
-            skip_serializing_if = "::std::option::Option::is_none"
-        )]
+        #[serde(flatten, skip_serializing_if = "::std::option::Option::is_none")]
         subtype_1: ::std::option::Option<DataVariant3FormatVariant0Subtype1>,
-        #[serde(
-            flatten,
-            default,
-            skip_serializing_if = "::std::option::Option::is_none"
-        )]
+        #[serde(flatten, skip_serializing_if = "::std::option::Option::is_none")]
         subtype_2: ::std::option::Option<DataVariant3FormatVariant0Subtype2>,
-        #[serde(
-            flatten,
-            default,
-            skip_serializing_if = "::std::option::Option::is_none"
-        )]
+        #[serde(flatten, skip_serializing_if = "::std::option::Option::is_none")]
         subtype_3: ::std::option::Option<DataVariant3FormatVariant0Subtype3>,
-        #[serde(
-            flatten,
-            default,
-            skip_serializing_if = "::std::option::Option::is_none"
-        )]
+        #[serde(flatten, skip_serializing_if = "::std::option::Option::is_none")]
         subtype_4: ::std::option::Option<DataVariant3FormatVariant0Subtype4>,
     },
     Variant1(SignalRef),
@@ -8526,11 +8391,10 @@ impl ::std::convert::From<SignalRef> for DataVariant3Format {
 #[doc = "`DataVariant3FormatVariant0Subtype0`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct DataVariant3FormatVariant0Subtype0 {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub parse: ::std::option::Option<DataVariant3FormatVariant0Subtype0Parse>,
     #[serde(
         rename = "type",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub type_: ::std::option::Option<StringOrSignal>,
@@ -8633,6 +8497,14 @@ pub enum DataVariant3FormatVariant0Subtype0ParseVariant1Value {
     Variant0(DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0),
     Variant1(DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant1),
 }
+impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype0ParseVariant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for DataVariant3FormatVariant0Subtype0ParseVariant1Value {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -8659,14 +8531,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype0ParseVariant1Value {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<DataVariant3FormatVariant0Subtype0ParseVariant1ValueVariant0>
@@ -8810,15 +8674,14 @@ impl<'de> ::serde::Deserialize<'de>
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct DataVariant3FormatVariant0Subtype1 {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub copy: ::std::option::Option<BooleanOrSignal>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub parse: ::std::option::Option<DataVariant3FormatVariant0Subtype1Parse>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub property: ::std::option::Option<StringOrSignal>,
     #[serde(
         rename = "type",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub type_: ::std::option::Option<DataVariant3FormatVariant0Subtype1Type>,
@@ -8921,6 +8784,14 @@ pub enum DataVariant3FormatVariant0Subtype1ParseVariant1Value {
     Variant0(DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0),
     Variant1(DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant1),
 }
+impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype1ParseVariant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for DataVariant3FormatVariant0Subtype1ParseVariant1Value {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -8947,14 +8818,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype1ParseVariant1Value {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<DataVariant3FormatVariant0Subtype1ParseVariant1ValueVariant0>
@@ -9147,7 +9010,7 @@ impl ::std::convert::TryFrom<::std::string::String> for DataVariant3FormatVarian
 pub struct DataVariant3FormatVariant0Subtype2 {
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub header: ::std::vec::Vec<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub parse: ::std::option::Option<DataVariant3FormatVariant0Subtype2Parse>,
     #[serde(rename = "type")]
     pub type_: DataVariant3FormatVariant0Subtype2Type,
@@ -9250,6 +9113,14 @@ pub enum DataVariant3FormatVariant0Subtype2ParseVariant1Value {
     Variant0(DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0),
     Variant1(DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant1),
 }
+impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype2ParseVariant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for DataVariant3FormatVariant0Subtype2ParseVariant1Value {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -9276,14 +9147,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype2ParseVariant1Value {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<DataVariant3FormatVariant0Subtype2ParseVariant1ValueVariant0>
@@ -9481,7 +9344,7 @@ pub struct DataVariant3FormatVariant0Subtype3 {
     pub delimiter: ::std::string::String,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub header: ::std::vec::Vec<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub parse: ::std::option::Option<DataVariant3FormatVariant0Subtype3Parse>,
     #[serde(rename = "type")]
     pub type_: DataVariant3FormatVariant0Subtype3Type,
@@ -9584,6 +9447,14 @@ pub enum DataVariant3FormatVariant0Subtype3ParseVariant1Value {
     Variant0(DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0),
     Variant1(DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant1),
 }
+impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype3ParseVariant1Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Variant0(x) => x.fmt(f),
+            Self::Variant1(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for DataVariant3FormatVariant0Subtype3ParseVariant1Value {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -9610,14 +9481,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for DataVariant3FormatVariant0Subtype3ParseVariant1Value {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Variant0(x) => x.fmt(f),
-            Self::Variant1(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<DataVariant3FormatVariant0Subtype3ParseVariant1ValueVariant0>
@@ -9810,16 +9673,16 @@ impl ::std::convert::TryFrom<::std::string::String> for DataVariant3FormatVarian
 pub enum DataVariant3FormatVariant0Subtype4 {
     Variant0 {
         feature: StringOrSignal,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         property: ::std::option::Option<StringOrSignal>,
         #[serde(rename = "type")]
         type_: DataVariant3FormatVariant0Subtype4Variant0Type,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         filter: ::std::option::Option<DataVariant3FormatVariant0Subtype4Variant1Filter>,
         mesh: StringOrSignal,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         property: ::std::option::Option<StringOrSignal>,
         #[serde(rename = "type")]
         type_: DataVariant3FormatVariant0Subtype4Variant1Type,
@@ -9999,9 +9862,9 @@ impl ::std::convert::From<SignalRef> for DataVariant3Values {
 pub struct DensityTransform {
     #[serde(rename = "as", default = "defaults::density_transform_as")]
     pub as_: DensityTransformAs,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub distribution: ::std::option::Option<DensityTransformDistribution>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub extent: ::std::option::Option<DensityTransformExtent>,
     #[serde(default = "defaults::density_transform_maxsteps")]
     pub maxsteps: DensityTransformMaxsteps,
@@ -10009,9 +9872,9 @@ pub struct DensityTransform {
     pub method: DensityTransformMethod,
     #[serde(default = "defaults::density_transform_minsteps")]
     pub minsteps: DensityTransformMinsteps,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub steps: ::std::option::Option<DensityTransformSteps>,
     #[serde(rename = "type")]
     pub type_: DensityTransformType,
@@ -10059,14 +9922,14 @@ impl ::std::convert::From<SignalRef> for DensityTransformAsArrayItem {
 pub enum DensityTransformDistribution {
     #[serde(rename = "normal")]
     Normal {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         mean: ::std::option::Option<DensityTransformDistributionMean>,
         #[serde(default = "defaults::density_transform_distribution_normal_stdev")]
         stdev: DensityTransformDistributionStdev,
     },
     #[serde(rename = "lognormal")]
     Lognormal {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         mean: ::std::option::Option<DensityTransformDistributionMean>,
         #[serde(default = "defaults::density_transform_distribution_lognormal_stdev")]
         stdev: DensityTransformDistributionStdev,
@@ -10075,22 +9938,22 @@ pub enum DensityTransformDistribution {
     Uniform {
         #[serde(default = "defaults::density_transform_distribution_uniform_max")]
         max: DensityTransformDistributionMax,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         min: ::std::option::Option<DensityTransformDistributionMin>,
     },
     #[serde(rename = "kde")]
     Kde {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         bandwidth: ::std::option::Option<DensityTransformDistributionBandwidth>,
         field: DensityTransformDistributionField,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         from: ::std::option::Option<::std::string::String>,
     },
     #[serde(rename = "mixture")]
     Mixture {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         distributions: ::std::option::Option<DensityTransformDistributionDistributions>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         weights: ::std::option::Option<DensityTransformDistributionWeights>,
     },
 }
@@ -10452,7 +10315,7 @@ pub enum DirectionValueVariant0Item {
     Variant2(DirectionValueVariant0ItemVariant2),
     Variant3 {
         offset: ::serde_json::Value,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -10476,31 +10339,31 @@ impl ::std::convert::From<DirectionValueVariant0ItemVariant2> for DirectionValue
 #[serde(untagged)]
 pub enum DirectionValueVariant0ItemVariant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
         value: DirectionValueVariant0ItemVariant0Variant1Value,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant3 {
         range: DirectionValueVariant0ItemVariant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -10564,6 +10427,14 @@ pub enum DirectionValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
 }
+impl ::std::fmt::Display for DirectionValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for DirectionValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -10590,14 +10461,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for DirectionValueVariant0ItemVariant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for DirectionValueVariant0ItemVariant0Variant3Range {
@@ -10669,23 +10532,23 @@ impl ::std::convert::From<DirectionValueVariant1Variant2> for DirectionValueVari
 #[serde(untagged)]
 pub enum DirectionValueVariant1Variant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         value: DirectionValueVariant1Variant0Variant1Value,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
     Variant3 {
         range: DirectionValueVariant1Variant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
 }
@@ -10749,6 +10612,14 @@ pub enum DirectionValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
 }
+impl ::std::fmt::Display for DirectionValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for DirectionValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -10775,14 +10646,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for DirectionValueVariant1Variant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for DirectionValueVariant1Variant0Variant3Range {
@@ -10832,13 +10695,13 @@ pub struct DotbinTransform {
     #[serde(rename = "as", default = "defaults::dotbin_transform_as")]
     pub as_: DotbinTransformAs,
     pub field: DotbinTransformField,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub groupby: ::std::option::Option<DotbinTransformGroupby>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub smooth: ::std::option::Option<DotbinTransformSmooth>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub step: ::std::option::Option<DotbinTransformStep>,
     #[serde(rename = "type")]
     pub type_: DotbinTransformType,
@@ -11036,15 +10899,15 @@ impl ::std::convert::From<::std::string::String> for Element {
         Self(value)
     }
 }
+impl ::std::fmt::Display for Element {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 impl ::std::str::FromStr for Element {
     type Err = ::std::convert::Infallible;
     fn from_str(value: &str) -> ::std::result::Result<Self, Self::Err> {
         Ok(Self(value.to_string()))
-    }
-}
-impl ::std::fmt::Display for Element {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        self.0.fmt(f)
     }
 }
 #[doc = "`Encode`"]
@@ -11070,259 +10933,230 @@ impl ::std::convert::From<::std::collections::HashMap<EncodeKey, EncodeEntry>> f
 #[doc = "`EncodeEntry`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct EncodeEntry {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub align: ::std::option::Option<AlignValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub angle: ::std::option::Option<NumberValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub aria: ::std::option::Option<BooleanValue>,
     #[serde(
         rename = "ariaRole",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub aria_role: ::std::option::Option<StringValue>,
     #[serde(
         rename = "ariaRoleDescription",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub aria_role_description: ::std::option::Option<StringValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub aspect: ::std::option::Option<BooleanValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub baseline: ::std::option::Option<BaselineValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub blend: ::std::option::Option<BlendValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub clip: ::std::option::Option<BooleanValue>,
     #[serde(
         rename = "cornerRadius",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub corner_radius: ::std::option::Option<NumberValue>,
     #[serde(
         rename = "cornerRadiusBottomLeft",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub corner_radius_bottom_left: ::std::option::Option<NumberValue>,
     #[serde(
         rename = "cornerRadiusBottomRight",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub corner_radius_bottom_right: ::std::option::Option<NumberValue>,
     #[serde(
         rename = "cornerRadiusTopLeft",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub corner_radius_top_left: ::std::option::Option<NumberValue>,
     #[serde(
         rename = "cornerRadiusTopRight",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub corner_radius_top_right: ::std::option::Option<NumberValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub cursor: ::std::option::Option<StringValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub defined: ::std::option::Option<BooleanValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub description: ::std::option::Option<StringValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub dir: ::std::option::Option<StringValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub dx: ::std::option::Option<NumberValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub dy: ::std::option::Option<NumberValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub ellipsis: ::std::option::Option<StringValue>,
     #[serde(
         rename = "endAngle",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub end_angle: ::std::option::Option<NumberValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub fill: ::std::option::Option<ColorValue>,
     #[serde(
         rename = "fillOpacity",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub fill_opacity: ::std::option::Option<NumberValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub font: ::std::option::Option<StringValue>,
     #[serde(
         rename = "fontSize",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub font_size: ::std::option::Option<NumberValue>,
     #[serde(
         rename = "fontStyle",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub font_style: ::std::option::Option<StringValue>,
     #[serde(
         rename = "fontWeight",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub font_weight: ::std::option::Option<FontWeightValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub height: ::std::option::Option<NumberValue>,
     #[serde(
         rename = "innerRadius",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub inner_radius: ::std::option::Option<NumberValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub interpolate: ::std::option::Option<StringValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub limit: ::std::option::Option<NumberValue>,
     #[serde(
         rename = "lineBreak",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub line_break: ::std::option::Option<StringValue>,
     #[serde(
         rename = "lineHeight",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub line_height: ::std::option::Option<NumberValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub opacity: ::std::option::Option<NumberValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub orient: ::std::option::Option<DirectionValue>,
     #[serde(
         rename = "outerRadius",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub outer_radius: ::std::option::Option<NumberValue>,
     #[serde(
         rename = "padAngle",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub pad_angle: ::std::option::Option<NumberValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub path: ::std::option::Option<StringValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub radius: ::std::option::Option<NumberValue>,
     #[serde(
         rename = "scaleX",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub scale_x: ::std::option::Option<NumberValue>,
     #[serde(
         rename = "scaleY",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub scale_y: ::std::option::Option<NumberValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub shape: ::std::option::Option<StringValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub size: ::std::option::Option<NumberValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub smooth: ::std::option::Option<BooleanValue>,
     #[serde(
         rename = "startAngle",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub start_angle: ::std::option::Option<NumberValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub stroke: ::std::option::Option<ColorValue>,
     #[serde(
         rename = "strokeCap",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub stroke_cap: ::std::option::Option<StrokeCapValue>,
     #[serde(
         rename = "strokeDash",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub stroke_dash: ::std::option::Option<ArrayValue>,
     #[serde(
         rename = "strokeDashOffset",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub stroke_dash_offset: ::std::option::Option<NumberValue>,
     #[serde(
         rename = "strokeForeground",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub stroke_foreground: ::std::option::Option<BooleanValue>,
     #[serde(
         rename = "strokeJoin",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub stroke_join: ::std::option::Option<StrokeJoinValue>,
     #[serde(
         rename = "strokeMiterLimit",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub stroke_miter_limit: ::std::option::Option<NumberValue>,
     #[serde(
         rename = "strokeOffset",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub stroke_offset: ::std::option::Option<NumberValue>,
     #[serde(
         rename = "strokeOpacity",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub stroke_opacity: ::std::option::Option<NumberValue>,
     #[serde(
         rename = "strokeWidth",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub stroke_width: ::std::option::Option<NumberValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub tension: ::std::option::Option<NumberValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub text: ::std::option::Option<TextValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub theta: ::std::option::Option<NumberValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub tooltip: ::std::option::Option<AnyValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub url: ::std::option::Option<StringValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub width: ::std::option::Option<NumberValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub x: ::std::option::Option<NumberValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub x2: ::std::option::Option<NumberValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub xc: ::std::option::Option<NumberValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub y: ::std::option::Option<NumberValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub y2: ::std::option::Option<NumberValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub yc: ::std::option::Option<NumberValue>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub zindex: ::std::option::Option<NumberValue>,
 }
 #[doc = "`EncodeKey`"]
@@ -11380,29 +11214,29 @@ impl<'de> ::serde::Deserialize<'de> for EncodeKey {
 #[doc = "`Everything`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct Everything {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub autosize: ::std::option::Option<Autosize>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub axes: ::std::vec::Vec<Axis>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub background: ::std::option::Option<Background>,
     #[serde(default, skip_serializing_if = "::serde_json::Map::is_empty")]
     pub config: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub data: ::std::vec::Vec<Data>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub description: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub encode: ::std::option::Option<Encode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub height: ::std::option::Option<NumberOrSignal>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub layout: ::std::option::Option<Layout>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub legends: ::std::vec::Vec<Legend>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub marks: ::std::vec::Vec<EverythingMarksItem>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub padding: ::std::option::Option<Padding>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub projections: ::std::vec::Vec<Projection>,
@@ -11410,19 +11244,18 @@ pub struct Everything {
     pub scales: ::std::vec::Vec<Scale>,
     #[serde(
         rename = "$schema",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub schema: ::std::option::Option<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub signals: ::std::vec::Vec<Signal>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub style: ::std::option::Option<Style>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<Title>,
     #[serde(default, skip_serializing_if = "::serde_json::Map::is_empty")]
     pub usermeta: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub width: ::std::option::Option<NumberOrSignal>,
 }
 #[doc = "`EverythingMarksItem`"]
@@ -11445,11 +11278,7 @@ impl ::std::convert::From<MarkVisual> for EverythingMarksItem {
 #[doc = "`Expr`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 pub struct Expr {
-    #[serde(
-        rename = "as",
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
+    #[serde(rename = "as", skip_serializing_if = "::std::option::Option::is_none")]
     pub as_: ::std::option::Option<::std::string::String>,
     pub expr: ::std::string::String,
 }
@@ -11483,15 +11312,15 @@ impl ::std::convert::From<::std::string::String> for ExprString {
         Self(value)
     }
 }
+impl ::std::fmt::Display for ExprString {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 impl ::std::str::FromStr for ExprString {
     type Err = ::std::convert::Infallible;
     fn from_str(value: &str) -> ::std::result::Result<Self, Self::Err> {
         Ok(Self(value.to_string()))
-    }
-}
-impl ::std::fmt::Display for ExprString {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        self.0.fmt(f)
     }
 }
 #[doc = "`ExtentTransform`"]
@@ -11499,7 +11328,7 @@ impl ::std::fmt::Display for ExprString {
 #[serde(deny_unknown_fields)]
 pub struct ExtentTransform {
     pub field: ExtentTransformField,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]
     pub type_: ExtentTransformType,
@@ -11578,7 +11407,7 @@ impl ::std::convert::TryFrom<::std::string::String> for ExtentTransformType {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct Facet {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub data: ::std::option::Option<::std::string::String>,
     pub facet: FacetFacet,
 }
@@ -11592,7 +11421,7 @@ pub enum FacetFacet {
         name: ::std::string::String,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         aggregate: ::std::option::Option<FacetFacetVariant1Aggregate>,
         data: ::std::string::String,
         groupby: FacetFacetVariant1Groupby,
@@ -11609,7 +11438,7 @@ pub struct FacetFacetVariant1Aggregate {
         skip_serializing_if = "::std::vec::Vec::is_empty"
     )]
     pub as_: ::std::vec::Vec<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub cross: ::std::option::Option<bool>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub fields: ::std::vec::Vec<::std::string::String>,
@@ -11639,11 +11468,11 @@ pub enum Field {
     },
     Variant3 {
         group: ::std::boxed::Box<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         level: ::std::option::Option<f64>,
     },
     Variant4 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         level: ::std::option::Option<f64>,
         parent: ::std::boxed::Box<Field>,
     },
@@ -11658,7 +11487,7 @@ impl ::std::convert::From<SignalRef> for Field {
 #[serde(deny_unknown_fields)]
 pub struct FilterTransform {
     pub expr: ExprString,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]
     pub type_: FilterTransformType,
@@ -11714,16 +11543,12 @@ impl ::std::convert::TryFrom<::std::string::String> for FilterTransformType {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct FlattenTransform {
-    #[serde(
-        rename = "as",
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
+    #[serde(rename = "as", skip_serializing_if = "::std::option::Option::is_none")]
     pub as_: ::std::option::Option<FlattenTransformAs>,
     pub fields: FlattenTransformFields,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub index: ::std::option::Option<FlattenTransformIndex>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]
     pub type_: FlattenTransformType,
@@ -11865,7 +11690,7 @@ pub struct FoldTransform {
     #[serde(rename = "as", default = "defaults::fold_transform_as")]
     pub as_: FoldTransformAs,
     pub fields: FoldTransformFields,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]
     pub type_: FoldTransformType,
@@ -12020,7 +11845,7 @@ pub enum FontWeightValueVariant0Item {
     Variant2(FontWeightValueVariant0ItemVariant2),
     Variant3 {
         offset: ::serde_json::Value,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -12044,31 +11869,31 @@ impl ::std::convert::From<FontWeightValueVariant0ItemVariant2> for FontWeightVal
 #[serde(untagged)]
 pub enum FontWeightValueVariant0ItemVariant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
         value: MyEnum,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant3 {
         range: FontWeightValueVariant0ItemVariant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -12078,6 +11903,14 @@ pub enum FontWeightValueVariant0ItemVariant0 {
 pub enum FontWeightValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
+}
+impl ::std::fmt::Display for FontWeightValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for FontWeightValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -12105,14 +11938,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for FontWeightValueVariant0ItemVariant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for FontWeightValueVariant0ItemVariant0Variant3Range {
@@ -12184,23 +12009,23 @@ impl ::std::convert::From<FontWeightValueVariant1Variant2> for FontWeightValueVa
 #[serde(untagged)]
 pub enum FontWeightValueVariant1Variant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         value: MyEnum,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
     Variant3 {
         range: FontWeightValueVariant1Variant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
 }
@@ -12210,6 +12035,14 @@ pub enum FontWeightValueVariant1Variant0 {
 pub enum FontWeightValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
+}
+impl ::std::fmt::Display for FontWeightValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for FontWeightValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -12237,14 +12070,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for FontWeightValueVariant1Variant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for FontWeightValueVariant1Variant0Variant3Range {
@@ -12297,7 +12122,6 @@ pub struct ForceTransform {
     pub alpha_min: ForceTransformAlphaMin,
     #[serde(
         rename = "alphaTarget",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub alpha_target: ::std::option::Option<ForceTransformAlphaTarget>,
@@ -12307,13 +12131,12 @@ pub struct ForceTransform {
     pub forces: ::std::vec::Vec<ForceTransformForcesItem>,
     #[serde(default = "defaults::force_transform_iterations")]
     pub iterations: ForceTransformIterations,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub restart: ::std::option::Option<ForceTransformRestart>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(
         rename = "static",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub static_: ::std::option::Option<ForceTransformStatic>,
@@ -12431,16 +12254,16 @@ impl ::std::convert::From<SignalRef> for ForceTransformAsArrayItem {
 pub enum ForceTransformForcesItem {
     #[serde(rename = "center")]
     Center {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         x: ::std::option::Option<ForceTransformForcesItemX>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         y: ::std::option::Option<ForceTransformForcesItemY>,
     },
     #[serde(rename = "collide")]
     Collide {
         #[serde(default = "defaults::force_transform_forces_item_collide_iterations")]
         iterations: ForceTransformForcesItemIterations,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         radius: ::std::option::Option<ForceTransformForcesItemRadius>,
         #[serde(default = "defaults::force_transform_forces_item_collide_strength")]
         strength: ForceTransformForcesItemStrength,
@@ -12449,7 +12272,6 @@ pub enum ForceTransformForcesItem {
     Nbody {
         #[serde(
             rename = "distanceMax",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         distance_max: ::std::option::Option<ForceTransformForcesItemDistanceMax>,
@@ -12467,27 +12289,27 @@ pub enum ForceTransformForcesItem {
     Link {
         #[serde(default = "defaults::force_transform_forces_item_link_distance")]
         distance: ForceTransformForcesItemDistance,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         id: ::std::option::Option<ForceTransformForcesItemId>,
         #[serde(default = "defaults::force_transform_forces_item_link_iterations")]
         iterations: ForceTransformForcesItemIterations,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         links: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         strength: ::std::option::Option<ForceTransformForcesItemStrength>,
     },
     #[serde(rename = "x")]
     X {
         #[serde(default = "defaults::force_transform_forces_item_x_strength")]
         strength: ForceTransformForcesItemStrength,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         x: ::std::option::Option<ForceTransformForcesItemX>,
     },
     #[serde(rename = "y")]
     Y {
         #[serde(default = "defaults::force_transform_forces_item_y_strength")]
         strength: ForceTransformForcesItemStrength,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         y: ::std::option::Option<ForceTransformForcesItemY>,
     },
 }
@@ -12848,9 +12670,9 @@ pub struct FormulaTransform {
     #[serde(rename = "as")]
     pub as_: FormulaTransformAs,
     pub expr: ExprString,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub initonly: ::std::option::Option<FormulaTransformInitonly>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]
     pub type_: FormulaTransformType,
@@ -12935,18 +12757,18 @@ impl ::std::convert::TryFrom<::std::string::String> for FormulaTransformType {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct From {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub data: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`GeojsonTransform`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct GeojsonTransform {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub fields: ::std::option::Option<GeojsonTransformFields>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub geojson: ::std::option::Option<GeojsonTransformGeojson>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]
     pub type_: GeojsonTransformType,
@@ -13067,17 +12889,16 @@ impl ::std::convert::TryFrom<::std::string::String> for GeojsonTransformType {
 pub struct GeopathTransform {
     #[serde(rename = "as", default = "defaults::geopath_transform_as")]
     pub as_: GeopathTransformAs,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub field: ::std::option::Option<GeopathTransformField>,
     #[serde(
         rename = "pointRadius",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub point_radius: ::std::option::Option<GeopathTransformPointRadius>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub projection: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]
     pub type_: GeopathTransformType,
@@ -13206,7 +13027,7 @@ pub struct GeopointTransform {
     pub as_: GeopointTransformAs,
     pub fields: GeopointTransformFields,
     pub projection: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]
     pub type_: GeopointTransformType,
@@ -13345,13 +13166,12 @@ pub struct GeoshapeTransform {
     pub field: GeoshapeTransformField,
     #[serde(
         rename = "pointRadius",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub point_radius: ::std::option::Option<GeoshapeTransformPointRadius>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub projection: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]
     pub type_: GeoshapeTransformType,
@@ -13508,25 +13328,23 @@ pub struct GradientStopsItem {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct GraticuleTransform {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub extent: ::std::option::Option<GraticuleTransformExtent>,
     #[serde(
         rename = "extentMajor",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub extent_major: ::std::option::Option<GraticuleTransformExtentMajor>,
     #[serde(
         rename = "extentMinor",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub extent_minor: ::std::option::Option<GraticuleTransformExtentMinor>,
     #[serde(default = "defaults::graticule_transform_precision")]
     pub precision: GraticuleTransformPrecision,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub step: ::std::option::Option<GraticuleTransformStep>,
     #[serde(
         rename = "stepMajor",
@@ -13789,9 +13607,9 @@ impl ::std::convert::TryFrom<::std::string::String> for GraticuleTransformType {
 pub struct GuideEncode {
     #[serde(default)]
     pub interactive: bool,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub style: ::std::option::Option<Style>,
 }
 #[doc = "`HeatmapTransform`"]
@@ -13800,15 +13618,15 @@ pub struct GuideEncode {
 pub struct HeatmapTransform {
     #[serde(rename = "as", default = "defaults::heatmap_transform_as")]
     pub as_: HeatmapTransformAs,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub color: ::std::option::Option<HeatmapTransformColor>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub field: ::std::option::Option<HeatmapTransformField>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub opacity: ::std::option::Option<HeatmapTransformOpacity>,
     #[serde(default = "defaults::heatmap_transform_resolve")]
     pub resolve: HeatmapTransformResolve,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]
     pub type_: HeatmapTransformType,
@@ -14032,7 +13850,7 @@ impl ::std::convert::TryFrom<::std::string::String> for HeatmapTransformType {
 pub struct IdentifierTransform {
     #[serde(rename = "as")]
     pub as_: IdentifierTransformAs,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]
     pub type_: IdentifierTransformType,
@@ -14101,18 +13919,18 @@ impl ::std::convert::TryFrom<::std::string::String> for IdentifierTransformType 
 #[serde(deny_unknown_fields)]
 pub struct ImputeTransform {
     pub field: ImputeTransformField,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub groupby: ::std::option::Option<ImputeTransformGroupby>,
     pub key: ImputeTransformKey,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub keyvals: ::std::option::Option<ImputeTransformKeyvals>,
     #[serde(default = "defaults::impute_transform_method")]
     pub method: ImputeTransformMethod,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]
     pub type_: ImputeTransformType,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub value: ::std::option::Option<::serde_json::Value>,
 }
 #[doc = "`ImputeTransformField`"]
@@ -14358,23 +14176,23 @@ impl ::std::convert::TryFrom<::std::string::String> for ImputeTransformType {
 pub struct IsocontourTransform {
     #[serde(rename = "as", default = "defaults::isocontour_transform_as")]
     pub as_: IsocontourTransformAs,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub field: ::std::option::Option<IsocontourTransformField>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub levels: ::std::option::Option<IsocontourTransformLevels>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub nice: ::std::option::Option<IsocontourTransformNice>,
     #[serde(default = "defaults::isocontour_transform_resolve")]
     pub resolve: IsocontourTransformResolve,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub scale: ::std::option::Option<IsocontourTransformScale>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(default = "defaults::isocontour_transform_smooth")]
     pub smooth: IsocontourTransformSmooth,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub thresholds: ::std::option::Option<IsocontourTransformThresholds>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub translate: ::std::option::Option<IsocontourTransformTranslate>,
     #[serde(rename = "type")]
     pub type_: IsocontourTransformType,
@@ -14737,21 +14555,17 @@ impl ::std::convert::From<SignalRef> for IsocontourTransformZero {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct JoinaggregateTransform {
-    #[serde(
-        rename = "as",
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
+    #[serde(rename = "as", skip_serializing_if = "::std::option::Option::is_none")]
     pub as_: ::std::option::Option<JoinaggregateTransformAs>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub fields: ::std::option::Option<JoinaggregateTransformFields>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub groupby: ::std::option::Option<JoinaggregateTransformGroupby>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub key: ::std::option::Option<JoinaggregateTransformKey>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub ops: ::std::option::Option<JoinaggregateTransformOps>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]
     pub type_: JoinaggregateTransformType,
@@ -15126,24 +14940,23 @@ impl ::std::convert::TryFrom<::std::string::String> for JoinaggregateTransformTy
 pub struct Kde2dTransform {
     #[serde(rename = "as", default = "defaults::kde2d_transform_as")]
     pub as_: Kde2dTransformAs,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub bandwidth: ::std::option::Option<Kde2dTransformBandwidth>,
     #[serde(
         rename = "cellSize",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub cell_size: ::std::option::Option<Kde2dTransformCellSize>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub counts: ::std::option::Option<Kde2dTransformCounts>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub groupby: ::std::option::Option<Kde2dTransformGroupby>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     pub size: Kde2dTransformSize,
     #[serde(rename = "type")]
     pub type_: Kde2dTransformType,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub weight: ::std::option::Option<Kde2dTransformWeight>,
     pub x: Kde2dTransformX,
     pub y: Kde2dTransformY,
@@ -15431,16 +15244,16 @@ impl ::std::convert::From<Expr> for Kde2dTransformY {
 pub struct KdeTransform {
     #[serde(rename = "as", default = "defaults::kde_transform_as")]
     pub as_: KdeTransformAs,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub bandwidth: ::std::option::Option<KdeTransformBandwidth>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub counts: ::std::option::Option<KdeTransformCounts>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub cumulative: ::std::option::Option<KdeTransformCumulative>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub extent: ::std::option::Option<KdeTransformExtent>,
     pub field: KdeTransformField,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub groupby: ::std::option::Option<KdeTransformGroupby>,
     #[serde(default = "defaults::kde_transform_maxsteps")]
     pub maxsteps: KdeTransformMaxsteps,
@@ -15448,9 +15261,9 @@ pub struct KdeTransform {
     pub minsteps: KdeTransformMinsteps,
     #[serde(default = "defaults::kde_transform_resolve")]
     pub resolve: KdeTransformResolve,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub steps: ::std::option::Option<KdeTransformSteps>,
     #[serde(rename = "type")]
     pub type_: KdeTransformType,
@@ -15910,7 +15723,6 @@ pub struct LabelTransform {
     pub avoid_base_mark: LabelTransformAvoidBaseMark,
     #[serde(
         rename = "avoidMarks",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub avoid_marks: ::std::option::Option<LabelTransformAvoidMarks>,
@@ -15921,7 +15733,6 @@ pub struct LabelTransform {
     pub line_anchor: LabelTransformLineAnchor,
     #[serde(
         rename = "markIndex",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub mark_index: ::std::option::Option<LabelTransformMarkIndex>,
@@ -15929,12 +15740,12 @@ pub struct LabelTransform {
     pub method: LabelTransformMethod,
     #[serde(default = "defaults::label_transform_offset")]
     pub offset: LabelTransformOffset,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub padding: ::std::option::Option<LabelTransformPadding>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     pub size: LabelTransformSize,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub sort: ::std::option::Option<Compare>,
     #[serde(rename = "type")]
     pub type_: LabelTransformType,
@@ -16255,39 +16066,35 @@ impl ::std::convert::TryFrom<::std::string::String> for LabelTransformType {
 #[serde(untagged, deny_unknown_fields)]
 pub enum Layout {
     Object {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         align: ::std::option::Option<LayoutObjectAlign>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         bounds: ::std::option::Option<LayoutObjectBounds>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         center: ::std::option::Option<LayoutObjectCenter>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         columns: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "footerBand",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         footer_band: ::std::option::Option<LayoutObjectFooterBand>,
         #[serde(
             rename = "headerBand",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         header_band: ::std::option::Option<LayoutObjectHeaderBand>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         offset: ::std::option::Option<LayoutObjectOffset>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         padding: ::std::option::Option<LayoutObjectPadding>,
         #[serde(
             rename = "titleAnchor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_anchor: ::std::option::Option<LayoutObjectTitleAnchor>,
         #[serde(
             rename = "titleBand",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_band: ::std::option::Option<LayoutObjectTitleBand>,
@@ -16305,9 +16112,9 @@ impl ::std::convert::From<SignalRef> for Layout {
 pub enum LayoutObjectAlign {
     Variant0(LayoutObjectAlignVariant0),
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         column: ::std::option::Option<LayoutObjectAlignVariant1Column>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         row: ::std::option::Option<LayoutObjectAlignVariant1Row>,
     },
 }
@@ -16609,9 +16416,9 @@ pub enum LayoutObjectCenter {
     Boolean(bool),
     SignalRef(SignalRef),
     Object {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         column: ::std::option::Option<BooleanOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         row: ::std::option::Option<BooleanOrSignal>,
     },
 }
@@ -16632,9 +16439,9 @@ pub enum LayoutObjectFooterBand {
     NumberOrSignal(NumberOrSignal),
     Null,
     Object {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         column: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         row: ::std::option::Option<NumberOrSignal>,
     },
 }
@@ -16650,9 +16457,9 @@ pub enum LayoutObjectHeaderBand {
     NumberOrSignal(NumberOrSignal),
     Null,
     Object {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         column: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         row: ::std::option::Option<NumberOrSignal>,
     },
 }
@@ -16670,37 +16477,31 @@ pub enum LayoutObjectOffset {
     Object {
         #[serde(
             rename = "columnFooter",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         column_footer: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "columnHeader",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         column_header: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "columnTitle",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         column_title: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "rowFooter",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         row_footer: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "rowHeader",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         row_header: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "rowTitle",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         row_title: ::std::option::Option<NumberOrSignal>,
@@ -16723,9 +16524,9 @@ pub enum LayoutObjectPadding {
     Number(f64),
     SignalRef(SignalRef),
     Object {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         column: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         row: ::std::option::Option<NumberOrSignal>,
     },
 }
@@ -16745,9 +16546,9 @@ impl ::std::convert::From<SignalRef> for LayoutObjectPadding {
 pub enum LayoutObjectTitleAnchor {
     Variant0(LayoutObjectTitleAnchorVariant0),
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         column: ::std::option::Option<LayoutObjectTitleAnchorVariant1Column>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         row: ::std::option::Option<LayoutObjectTitleAnchorVariant1Row>,
     },
 }
@@ -16975,9 +16776,9 @@ pub enum LayoutObjectTitleBand {
     NumberOrSignal(NumberOrSignal),
     Null,
     Object {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         column: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         row: ::std::option::Option<NumberOrSignal>,
     },
 }
@@ -16991,1908 +16792,1616 @@ impl ::std::convert::From<NumberOrSignal> for LayoutObjectTitleBand {
 #[serde(untagged, deny_unknown_fields)]
 pub enum Legend {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         aria: ::std::option::Option<bool>,
         #[serde(
             rename = "clipHeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         clip_height: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "columnPadding",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         column_padding: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         columns: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "cornerRadius",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         corner_radius: ::std::option::Option<LegendVariant0CornerRadius>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         description: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         direction: ::std::option::Option<LegendVariant0Direction>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         encode: ::std::option::Option<LegendVariant0Encode>,
         #[serde(
             rename = "fillColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         fill_color: ::std::option::Option<LegendVariant0FillColor>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         format: ::std::option::Option<LegendVariant0Format>,
         #[serde(
             rename = "formatType",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         format_type: ::std::option::Option<LegendVariant0FormatType>,
         #[serde(
             rename = "gradientLength",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_length: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "gradientOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_opacity: ::std::option::Option<LegendVariant0GradientOpacity>,
         #[serde(
             rename = "gradientStrokeColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_stroke_color: ::std::option::Option<LegendVariant0GradientStrokeColor>,
         #[serde(
             rename = "gradientStrokeWidth",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_stroke_width: ::std::option::Option<LegendVariant0GradientStrokeWidth>,
         #[serde(
             rename = "gradientThickness",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_thickness: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "gridAlign",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         grid_align: ::std::option::Option<LegendVariant0GridAlign>,
         #[serde(
             rename = "labelAlign",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_align: ::std::option::Option<LegendVariant0LabelAlign>,
         #[serde(
             rename = "labelBaseline",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_baseline: ::std::option::Option<LegendVariant0LabelBaseline>,
         #[serde(
             rename = "labelColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_color: ::std::option::Option<LegendVariant0LabelColor>,
         #[serde(
             rename = "labelFont",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font: ::std::option::Option<LegendVariant0LabelFont>,
         #[serde(
             rename = "labelFontSize",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font_size: ::std::option::Option<LegendVariant0LabelFontSize>,
         #[serde(
             rename = "labelFontStyle",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font_style: ::std::option::Option<LegendVariant0LabelFontStyle>,
         #[serde(
             rename = "labelFontWeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font_weight: ::std::option::Option<LegendVariant0LabelFontWeight>,
         #[serde(
             rename = "labelLimit",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_limit: ::std::option::Option<LegendVariant0LabelLimit>,
         #[serde(
             rename = "labelOffset",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_offset: ::std::option::Option<LegendVariant0LabelOffset>,
         #[serde(
             rename = "labelOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_opacity: ::std::option::Option<LegendVariant0LabelOpacity>,
         #[serde(
             rename = "labelOverlap",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_overlap: ::std::option::Option<LabelOverlap>,
         #[serde(
             rename = "labelSeparation",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_separation: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "legendX",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         legend_x: ::std::option::Option<LegendVariant0LegendX>,
         #[serde(
             rename = "legendY",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         legend_y: ::std::option::Option<LegendVariant0LegendY>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         offset: ::std::option::Option<LegendVariant0Offset>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         orient: ::std::option::Option<LegendVariant0Orient>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         padding: ::std::option::Option<LegendVariant0Padding>,
         #[serde(
             rename = "rowPadding",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         row_padding: ::std::option::Option<NumberOrSignal>,
         size: ::std::string::String,
         #[serde(
             rename = "strokeColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         stroke_color: ::std::option::Option<LegendVariant0StrokeColor>,
         #[serde(
             rename = "symbolDash",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_dash: ::std::option::Option<LegendVariant0SymbolDash>,
         #[serde(
             rename = "symbolDashOffset",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_dash_offset: ::std::option::Option<LegendVariant0SymbolDashOffset>,
         #[serde(
             rename = "symbolFillColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_fill_color: ::std::option::Option<LegendVariant0SymbolFillColor>,
         #[serde(
             rename = "symbolLimit",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_limit: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "symbolOffset",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_offset: ::std::option::Option<LegendVariant0SymbolOffset>,
         #[serde(
             rename = "symbolOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_opacity: ::std::option::Option<LegendVariant0SymbolOpacity>,
         #[serde(
             rename = "symbolSize",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_size: ::std::option::Option<LegendVariant0SymbolSize>,
         #[serde(
             rename = "symbolStrokeColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_stroke_color: ::std::option::Option<LegendVariant0SymbolStrokeColor>,
         #[serde(
             rename = "symbolStrokeWidth",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_stroke_width: ::std::option::Option<LegendVariant0SymbolStrokeWidth>,
         #[serde(
             rename = "symbolType",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_type: ::std::option::Option<LegendVariant0SymbolType>,
         #[serde(
             rename = "tickCount",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         tick_count: ::std::option::Option<TickCount>,
         #[serde(
             rename = "tickMinStep",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         tick_min_step: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         title: ::std::option::Option<TextOrSignal>,
         #[serde(
             rename = "titleAlign",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_align: ::std::option::Option<LegendVariant0TitleAlign>,
         #[serde(
             rename = "titleAnchor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_anchor: ::std::option::Option<LegendVariant0TitleAnchor>,
         #[serde(
             rename = "titleBaseline",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_baseline: ::std::option::Option<LegendVariant0TitleBaseline>,
         #[serde(
             rename = "titleColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_color: ::std::option::Option<LegendVariant0TitleColor>,
         #[serde(
             rename = "titleFont",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font: ::std::option::Option<LegendVariant0TitleFont>,
         #[serde(
             rename = "titleFontSize",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font_size: ::std::option::Option<LegendVariant0TitleFontSize>,
         #[serde(
             rename = "titleFontStyle",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font_style: ::std::option::Option<LegendVariant0TitleFontStyle>,
         #[serde(
             rename = "titleFontWeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font_weight: ::std::option::Option<LegendVariant0TitleFontWeight>,
         #[serde(
             rename = "titleLimit",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_limit: ::std::option::Option<LegendVariant0TitleLimit>,
         #[serde(
             rename = "titleLineHeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_line_height: ::std::option::Option<LegendVariant0TitleLineHeight>,
         #[serde(
             rename = "titleOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_opacity: ::std::option::Option<LegendVariant0TitleOpacity>,
         #[serde(
             rename = "titleOrient",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_orient: ::std::option::Option<LegendVariant0TitleOrient>,
         #[serde(
             rename = "titlePadding",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_padding: ::std::option::Option<LegendVariant0TitlePadding>,
         #[serde(
             rename = "type",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         type_: ::std::option::Option<LegendVariant0Type>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         values: ::std::option::Option<ArrayOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         zindex: ::std::option::Option<f64>,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         aria: ::std::option::Option<bool>,
         #[serde(
             rename = "clipHeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         clip_height: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "columnPadding",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         column_padding: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         columns: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "cornerRadius",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         corner_radius: ::std::option::Option<LegendVariant1CornerRadius>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         description: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         direction: ::std::option::Option<LegendVariant1Direction>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         encode: ::std::option::Option<LegendVariant1Encode>,
         #[serde(
             rename = "fillColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         fill_color: ::std::option::Option<LegendVariant1FillColor>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         format: ::std::option::Option<LegendVariant1Format>,
         #[serde(
             rename = "formatType",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         format_type: ::std::option::Option<LegendVariant1FormatType>,
         #[serde(
             rename = "gradientLength",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_length: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "gradientOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_opacity: ::std::option::Option<LegendVariant1GradientOpacity>,
         #[serde(
             rename = "gradientStrokeColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_stroke_color: ::std::option::Option<LegendVariant1GradientStrokeColor>,
         #[serde(
             rename = "gradientStrokeWidth",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_stroke_width: ::std::option::Option<LegendVariant1GradientStrokeWidth>,
         #[serde(
             rename = "gradientThickness",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_thickness: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "gridAlign",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         grid_align: ::std::option::Option<LegendVariant1GridAlign>,
         #[serde(
             rename = "labelAlign",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_align: ::std::option::Option<LegendVariant1LabelAlign>,
         #[serde(
             rename = "labelBaseline",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_baseline: ::std::option::Option<LegendVariant1LabelBaseline>,
         #[serde(
             rename = "labelColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_color: ::std::option::Option<LegendVariant1LabelColor>,
         #[serde(
             rename = "labelFont",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font: ::std::option::Option<LegendVariant1LabelFont>,
         #[serde(
             rename = "labelFontSize",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font_size: ::std::option::Option<LegendVariant1LabelFontSize>,
         #[serde(
             rename = "labelFontStyle",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font_style: ::std::option::Option<LegendVariant1LabelFontStyle>,
         #[serde(
             rename = "labelFontWeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font_weight: ::std::option::Option<LegendVariant1LabelFontWeight>,
         #[serde(
             rename = "labelLimit",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_limit: ::std::option::Option<LegendVariant1LabelLimit>,
         #[serde(
             rename = "labelOffset",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_offset: ::std::option::Option<LegendVariant1LabelOffset>,
         #[serde(
             rename = "labelOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_opacity: ::std::option::Option<LegendVariant1LabelOpacity>,
         #[serde(
             rename = "labelOverlap",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_overlap: ::std::option::Option<LabelOverlap>,
         #[serde(
             rename = "labelSeparation",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_separation: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "legendX",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         legend_x: ::std::option::Option<LegendVariant1LegendX>,
         #[serde(
             rename = "legendY",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         legend_y: ::std::option::Option<LegendVariant1LegendY>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         offset: ::std::option::Option<LegendVariant1Offset>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         orient: ::std::option::Option<LegendVariant1Orient>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         padding: ::std::option::Option<LegendVariant1Padding>,
         #[serde(
             rename = "rowPadding",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         row_padding: ::std::option::Option<NumberOrSignal>,
         shape: ::std::string::String,
         #[serde(
             rename = "strokeColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         stroke_color: ::std::option::Option<LegendVariant1StrokeColor>,
         #[serde(
             rename = "symbolDash",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_dash: ::std::option::Option<LegendVariant1SymbolDash>,
         #[serde(
             rename = "symbolDashOffset",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_dash_offset: ::std::option::Option<LegendVariant1SymbolDashOffset>,
         #[serde(
             rename = "symbolFillColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_fill_color: ::std::option::Option<LegendVariant1SymbolFillColor>,
         #[serde(
             rename = "symbolLimit",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_limit: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "symbolOffset",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_offset: ::std::option::Option<LegendVariant1SymbolOffset>,
         #[serde(
             rename = "symbolOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_opacity: ::std::option::Option<LegendVariant1SymbolOpacity>,
         #[serde(
             rename = "symbolSize",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_size: ::std::option::Option<LegendVariant1SymbolSize>,
         #[serde(
             rename = "symbolStrokeColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_stroke_color: ::std::option::Option<LegendVariant1SymbolStrokeColor>,
         #[serde(
             rename = "symbolStrokeWidth",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_stroke_width: ::std::option::Option<LegendVariant1SymbolStrokeWidth>,
         #[serde(
             rename = "symbolType",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_type: ::std::option::Option<LegendVariant1SymbolType>,
         #[serde(
             rename = "tickCount",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         tick_count: ::std::option::Option<TickCount>,
         #[serde(
             rename = "tickMinStep",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         tick_min_step: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         title: ::std::option::Option<TextOrSignal>,
         #[serde(
             rename = "titleAlign",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_align: ::std::option::Option<LegendVariant1TitleAlign>,
         #[serde(
             rename = "titleAnchor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_anchor: ::std::option::Option<LegendVariant1TitleAnchor>,
         #[serde(
             rename = "titleBaseline",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_baseline: ::std::option::Option<LegendVariant1TitleBaseline>,
         #[serde(
             rename = "titleColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_color: ::std::option::Option<LegendVariant1TitleColor>,
         #[serde(
             rename = "titleFont",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font: ::std::option::Option<LegendVariant1TitleFont>,
         #[serde(
             rename = "titleFontSize",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font_size: ::std::option::Option<LegendVariant1TitleFontSize>,
         #[serde(
             rename = "titleFontStyle",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font_style: ::std::option::Option<LegendVariant1TitleFontStyle>,
         #[serde(
             rename = "titleFontWeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font_weight: ::std::option::Option<LegendVariant1TitleFontWeight>,
         #[serde(
             rename = "titleLimit",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_limit: ::std::option::Option<LegendVariant1TitleLimit>,
         #[serde(
             rename = "titleLineHeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_line_height: ::std::option::Option<LegendVariant1TitleLineHeight>,
         #[serde(
             rename = "titleOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_opacity: ::std::option::Option<LegendVariant1TitleOpacity>,
         #[serde(
             rename = "titleOrient",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_orient: ::std::option::Option<LegendVariant1TitleOrient>,
         #[serde(
             rename = "titlePadding",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_padding: ::std::option::Option<LegendVariant1TitlePadding>,
         #[serde(
             rename = "type",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         type_: ::std::option::Option<LegendVariant1Type>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         values: ::std::option::Option<ArrayOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         zindex: ::std::option::Option<f64>,
     },
     Variant2 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         aria: ::std::option::Option<bool>,
         #[serde(
             rename = "clipHeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         clip_height: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "columnPadding",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         column_padding: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         columns: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "cornerRadius",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         corner_radius: ::std::option::Option<LegendVariant2CornerRadius>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         description: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         direction: ::std::option::Option<LegendVariant2Direction>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         encode: ::std::option::Option<LegendVariant2Encode>,
         fill: ::std::string::String,
         #[serde(
             rename = "fillColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         fill_color: ::std::option::Option<LegendVariant2FillColor>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         format: ::std::option::Option<LegendVariant2Format>,
         #[serde(
             rename = "formatType",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         format_type: ::std::option::Option<LegendVariant2FormatType>,
         #[serde(
             rename = "gradientLength",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_length: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "gradientOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_opacity: ::std::option::Option<LegendVariant2GradientOpacity>,
         #[serde(
             rename = "gradientStrokeColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_stroke_color: ::std::option::Option<LegendVariant2GradientStrokeColor>,
         #[serde(
             rename = "gradientStrokeWidth",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_stroke_width: ::std::option::Option<LegendVariant2GradientStrokeWidth>,
         #[serde(
             rename = "gradientThickness",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_thickness: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "gridAlign",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         grid_align: ::std::option::Option<LegendVariant2GridAlign>,
         #[serde(
             rename = "labelAlign",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_align: ::std::option::Option<LegendVariant2LabelAlign>,
         #[serde(
             rename = "labelBaseline",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_baseline: ::std::option::Option<LegendVariant2LabelBaseline>,
         #[serde(
             rename = "labelColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_color: ::std::option::Option<LegendVariant2LabelColor>,
         #[serde(
             rename = "labelFont",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font: ::std::option::Option<LegendVariant2LabelFont>,
         #[serde(
             rename = "labelFontSize",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font_size: ::std::option::Option<LegendVariant2LabelFontSize>,
         #[serde(
             rename = "labelFontStyle",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font_style: ::std::option::Option<LegendVariant2LabelFontStyle>,
         #[serde(
             rename = "labelFontWeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font_weight: ::std::option::Option<LegendVariant2LabelFontWeight>,
         #[serde(
             rename = "labelLimit",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_limit: ::std::option::Option<LegendVariant2LabelLimit>,
         #[serde(
             rename = "labelOffset",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_offset: ::std::option::Option<LegendVariant2LabelOffset>,
         #[serde(
             rename = "labelOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_opacity: ::std::option::Option<LegendVariant2LabelOpacity>,
         #[serde(
             rename = "labelOverlap",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_overlap: ::std::option::Option<LabelOverlap>,
         #[serde(
             rename = "labelSeparation",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_separation: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "legendX",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         legend_x: ::std::option::Option<LegendVariant2LegendX>,
         #[serde(
             rename = "legendY",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         legend_y: ::std::option::Option<LegendVariant2LegendY>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         offset: ::std::option::Option<LegendVariant2Offset>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         orient: ::std::option::Option<LegendVariant2Orient>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         padding: ::std::option::Option<LegendVariant2Padding>,
         #[serde(
             rename = "rowPadding",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         row_padding: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "strokeColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         stroke_color: ::std::option::Option<LegendVariant2StrokeColor>,
         #[serde(
             rename = "symbolDash",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_dash: ::std::option::Option<LegendVariant2SymbolDash>,
         #[serde(
             rename = "symbolDashOffset",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_dash_offset: ::std::option::Option<LegendVariant2SymbolDashOffset>,
         #[serde(
             rename = "symbolFillColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_fill_color: ::std::option::Option<LegendVariant2SymbolFillColor>,
         #[serde(
             rename = "symbolLimit",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_limit: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "symbolOffset",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_offset: ::std::option::Option<LegendVariant2SymbolOffset>,
         #[serde(
             rename = "symbolOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_opacity: ::std::option::Option<LegendVariant2SymbolOpacity>,
         #[serde(
             rename = "symbolSize",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_size: ::std::option::Option<LegendVariant2SymbolSize>,
         #[serde(
             rename = "symbolStrokeColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_stroke_color: ::std::option::Option<LegendVariant2SymbolStrokeColor>,
         #[serde(
             rename = "symbolStrokeWidth",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_stroke_width: ::std::option::Option<LegendVariant2SymbolStrokeWidth>,
         #[serde(
             rename = "symbolType",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_type: ::std::option::Option<LegendVariant2SymbolType>,
         #[serde(
             rename = "tickCount",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         tick_count: ::std::option::Option<TickCount>,
         #[serde(
             rename = "tickMinStep",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         tick_min_step: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         title: ::std::option::Option<TextOrSignal>,
         #[serde(
             rename = "titleAlign",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_align: ::std::option::Option<LegendVariant2TitleAlign>,
         #[serde(
             rename = "titleAnchor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_anchor: ::std::option::Option<LegendVariant2TitleAnchor>,
         #[serde(
             rename = "titleBaseline",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_baseline: ::std::option::Option<LegendVariant2TitleBaseline>,
         #[serde(
             rename = "titleColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_color: ::std::option::Option<LegendVariant2TitleColor>,
         #[serde(
             rename = "titleFont",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font: ::std::option::Option<LegendVariant2TitleFont>,
         #[serde(
             rename = "titleFontSize",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font_size: ::std::option::Option<LegendVariant2TitleFontSize>,
         #[serde(
             rename = "titleFontStyle",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font_style: ::std::option::Option<LegendVariant2TitleFontStyle>,
         #[serde(
             rename = "titleFontWeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font_weight: ::std::option::Option<LegendVariant2TitleFontWeight>,
         #[serde(
             rename = "titleLimit",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_limit: ::std::option::Option<LegendVariant2TitleLimit>,
         #[serde(
             rename = "titleLineHeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_line_height: ::std::option::Option<LegendVariant2TitleLineHeight>,
         #[serde(
             rename = "titleOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_opacity: ::std::option::Option<LegendVariant2TitleOpacity>,
         #[serde(
             rename = "titleOrient",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_orient: ::std::option::Option<LegendVariant2TitleOrient>,
         #[serde(
             rename = "titlePadding",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_padding: ::std::option::Option<LegendVariant2TitlePadding>,
         #[serde(
             rename = "type",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         type_: ::std::option::Option<LegendVariant2Type>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         values: ::std::option::Option<ArrayOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         zindex: ::std::option::Option<f64>,
     },
     Variant3 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         aria: ::std::option::Option<bool>,
         #[serde(
             rename = "clipHeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         clip_height: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "columnPadding",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         column_padding: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         columns: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "cornerRadius",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         corner_radius: ::std::option::Option<LegendVariant3CornerRadius>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         description: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         direction: ::std::option::Option<LegendVariant3Direction>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         encode: ::std::option::Option<LegendVariant3Encode>,
         #[serde(
             rename = "fillColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         fill_color: ::std::option::Option<LegendVariant3FillColor>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         format: ::std::option::Option<LegendVariant3Format>,
         #[serde(
             rename = "formatType",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         format_type: ::std::option::Option<LegendVariant3FormatType>,
         #[serde(
             rename = "gradientLength",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_length: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "gradientOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_opacity: ::std::option::Option<LegendVariant3GradientOpacity>,
         #[serde(
             rename = "gradientStrokeColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_stroke_color: ::std::option::Option<LegendVariant3GradientStrokeColor>,
         #[serde(
             rename = "gradientStrokeWidth",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_stroke_width: ::std::option::Option<LegendVariant3GradientStrokeWidth>,
         #[serde(
             rename = "gradientThickness",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_thickness: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "gridAlign",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         grid_align: ::std::option::Option<LegendVariant3GridAlign>,
         #[serde(
             rename = "labelAlign",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_align: ::std::option::Option<LegendVariant3LabelAlign>,
         #[serde(
             rename = "labelBaseline",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_baseline: ::std::option::Option<LegendVariant3LabelBaseline>,
         #[serde(
             rename = "labelColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_color: ::std::option::Option<LegendVariant3LabelColor>,
         #[serde(
             rename = "labelFont",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font: ::std::option::Option<LegendVariant3LabelFont>,
         #[serde(
             rename = "labelFontSize",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font_size: ::std::option::Option<LegendVariant3LabelFontSize>,
         #[serde(
             rename = "labelFontStyle",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font_style: ::std::option::Option<LegendVariant3LabelFontStyle>,
         #[serde(
             rename = "labelFontWeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font_weight: ::std::option::Option<LegendVariant3LabelFontWeight>,
         #[serde(
             rename = "labelLimit",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_limit: ::std::option::Option<LegendVariant3LabelLimit>,
         #[serde(
             rename = "labelOffset",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_offset: ::std::option::Option<LegendVariant3LabelOffset>,
         #[serde(
             rename = "labelOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_opacity: ::std::option::Option<LegendVariant3LabelOpacity>,
         #[serde(
             rename = "labelOverlap",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_overlap: ::std::option::Option<LabelOverlap>,
         #[serde(
             rename = "labelSeparation",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_separation: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "legendX",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         legend_x: ::std::option::Option<LegendVariant3LegendX>,
         #[serde(
             rename = "legendY",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         legend_y: ::std::option::Option<LegendVariant3LegendY>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         offset: ::std::option::Option<LegendVariant3Offset>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         orient: ::std::option::Option<LegendVariant3Orient>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         padding: ::std::option::Option<LegendVariant3Padding>,
         #[serde(
             rename = "rowPadding",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         row_padding: ::std::option::Option<NumberOrSignal>,
         stroke: ::std::string::String,
         #[serde(
             rename = "strokeColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         stroke_color: ::std::option::Option<LegendVariant3StrokeColor>,
         #[serde(
             rename = "symbolDash",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_dash: ::std::option::Option<LegendVariant3SymbolDash>,
         #[serde(
             rename = "symbolDashOffset",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_dash_offset: ::std::option::Option<LegendVariant3SymbolDashOffset>,
         #[serde(
             rename = "symbolFillColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_fill_color: ::std::option::Option<LegendVariant3SymbolFillColor>,
         #[serde(
             rename = "symbolLimit",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_limit: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "symbolOffset",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_offset: ::std::option::Option<LegendVariant3SymbolOffset>,
         #[serde(
             rename = "symbolOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_opacity: ::std::option::Option<LegendVariant3SymbolOpacity>,
         #[serde(
             rename = "symbolSize",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_size: ::std::option::Option<LegendVariant3SymbolSize>,
         #[serde(
             rename = "symbolStrokeColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_stroke_color: ::std::option::Option<LegendVariant3SymbolStrokeColor>,
         #[serde(
             rename = "symbolStrokeWidth",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_stroke_width: ::std::option::Option<LegendVariant3SymbolStrokeWidth>,
         #[serde(
             rename = "symbolType",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_type: ::std::option::Option<LegendVariant3SymbolType>,
         #[serde(
             rename = "tickCount",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         tick_count: ::std::option::Option<TickCount>,
         #[serde(
             rename = "tickMinStep",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         tick_min_step: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         title: ::std::option::Option<TextOrSignal>,
         #[serde(
             rename = "titleAlign",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_align: ::std::option::Option<LegendVariant3TitleAlign>,
         #[serde(
             rename = "titleAnchor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_anchor: ::std::option::Option<LegendVariant3TitleAnchor>,
         #[serde(
             rename = "titleBaseline",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_baseline: ::std::option::Option<LegendVariant3TitleBaseline>,
         #[serde(
             rename = "titleColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_color: ::std::option::Option<LegendVariant3TitleColor>,
         #[serde(
             rename = "titleFont",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font: ::std::option::Option<LegendVariant3TitleFont>,
         #[serde(
             rename = "titleFontSize",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font_size: ::std::option::Option<LegendVariant3TitleFontSize>,
         #[serde(
             rename = "titleFontStyle",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font_style: ::std::option::Option<LegendVariant3TitleFontStyle>,
         #[serde(
             rename = "titleFontWeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font_weight: ::std::option::Option<LegendVariant3TitleFontWeight>,
         #[serde(
             rename = "titleLimit",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_limit: ::std::option::Option<LegendVariant3TitleLimit>,
         #[serde(
             rename = "titleLineHeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_line_height: ::std::option::Option<LegendVariant3TitleLineHeight>,
         #[serde(
             rename = "titleOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_opacity: ::std::option::Option<LegendVariant3TitleOpacity>,
         #[serde(
             rename = "titleOrient",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_orient: ::std::option::Option<LegendVariant3TitleOrient>,
         #[serde(
             rename = "titlePadding",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_padding: ::std::option::Option<LegendVariant3TitlePadding>,
         #[serde(
             rename = "type",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         type_: ::std::option::Option<LegendVariant3Type>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         values: ::std::option::Option<ArrayOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         zindex: ::std::option::Option<f64>,
     },
     Variant4 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         aria: ::std::option::Option<bool>,
         #[serde(
             rename = "clipHeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         clip_height: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "columnPadding",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         column_padding: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         columns: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "cornerRadius",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         corner_radius: ::std::option::Option<LegendVariant4CornerRadius>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         description: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         direction: ::std::option::Option<LegendVariant4Direction>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         encode: ::std::option::Option<LegendVariant4Encode>,
         #[serde(
             rename = "fillColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         fill_color: ::std::option::Option<LegendVariant4FillColor>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         format: ::std::option::Option<LegendVariant4Format>,
         #[serde(
             rename = "formatType",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         format_type: ::std::option::Option<LegendVariant4FormatType>,
         #[serde(
             rename = "gradientLength",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_length: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "gradientOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_opacity: ::std::option::Option<LegendVariant4GradientOpacity>,
         #[serde(
             rename = "gradientStrokeColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_stroke_color: ::std::option::Option<LegendVariant4GradientStrokeColor>,
         #[serde(
             rename = "gradientStrokeWidth",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_stroke_width: ::std::option::Option<LegendVariant4GradientStrokeWidth>,
         #[serde(
             rename = "gradientThickness",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_thickness: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "gridAlign",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         grid_align: ::std::option::Option<LegendVariant4GridAlign>,
         #[serde(
             rename = "labelAlign",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_align: ::std::option::Option<LegendVariant4LabelAlign>,
         #[serde(
             rename = "labelBaseline",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_baseline: ::std::option::Option<LegendVariant4LabelBaseline>,
         #[serde(
             rename = "labelColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_color: ::std::option::Option<LegendVariant4LabelColor>,
         #[serde(
             rename = "labelFont",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font: ::std::option::Option<LegendVariant4LabelFont>,
         #[serde(
             rename = "labelFontSize",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font_size: ::std::option::Option<LegendVariant4LabelFontSize>,
         #[serde(
             rename = "labelFontStyle",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font_style: ::std::option::Option<LegendVariant4LabelFontStyle>,
         #[serde(
             rename = "labelFontWeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font_weight: ::std::option::Option<LegendVariant4LabelFontWeight>,
         #[serde(
             rename = "labelLimit",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_limit: ::std::option::Option<LegendVariant4LabelLimit>,
         #[serde(
             rename = "labelOffset",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_offset: ::std::option::Option<LegendVariant4LabelOffset>,
         #[serde(
             rename = "labelOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_opacity: ::std::option::Option<LegendVariant4LabelOpacity>,
         #[serde(
             rename = "labelOverlap",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_overlap: ::std::option::Option<LabelOverlap>,
         #[serde(
             rename = "labelSeparation",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_separation: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "legendX",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         legend_x: ::std::option::Option<LegendVariant4LegendX>,
         #[serde(
             rename = "legendY",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         legend_y: ::std::option::Option<LegendVariant4LegendY>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         offset: ::std::option::Option<LegendVariant4Offset>,
         opacity: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         orient: ::std::option::Option<LegendVariant4Orient>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         padding: ::std::option::Option<LegendVariant4Padding>,
         #[serde(
             rename = "rowPadding",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         row_padding: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "strokeColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         stroke_color: ::std::option::Option<LegendVariant4StrokeColor>,
         #[serde(
             rename = "symbolDash",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_dash: ::std::option::Option<LegendVariant4SymbolDash>,
         #[serde(
             rename = "symbolDashOffset",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_dash_offset: ::std::option::Option<LegendVariant4SymbolDashOffset>,
         #[serde(
             rename = "symbolFillColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_fill_color: ::std::option::Option<LegendVariant4SymbolFillColor>,
         #[serde(
             rename = "symbolLimit",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_limit: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "symbolOffset",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_offset: ::std::option::Option<LegendVariant4SymbolOffset>,
         #[serde(
             rename = "symbolOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_opacity: ::std::option::Option<LegendVariant4SymbolOpacity>,
         #[serde(
             rename = "symbolSize",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_size: ::std::option::Option<LegendVariant4SymbolSize>,
         #[serde(
             rename = "symbolStrokeColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_stroke_color: ::std::option::Option<LegendVariant4SymbolStrokeColor>,
         #[serde(
             rename = "symbolStrokeWidth",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_stroke_width: ::std::option::Option<LegendVariant4SymbolStrokeWidth>,
         #[serde(
             rename = "symbolType",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_type: ::std::option::Option<LegendVariant4SymbolType>,
         #[serde(
             rename = "tickCount",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         tick_count: ::std::option::Option<TickCount>,
         #[serde(
             rename = "tickMinStep",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         tick_min_step: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         title: ::std::option::Option<TextOrSignal>,
         #[serde(
             rename = "titleAlign",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_align: ::std::option::Option<LegendVariant4TitleAlign>,
         #[serde(
             rename = "titleAnchor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_anchor: ::std::option::Option<LegendVariant4TitleAnchor>,
         #[serde(
             rename = "titleBaseline",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_baseline: ::std::option::Option<LegendVariant4TitleBaseline>,
         #[serde(
             rename = "titleColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_color: ::std::option::Option<LegendVariant4TitleColor>,
         #[serde(
             rename = "titleFont",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font: ::std::option::Option<LegendVariant4TitleFont>,
         #[serde(
             rename = "titleFontSize",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font_size: ::std::option::Option<LegendVariant4TitleFontSize>,
         #[serde(
             rename = "titleFontStyle",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font_style: ::std::option::Option<LegendVariant4TitleFontStyle>,
         #[serde(
             rename = "titleFontWeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font_weight: ::std::option::Option<LegendVariant4TitleFontWeight>,
         #[serde(
             rename = "titleLimit",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_limit: ::std::option::Option<LegendVariant4TitleLimit>,
         #[serde(
             rename = "titleLineHeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_line_height: ::std::option::Option<LegendVariant4TitleLineHeight>,
         #[serde(
             rename = "titleOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_opacity: ::std::option::Option<LegendVariant4TitleOpacity>,
         #[serde(
             rename = "titleOrient",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_orient: ::std::option::Option<LegendVariant4TitleOrient>,
         #[serde(
             rename = "titlePadding",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_padding: ::std::option::Option<LegendVariant4TitlePadding>,
         #[serde(
             rename = "type",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         type_: ::std::option::Option<LegendVariant4Type>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         values: ::std::option::Option<ArrayOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         zindex: ::std::option::Option<f64>,
     },
     Variant5 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         aria: ::std::option::Option<bool>,
         #[serde(
             rename = "clipHeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         clip_height: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "columnPadding",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         column_padding: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         columns: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "cornerRadius",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         corner_radius: ::std::option::Option<LegendVariant5CornerRadius>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         description: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         direction: ::std::option::Option<LegendVariant5Direction>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         encode: ::std::option::Option<LegendVariant5Encode>,
         #[serde(
             rename = "fillColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         fill_color: ::std::option::Option<LegendVariant5FillColor>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         format: ::std::option::Option<LegendVariant5Format>,
         #[serde(
             rename = "formatType",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         format_type: ::std::option::Option<LegendVariant5FormatType>,
         #[serde(
             rename = "gradientLength",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_length: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "gradientOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_opacity: ::std::option::Option<LegendVariant5GradientOpacity>,
         #[serde(
             rename = "gradientStrokeColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_stroke_color: ::std::option::Option<LegendVariant5GradientStrokeColor>,
         #[serde(
             rename = "gradientStrokeWidth",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_stroke_width: ::std::option::Option<LegendVariant5GradientStrokeWidth>,
         #[serde(
             rename = "gradientThickness",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_thickness: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "gridAlign",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         grid_align: ::std::option::Option<LegendVariant5GridAlign>,
         #[serde(
             rename = "labelAlign",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_align: ::std::option::Option<LegendVariant5LabelAlign>,
         #[serde(
             rename = "labelBaseline",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_baseline: ::std::option::Option<LegendVariant5LabelBaseline>,
         #[serde(
             rename = "labelColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_color: ::std::option::Option<LegendVariant5LabelColor>,
         #[serde(
             rename = "labelFont",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font: ::std::option::Option<LegendVariant5LabelFont>,
         #[serde(
             rename = "labelFontSize",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font_size: ::std::option::Option<LegendVariant5LabelFontSize>,
         #[serde(
             rename = "labelFontStyle",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font_style: ::std::option::Option<LegendVariant5LabelFontStyle>,
         #[serde(
             rename = "labelFontWeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font_weight: ::std::option::Option<LegendVariant5LabelFontWeight>,
         #[serde(
             rename = "labelLimit",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_limit: ::std::option::Option<LegendVariant5LabelLimit>,
         #[serde(
             rename = "labelOffset",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_offset: ::std::option::Option<LegendVariant5LabelOffset>,
         #[serde(
             rename = "labelOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_opacity: ::std::option::Option<LegendVariant5LabelOpacity>,
         #[serde(
             rename = "labelOverlap",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_overlap: ::std::option::Option<LabelOverlap>,
         #[serde(
             rename = "labelSeparation",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_separation: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "legendX",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         legend_x: ::std::option::Option<LegendVariant5LegendX>,
         #[serde(
             rename = "legendY",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         legend_y: ::std::option::Option<LegendVariant5LegendY>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         offset: ::std::option::Option<LegendVariant5Offset>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         orient: ::std::option::Option<LegendVariant5Orient>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         padding: ::std::option::Option<LegendVariant5Padding>,
         #[serde(
             rename = "rowPadding",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         row_padding: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "strokeColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         stroke_color: ::std::option::Option<LegendVariant5StrokeColor>,
@@ -18900,345 +18409,292 @@ pub enum Legend {
         stroke_dash: ::std::string::String,
         #[serde(
             rename = "symbolDash",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_dash: ::std::option::Option<LegendVariant5SymbolDash>,
         #[serde(
             rename = "symbolDashOffset",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_dash_offset: ::std::option::Option<LegendVariant5SymbolDashOffset>,
         #[serde(
             rename = "symbolFillColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_fill_color: ::std::option::Option<LegendVariant5SymbolFillColor>,
         #[serde(
             rename = "symbolLimit",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_limit: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "symbolOffset",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_offset: ::std::option::Option<LegendVariant5SymbolOffset>,
         #[serde(
             rename = "symbolOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_opacity: ::std::option::Option<LegendVariant5SymbolOpacity>,
         #[serde(
             rename = "symbolSize",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_size: ::std::option::Option<LegendVariant5SymbolSize>,
         #[serde(
             rename = "symbolStrokeColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_stroke_color: ::std::option::Option<LegendVariant5SymbolStrokeColor>,
         #[serde(
             rename = "symbolStrokeWidth",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_stroke_width: ::std::option::Option<LegendVariant5SymbolStrokeWidth>,
         #[serde(
             rename = "symbolType",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_type: ::std::option::Option<LegendVariant5SymbolType>,
         #[serde(
             rename = "tickCount",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         tick_count: ::std::option::Option<TickCount>,
         #[serde(
             rename = "tickMinStep",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         tick_min_step: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         title: ::std::option::Option<TextOrSignal>,
         #[serde(
             rename = "titleAlign",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_align: ::std::option::Option<LegendVariant5TitleAlign>,
         #[serde(
             rename = "titleAnchor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_anchor: ::std::option::Option<LegendVariant5TitleAnchor>,
         #[serde(
             rename = "titleBaseline",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_baseline: ::std::option::Option<LegendVariant5TitleBaseline>,
         #[serde(
             rename = "titleColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_color: ::std::option::Option<LegendVariant5TitleColor>,
         #[serde(
             rename = "titleFont",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font: ::std::option::Option<LegendVariant5TitleFont>,
         #[serde(
             rename = "titleFontSize",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font_size: ::std::option::Option<LegendVariant5TitleFontSize>,
         #[serde(
             rename = "titleFontStyle",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font_style: ::std::option::Option<LegendVariant5TitleFontStyle>,
         #[serde(
             rename = "titleFontWeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font_weight: ::std::option::Option<LegendVariant5TitleFontWeight>,
         #[serde(
             rename = "titleLimit",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_limit: ::std::option::Option<LegendVariant5TitleLimit>,
         #[serde(
             rename = "titleLineHeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_line_height: ::std::option::Option<LegendVariant5TitleLineHeight>,
         #[serde(
             rename = "titleOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_opacity: ::std::option::Option<LegendVariant5TitleOpacity>,
         #[serde(
             rename = "titleOrient",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_orient: ::std::option::Option<LegendVariant5TitleOrient>,
         #[serde(
             rename = "titlePadding",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_padding: ::std::option::Option<LegendVariant5TitlePadding>,
         #[serde(
             rename = "type",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         type_: ::std::option::Option<LegendVariant5Type>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         values: ::std::option::Option<ArrayOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         zindex: ::std::option::Option<f64>,
     },
     Variant6 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         aria: ::std::option::Option<bool>,
         #[serde(
             rename = "clipHeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         clip_height: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "columnPadding",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         column_padding: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         columns: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "cornerRadius",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         corner_radius: ::std::option::Option<LegendVariant6CornerRadius>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         description: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         direction: ::std::option::Option<LegendVariant6Direction>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         encode: ::std::option::Option<LegendVariant6Encode>,
         #[serde(
             rename = "fillColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         fill_color: ::std::option::Option<LegendVariant6FillColor>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         format: ::std::option::Option<LegendVariant6Format>,
         #[serde(
             rename = "formatType",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         format_type: ::std::option::Option<LegendVariant6FormatType>,
         #[serde(
             rename = "gradientLength",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_length: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "gradientOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_opacity: ::std::option::Option<LegendVariant6GradientOpacity>,
         #[serde(
             rename = "gradientStrokeColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_stroke_color: ::std::option::Option<LegendVariant6GradientStrokeColor>,
         #[serde(
             rename = "gradientStrokeWidth",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_stroke_width: ::std::option::Option<LegendVariant6GradientStrokeWidth>,
         #[serde(
             rename = "gradientThickness",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         gradient_thickness: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "gridAlign",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         grid_align: ::std::option::Option<LegendVariant6GridAlign>,
         #[serde(
             rename = "labelAlign",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_align: ::std::option::Option<LegendVariant6LabelAlign>,
         #[serde(
             rename = "labelBaseline",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_baseline: ::std::option::Option<LegendVariant6LabelBaseline>,
         #[serde(
             rename = "labelColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_color: ::std::option::Option<LegendVariant6LabelColor>,
         #[serde(
             rename = "labelFont",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font: ::std::option::Option<LegendVariant6LabelFont>,
         #[serde(
             rename = "labelFontSize",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font_size: ::std::option::Option<LegendVariant6LabelFontSize>,
         #[serde(
             rename = "labelFontStyle",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font_style: ::std::option::Option<LegendVariant6LabelFontStyle>,
         #[serde(
             rename = "labelFontWeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_font_weight: ::std::option::Option<LegendVariant6LabelFontWeight>,
         #[serde(
             rename = "labelLimit",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_limit: ::std::option::Option<LegendVariant6LabelLimit>,
         #[serde(
             rename = "labelOffset",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_offset: ::std::option::Option<LegendVariant6LabelOffset>,
         #[serde(
             rename = "labelOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_opacity: ::std::option::Option<LegendVariant6LabelOpacity>,
         #[serde(
             rename = "labelOverlap",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_overlap: ::std::option::Option<LabelOverlap>,
         #[serde(
             rename = "labelSeparation",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         label_separation: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "legendX",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         legend_x: ::std::option::Option<LegendVariant6LegendX>,
         #[serde(
             rename = "legendY",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         legend_y: ::std::option::Option<LegendVariant6LegendY>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         offset: ::std::option::Option<LegendVariant6Offset>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         orient: ::std::option::Option<LegendVariant6Orient>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         padding: ::std::option::Option<LegendVariant6Padding>,
         #[serde(
             rename = "rowPadding",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         row_padding: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "strokeColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         stroke_color: ::std::option::Option<LegendVariant6StrokeColor>,
@@ -19246,165 +18702,139 @@ pub enum Legend {
         stroke_width: ::std::string::String,
         #[serde(
             rename = "symbolDash",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_dash: ::std::option::Option<LegendVariant6SymbolDash>,
         #[serde(
             rename = "symbolDashOffset",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_dash_offset: ::std::option::Option<LegendVariant6SymbolDashOffset>,
         #[serde(
             rename = "symbolFillColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_fill_color: ::std::option::Option<LegendVariant6SymbolFillColor>,
         #[serde(
             rename = "symbolLimit",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_limit: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "symbolOffset",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_offset: ::std::option::Option<LegendVariant6SymbolOffset>,
         #[serde(
             rename = "symbolOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_opacity: ::std::option::Option<LegendVariant6SymbolOpacity>,
         #[serde(
             rename = "symbolSize",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_size: ::std::option::Option<LegendVariant6SymbolSize>,
         #[serde(
             rename = "symbolStrokeColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_stroke_color: ::std::option::Option<LegendVariant6SymbolStrokeColor>,
         #[serde(
             rename = "symbolStrokeWidth",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_stroke_width: ::std::option::Option<LegendVariant6SymbolStrokeWidth>,
         #[serde(
             rename = "symbolType",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         symbol_type: ::std::option::Option<LegendVariant6SymbolType>,
         #[serde(
             rename = "tickCount",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         tick_count: ::std::option::Option<TickCount>,
         #[serde(
             rename = "tickMinStep",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         tick_min_step: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         title: ::std::option::Option<TextOrSignal>,
         #[serde(
             rename = "titleAlign",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_align: ::std::option::Option<LegendVariant6TitleAlign>,
         #[serde(
             rename = "titleAnchor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_anchor: ::std::option::Option<LegendVariant6TitleAnchor>,
         #[serde(
             rename = "titleBaseline",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_baseline: ::std::option::Option<LegendVariant6TitleBaseline>,
         #[serde(
             rename = "titleColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_color: ::std::option::Option<LegendVariant6TitleColor>,
         #[serde(
             rename = "titleFont",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font: ::std::option::Option<LegendVariant6TitleFont>,
         #[serde(
             rename = "titleFontSize",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font_size: ::std::option::Option<LegendVariant6TitleFontSize>,
         #[serde(
             rename = "titleFontStyle",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font_style: ::std::option::Option<LegendVariant6TitleFontStyle>,
         #[serde(
             rename = "titleFontWeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_font_weight: ::std::option::Option<LegendVariant6TitleFontWeight>,
         #[serde(
             rename = "titleLimit",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_limit: ::std::option::Option<LegendVariant6TitleLimit>,
         #[serde(
             rename = "titleLineHeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_line_height: ::std::option::Option<LegendVariant6TitleLineHeight>,
         #[serde(
             rename = "titleOpacity",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_opacity: ::std::option::Option<LegendVariant6TitleOpacity>,
         #[serde(
             rename = "titleOrient",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_orient: ::std::option::Option<LegendVariant6TitleOrient>,
         #[serde(
             rename = "titlePadding",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         title_padding: ::std::option::Option<LegendVariant6TitlePadding>,
         #[serde(
             rename = "type",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         type_: ::std::option::Option<LegendVariant6Type>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         values: ::std::option::Option<ArrayOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         zindex: ::std::option::Option<f64>,
     },
 }
@@ -19480,17 +18910,17 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant0Direction 
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct LegendVariant0Encode {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub entries: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub gradient: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub labels: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub legend: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub symbols: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
 }
 #[doc = "`LegendVariant0FillColor`"]
@@ -19512,25 +18942,25 @@ impl ::std::convert::From<ColorValue> for LegendVariant0FillColor {
 pub enum LegendVariant0Format {
     String(::std::string::String),
     Object {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         date: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         day: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         hours: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         milliseconds: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         minutes: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         month: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         quarter: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         seconds: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         week: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         year: ::std::option::Option<::std::string::String>,
     },
     SignalRef(SignalRef),
@@ -20894,17 +20324,17 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant1Direction 
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct LegendVariant1Encode {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub entries: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub gradient: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub labels: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub legend: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub symbols: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
 }
 #[doc = "`LegendVariant1FillColor`"]
@@ -20926,25 +20356,25 @@ impl ::std::convert::From<ColorValue> for LegendVariant1FillColor {
 pub enum LegendVariant1Format {
     String(::std::string::String),
     Object {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         date: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         day: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         hours: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         milliseconds: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         minutes: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         month: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         quarter: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         seconds: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         week: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         year: ::std::option::Option<::std::string::String>,
     },
     SignalRef(SignalRef),
@@ -22308,17 +21738,17 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant2Direction 
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct LegendVariant2Encode {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub entries: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub gradient: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub labels: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub legend: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub symbols: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
 }
 #[doc = "`LegendVariant2FillColor`"]
@@ -22340,25 +21770,25 @@ impl ::std::convert::From<ColorValue> for LegendVariant2FillColor {
 pub enum LegendVariant2Format {
     String(::std::string::String),
     Object {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         date: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         day: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         hours: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         milliseconds: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         minutes: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         month: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         quarter: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         seconds: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         week: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         year: ::std::option::Option<::std::string::String>,
     },
     SignalRef(SignalRef),
@@ -23722,17 +23152,17 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant3Direction 
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct LegendVariant3Encode {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub entries: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub gradient: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub labels: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub legend: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub symbols: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
 }
 #[doc = "`LegendVariant3FillColor`"]
@@ -23754,25 +23184,25 @@ impl ::std::convert::From<ColorValue> for LegendVariant3FillColor {
 pub enum LegendVariant3Format {
     String(::std::string::String),
     Object {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         date: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         day: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         hours: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         milliseconds: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         minutes: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         month: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         quarter: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         seconds: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         week: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         year: ::std::option::Option<::std::string::String>,
     },
     SignalRef(SignalRef),
@@ -25136,17 +24566,17 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant4Direction 
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct LegendVariant4Encode {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub entries: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub gradient: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub labels: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub legend: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub symbols: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
 }
 #[doc = "`LegendVariant4FillColor`"]
@@ -25168,25 +24598,25 @@ impl ::std::convert::From<ColorValue> for LegendVariant4FillColor {
 pub enum LegendVariant4Format {
     String(::std::string::String),
     Object {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         date: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         day: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         hours: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         milliseconds: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         minutes: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         month: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         quarter: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         seconds: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         week: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         year: ::std::option::Option<::std::string::String>,
     },
     SignalRef(SignalRef),
@@ -26550,17 +25980,17 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant5Direction 
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct LegendVariant5Encode {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub entries: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub gradient: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub labels: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub legend: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub symbols: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
 }
 #[doc = "`LegendVariant5FillColor`"]
@@ -26582,25 +26012,25 @@ impl ::std::convert::From<ColorValue> for LegendVariant5FillColor {
 pub enum LegendVariant5Format {
     String(::std::string::String),
     Object {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         date: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         day: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         hours: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         milliseconds: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         minutes: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         month: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         quarter: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         seconds: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         week: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         year: ::std::option::Option<::std::string::String>,
     },
     SignalRef(SignalRef),
@@ -27964,17 +27394,17 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant6Direction 
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct LegendVariant6Encode {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub entries: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub gradient: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub labels: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub legend: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub symbols: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
 }
 #[doc = "`LegendVariant6FillColor`"]
@@ -27996,25 +27426,25 @@ impl ::std::convert::From<ColorValue> for LegendVariant6FillColor {
 pub enum LegendVariant6Format {
     String(::std::string::String),
     Object {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         date: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         day: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         hours: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         milliseconds: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         minutes: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         month: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         quarter: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         seconds: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         week: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         year: ::std::option::Option<::std::string::String>,
     },
     SignalRef(SignalRef),
@@ -29311,16 +28741,16 @@ impl ::std::convert::TryFrom<::std::string::String> for LegendVariant6Type {
 #[serde(deny_unknown_fields)]
 pub struct LinearGradient {
     pub gradient: LinearGradientGradient,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub id: ::std::option::Option<::std::string::String>,
     pub stops: GradientStops,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub x1: ::std::option::Option<f64>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub x2: ::std::option::Option<f64>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub y1: ::std::option::Option<f64>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub y2: ::std::option::Option<f64>,
 }
 #[doc = "`LinearGradientGradient`"]
@@ -29378,11 +28808,11 @@ pub struct LinkpathTransform {
     pub as_: LinkpathTransformAs,
     #[serde(default = "defaults::linkpath_transform_orient")]
     pub orient: LinkpathTransformOrient,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub require: ::std::option::Option<SignalRef>,
     #[serde(default = "defaults::linkpath_transform_shape")]
     pub shape: LinkpathTransformShape,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(rename = "sourceX", default = "defaults::linkpath_transform_source_x")]
     pub source_x: LinkpathTransformSourceX,
@@ -29763,17 +29193,13 @@ impl ::std::convert::From<Stream> for Listener {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct LoessTransform {
-    #[serde(
-        rename = "as",
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
+    #[serde(rename = "as", skip_serializing_if = "::std::option::Option::is_none")]
     pub as_: ::std::option::Option<LoessTransformAs>,
     #[serde(default = "defaults::loess_transform_bandwidth")]
     pub bandwidth: LoessTransformBandwidth,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub groupby: ::std::option::Option<LoessTransformGroupby>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]
     pub type_: LoessTransformType,
@@ -29970,22 +29396,18 @@ impl ::std::convert::From<Expr> for LoessTransformY {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct LookupTransform {
-    #[serde(
-        rename = "as",
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
+    #[serde(rename = "as", skip_serializing_if = "::std::option::Option::is_none")]
     pub as_: ::std::option::Option<LookupTransformAs>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub default: ::std::option::Option<::serde_json::Value>,
     pub fields: LookupTransformFields,
     pub from: ::std::string::String,
     pub key: LookupTransformKey,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]
     pub type_: LookupTransformType,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub values: ::std::option::Option<LookupTransformValues>,
 }
 #[doc = "`LookupTransformAs`"]
@@ -30174,27 +29596,27 @@ impl ::std::convert::From<Expr> for LookupTransformValuesArrayItem {
 #[doc = "`Mark`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 pub struct Mark {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub aria: ::std::option::Option<bool>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub clip: ::std::option::Option<Markclip>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub description: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub encode: ::std::option::Option<Encode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub interactive: ::std::option::Option<BooleanOrSignal>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub key: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub on: ::std::option::Option<OnMarkTrigger>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub role: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub sort: ::std::option::Option<Compare>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub style: ::std::option::Option<Style>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub transform: ::std::vec::Vec<TransformMark>,
@@ -30204,47 +29626,47 @@ pub struct Mark {
 #[doc = "`MarkGroup`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 pub struct MarkGroup {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub aria: ::std::option::Option<bool>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub axes: ::std::vec::Vec<Axis>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub clip: ::std::option::Option<Markclip>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub data: ::std::vec::Vec<Data>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub description: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub encode: ::std::option::Option<Encode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub from: ::std::option::Option<MarkGroupFrom>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub interactive: ::std::option::Option<BooleanOrSignal>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub key: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub layout: ::std::option::Option<Layout>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub legends: ::std::vec::Vec<Legend>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub marks: ::std::vec::Vec<MarkGroupMarksItem>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub on: ::std::option::Option<OnMarkTrigger>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub projections: ::std::vec::Vec<Projection>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub role: ::std::option::Option<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub scales: ::std::vec::Vec<Scale>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub signals: ::std::vec::Vec<Signal>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub sort: ::std::option::Option<Compare>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub style: ::std::option::Option<Style>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<Title>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub transform: ::std::vec::Vec<TransformMark>,
@@ -30337,29 +29759,29 @@ impl ::std::convert::TryFrom<::std::string::String> for MarkGroupType {
 #[doc = "`MarkVisual`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 pub struct MarkVisual {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub aria: ::std::option::Option<bool>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub clip: ::std::option::Option<Markclip>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub description: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub encode: ::std::option::Option<Encode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub from: ::std::option::Option<From>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub interactive: ::std::option::Option<BooleanOrSignal>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub key: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub on: ::std::option::Option<OnMarkTrigger>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub role: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub sort: ::std::option::Option<Compare>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub style: ::std::option::Option<Style>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub transform: ::std::vec::Vec<TransformMark>,
@@ -30409,26 +29831,26 @@ impl ::std::convert::From<::std::string::String> for Marktype {
         Self(value)
     }
 }
+impl ::std::fmt::Display for Marktype {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 impl ::std::str::FromStr for Marktype {
     type Err = ::std::convert::Infallible;
     fn from_str(value: &str) -> ::std::result::Result<Self, Self::Err> {
         Ok(Self(value.to_string()))
     }
 }
-impl ::std::fmt::Display for Marktype {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        self.0.fmt(f)
-    }
-}
 #[doc = "`NestTransform`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct NestTransform {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub generate: ::std::option::Option<NestTransformGenerate>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub keys: ::std::option::Option<NestTransformKeys>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]
     pub type_: NestTransformType,
@@ -30540,19 +29962,19 @@ impl ::std::convert::TryFrom<::std::string::String> for NestTransformType {
 #[doc = "`NumberModifiers`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct NumberModifiers {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub band: ::std::option::Option<NumberModifiersBand>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub exponent: ::std::option::Option<NumberModifiersExponent>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub extra: ::std::option::Option<bool>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub mult: ::std::option::Option<NumberModifiersMult>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub offset: ::std::option::Option<NumberModifiersOffset>,
     #[serde(default)]
     pub round: bool,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub scale: ::std::option::Option<Field>,
 }
 #[doc = "`NumberModifiersBand`"]
@@ -30561,6 +29983,14 @@ pub struct NumberModifiers {
 pub enum NumberModifiersBand {
     Number(f64),
     Boolean(bool),
+}
+impl ::std::fmt::Display for NumberModifiersBand {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for NumberModifiersBand {
     type Err = self::error::ConversionError;
@@ -30586,14 +30016,6 @@ impl ::std::convert::TryFrom<::std::string::String> for NumberModifiersBand {
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for NumberModifiersBand {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for NumberModifiersBand {
@@ -30699,16 +30121,16 @@ pub enum NumberValueVariant0Item {
     Variant1(NumberValueVariant0ItemVariant1),
     Variant2(NumberValueVariant0ItemVariant2),
     Variant3 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         exponent: ::std::option::Option<NumberValueVariant0ItemVariant3Exponent>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         extra: ::std::option::Option<bool>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         mult: ::std::option::Option<NumberValueVariant0ItemVariant3Mult>,
         offset: NumberValueVariant0ItemVariant3Offset,
         #[serde(default)]
         round: bool,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -30732,79 +30154,79 @@ impl ::std::convert::From<NumberValueVariant0ItemVariant2> for NumberValueVarian
 #[serde(untagged)]
 pub enum NumberValueVariant0ItemVariant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         band: ::std::option::Option<NumberValueVariant0ItemVariant0Variant0Band>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         exponent: ::std::option::Option<NumberValueVariant0ItemVariant0Variant0Exponent>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         extra: ::std::option::Option<bool>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         mult: ::std::option::Option<NumberValueVariant0ItemVariant0Variant0Mult>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         offset: ::std::option::Option<NumberValueVariant0ItemVariant0Variant0Offset>,
         #[serde(default)]
         round: bool,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         band: ::std::option::Option<NumberValueVariant0ItemVariant0Variant1Band>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         exponent: ::std::option::Option<NumberValueVariant0ItemVariant0Variant1Exponent>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         extra: ::std::option::Option<bool>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         mult: ::std::option::Option<NumberValueVariant0ItemVariant0Variant1Mult>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         offset: ::std::option::Option<NumberValueVariant0ItemVariant0Variant1Offset>,
         #[serde(default)]
         round: bool,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
         value: f64,
     },
     Variant2 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         band: ::std::option::Option<NumberValueVariant0ItemVariant0Variant2Band>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         exponent: ::std::option::Option<NumberValueVariant0ItemVariant0Variant2Exponent>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         extra: ::std::option::Option<bool>,
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         mult: ::std::option::Option<NumberValueVariant0ItemVariant0Variant2Mult>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         offset: ::std::option::Option<NumberValueVariant0ItemVariant0Variant2Offset>,
         #[serde(default)]
         round: bool,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant3 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         band: ::std::option::Option<NumberValueVariant0ItemVariant0Variant3Band>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         exponent: ::std::option::Option<NumberValueVariant0ItemVariant0Variant3Exponent>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         extra: ::std::option::Option<bool>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         mult: ::std::option::Option<NumberValueVariant0ItemVariant0Variant3Mult>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         offset: ::std::option::Option<NumberValueVariant0ItemVariant0Variant3Offset>,
         range: NumberValueVariant0ItemVariant0Variant3Range,
         #[serde(default)]
         round: bool,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -30814,6 +30236,14 @@ pub enum NumberValueVariant0ItemVariant0 {
 pub enum NumberValueVariant0ItemVariant0Variant0Band {
     Number(f64),
     Boolean(bool),
+}
+impl ::std::fmt::Display for NumberValueVariant0ItemVariant0Variant0Band {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for NumberValueVariant0ItemVariant0Variant0Band {
     type Err = self::error::ConversionError;
@@ -30841,14 +30271,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for NumberValueVariant0ItemVariant0Variant0Band {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for NumberValueVariant0ItemVariant0Variant0Band {
@@ -30919,6 +30341,14 @@ pub enum NumberValueVariant0ItemVariant0Variant1Band {
     Number(f64),
     Boolean(bool),
 }
+impl ::std::fmt::Display for NumberValueVariant0ItemVariant0Variant1Band {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for NumberValueVariant0ItemVariant0Variant1Band {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -30945,14 +30375,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for NumberValueVariant0ItemVariant0Variant1Band {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for NumberValueVariant0ItemVariant0Variant1Band {
@@ -31023,6 +30445,14 @@ pub enum NumberValueVariant0ItemVariant0Variant2Band {
     Number(f64),
     Boolean(bool),
 }
+impl ::std::fmt::Display for NumberValueVariant0ItemVariant0Variant2Band {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for NumberValueVariant0ItemVariant0Variant2Band {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -31049,14 +30479,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for NumberValueVariant0ItemVariant0Variant2Band {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for NumberValueVariant0ItemVariant0Variant2Band {
@@ -31127,6 +30549,14 @@ pub enum NumberValueVariant0ItemVariant0Variant3Band {
     Number(f64),
     Boolean(bool),
 }
+impl ::std::fmt::Display for NumberValueVariant0ItemVariant0Variant3Band {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for NumberValueVariant0ItemVariant0Variant3Band {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -31153,14 +30583,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for NumberValueVariant0ItemVariant0Variant3Band {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for NumberValueVariant0ItemVariant0Variant3Band {
@@ -31231,6 +30653,14 @@ pub enum NumberValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
 }
+impl ::std::fmt::Display for NumberValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for NumberValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -31257,14 +30687,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for NumberValueVariant0ItemVariant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for NumberValueVariant0ItemVariant0Variant3Range {
@@ -31366,11 +30788,11 @@ pub enum NumberValueVariant1 {
     Variant1(NumberValueVariant1Variant1),
     Variant2(NumberValueVariant1Variant2),
     Variant3 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         exponent: ::std::option::Option<NumberValueVariant1Variant3Exponent>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         extra: ::std::option::Option<bool>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         mult: ::std::option::Option<NumberValueVariant1Variant3Mult>,
         offset: NumberValueVariant1Variant3Offset,
         #[serde(default)]
@@ -31397,71 +30819,71 @@ impl ::std::convert::From<NumberValueVariant1Variant2> for NumberValueVariant1 {
 #[serde(untagged)]
 pub enum NumberValueVariant1Variant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         band: ::std::option::Option<NumberValueVariant1Variant0Variant0Band>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         exponent: ::std::option::Option<NumberValueVariant1Variant0Variant0Exponent>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         extra: ::std::option::Option<bool>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         mult: ::std::option::Option<NumberValueVariant1Variant0Variant0Mult>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         offset: ::std::option::Option<NumberValueVariant1Variant0Variant0Offset>,
         #[serde(default)]
         round: bool,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         band: ::std::option::Option<NumberValueVariant1Variant0Variant1Band>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         exponent: ::std::option::Option<NumberValueVariant1Variant0Variant1Exponent>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         extra: ::std::option::Option<bool>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         mult: ::std::option::Option<NumberValueVariant1Variant0Variant1Mult>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         offset: ::std::option::Option<NumberValueVariant1Variant0Variant1Offset>,
         #[serde(default)]
         round: bool,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         value: f64,
     },
     Variant2 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         band: ::std::option::Option<NumberValueVariant1Variant0Variant2Band>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         exponent: ::std::option::Option<NumberValueVariant1Variant0Variant2Exponent>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         extra: ::std::option::Option<bool>,
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         mult: ::std::option::Option<NumberValueVariant1Variant0Variant2Mult>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         offset: ::std::option::Option<NumberValueVariant1Variant0Variant2Offset>,
         #[serde(default)]
         round: bool,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
     Variant3 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         band: ::std::option::Option<NumberValueVariant1Variant0Variant3Band>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         exponent: ::std::option::Option<NumberValueVariant1Variant0Variant3Exponent>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         extra: ::std::option::Option<bool>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         mult: ::std::option::Option<NumberValueVariant1Variant0Variant3Mult>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         offset: ::std::option::Option<NumberValueVariant1Variant0Variant3Offset>,
         range: NumberValueVariant1Variant0Variant3Range,
         #[serde(default)]
         round: bool,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
 }
@@ -31471,6 +30893,14 @@ pub enum NumberValueVariant1Variant0 {
 pub enum NumberValueVariant1Variant0Variant0Band {
     Number(f64),
     Boolean(bool),
+}
+impl ::std::fmt::Display for NumberValueVariant1Variant0Variant0Band {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for NumberValueVariant1Variant0Variant0Band {
     type Err = self::error::ConversionError;
@@ -31496,14 +30926,6 @@ impl ::std::convert::TryFrom<::std::string::String> for NumberValueVariant1Varia
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for NumberValueVariant1Variant0Variant0Band {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for NumberValueVariant1Variant0Variant0Band {
@@ -31580,6 +31002,14 @@ pub enum NumberValueVariant1Variant0Variant1Band {
     Number(f64),
     Boolean(bool),
 }
+impl ::std::fmt::Display for NumberValueVariant1Variant0Variant1Band {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for NumberValueVariant1Variant0Variant1Band {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -31604,14 +31034,6 @@ impl ::std::convert::TryFrom<::std::string::String> for NumberValueVariant1Varia
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for NumberValueVariant1Variant0Variant1Band {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for NumberValueVariant1Variant0Variant1Band {
@@ -31688,6 +31110,14 @@ pub enum NumberValueVariant1Variant0Variant2Band {
     Number(f64),
     Boolean(bool),
 }
+impl ::std::fmt::Display for NumberValueVariant1Variant0Variant2Band {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for NumberValueVariant1Variant0Variant2Band {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -31712,14 +31142,6 @@ impl ::std::convert::TryFrom<::std::string::String> for NumberValueVariant1Varia
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for NumberValueVariant1Variant0Variant2Band {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for NumberValueVariant1Variant0Variant2Band {
@@ -31796,6 +31218,14 @@ pub enum NumberValueVariant1Variant0Variant3Band {
     Number(f64),
     Boolean(bool),
 }
+impl ::std::fmt::Display for NumberValueVariant1Variant0Variant3Band {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for NumberValueVariant1Variant0Variant3Band {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -31820,14 +31250,6 @@ impl ::std::convert::TryFrom<::std::string::String> for NumberValueVariant1Varia
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for NumberValueVariant1Variant0Variant3Band {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for NumberValueVariant1Variant0Variant3Band {
@@ -31904,6 +31326,14 @@ pub enum NumberValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
 }
+impl ::std::fmt::Display for NumberValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for NumberValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -31928,14 +31358,6 @@ impl ::std::convert::TryFrom<::std::string::String> for NumberValueVariant1Varia
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for NumberValueVariant1Variant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for NumberValueVariant1Variant0Variant3Range {
@@ -32056,12 +31478,12 @@ pub enum OnEventsItem {
     Variant0 {
         encode: ::std::string::String,
         events: OnEventsItemVariant0Events,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         force: ::std::option::Option<bool>,
     },
     Variant1 {
         events: OnEventsItemVariant1Events,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         force: ::std::option::Option<bool>,
         update: OnEventsItemVariant1Update,
     },
@@ -32160,10 +31582,10 @@ impl ::std::convert::From<::std::vec::Vec<OnMarkTriggerItem>> for OnMarkTrigger 
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct OnMarkTriggerItem {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub modify: ::std::option::Option<ExprString>,
     pub trigger: ExprString,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub values: ::std::option::Option<ExprString>,
 }
 #[doc = "`OnTrigger`"]
@@ -32190,16 +31612,16 @@ impl ::std::convert::From<::std::vec::Vec<OnTriggerItem>> for OnTrigger {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct OnTriggerItem {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub insert: ::std::option::Option<ExprString>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub modify: ::std::option::Option<ExprString>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub remove: ::std::option::Option<OnTriggerItemRemove>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub toggle: ::std::option::Option<ExprString>,
     pub trigger: ExprString,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub values: ::std::option::Option<ExprString>,
 }
 #[doc = "`OnTriggerItemRemove`"]
@@ -32253,7 +31675,7 @@ pub enum OrientValueVariant0Item {
     Variant2(OrientValueVariant0ItemVariant2),
     Variant3 {
         offset: ::serde_json::Value,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -32277,31 +31699,31 @@ impl ::std::convert::From<OrientValueVariant0ItemVariant2> for OrientValueVarian
 #[serde(untagged)]
 pub enum OrientValueVariant0ItemVariant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
         value: OrientValueVariant0ItemVariant0Variant1Value,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant3 {
         range: OrientValueVariant0ItemVariant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -32373,6 +31795,14 @@ pub enum OrientValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
 }
+impl ::std::fmt::Display for OrientValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for OrientValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -32399,14 +31829,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for OrientValueVariant0ItemVariant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for OrientValueVariant0ItemVariant0Variant3Range {
@@ -32478,23 +31900,23 @@ impl ::std::convert::From<OrientValueVariant1Variant2> for OrientValueVariant1 {
 #[serde(untagged)]
 pub enum OrientValueVariant1Variant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         value: OrientValueVariant1Variant0Variant1Value,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
     Variant3 {
         range: OrientValueVariant1Variant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
 }
@@ -32564,6 +31986,14 @@ pub enum OrientValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
 }
+impl ::std::fmt::Display for OrientValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for OrientValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -32588,14 +32018,6 @@ impl ::std::convert::TryFrom<::std::string::String> for OrientValueVariant1Varia
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for OrientValueVariant1Variant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for OrientValueVariant1Variant0Variant3Range {
@@ -32644,17 +32066,17 @@ pub enum OrientValueVariant1Variant2 {}
 pub struct PackTransform {
     #[serde(rename = "as", default = "defaults::pack_transform_as")]
     pub as_: PackTransformAs,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub field: ::std::option::Option<PackTransformField>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub padding: ::std::option::Option<PackTransformPadding>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub radius: ::std::option::Option<PackTransformRadius>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub size: ::std::option::Option<PackTransformSize>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub sort: ::std::option::Option<Compare>,
     #[serde(rename = "type")]
     pub type_: PackTransformType,
@@ -32849,13 +32271,13 @@ impl ::std::convert::TryFrom<::std::string::String> for PackTransformType {
 pub enum Padding {
     Number(f64),
     Object {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         bottom: ::std::option::Option<f64>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         left: ::std::option::Option<f64>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         right: ::std::option::Option<f64>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         top: ::std::option::Option<f64>,
     },
     SignalRef(SignalRef),
@@ -32874,11 +32296,7 @@ impl ::std::convert::From<SignalRef> for Padding {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct ParamField {
-    #[serde(
-        rename = "as",
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
+    #[serde(rename = "as", skip_serializing_if = "::std::option::Option::is_none")]
     pub as_: ::std::option::Option<::std::string::String>,
     pub field: ::std::string::String,
 }
@@ -32888,17 +32306,17 @@ pub struct ParamField {
 pub struct PartitionTransform {
     #[serde(rename = "as", default = "defaults::partition_transform_as")]
     pub as_: PartitionTransformAs,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub field: ::std::option::Option<PartitionTransformField>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub padding: ::std::option::Option<PartitionTransformPadding>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub round: ::std::option::Option<PartitionTransformRound>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub size: ::std::option::Option<PartitionTransformSize>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub sort: ::std::option::Option<Compare>,
     #[serde(rename = "type")]
     pub type_: PartitionTransformType,
@@ -33090,15 +32508,14 @@ pub struct PieTransform {
     pub as_: PieTransformAs,
     #[serde(rename = "endAngle", default = "defaults::pie_transform_end_angle")]
     pub end_angle: PieTransformEndAngle,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub field: ::std::option::Option<PieTransformField>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub sort: ::std::option::Option<PieTransformSort>,
     #[serde(
         rename = "startAngle",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub start_angle: ::std::option::Option<PieTransformStartAngle>,
@@ -33273,15 +32690,15 @@ impl ::std::convert::TryFrom<::std::string::String> for PieTransformType {
 #[serde(deny_unknown_fields)]
 pub struct PivotTransform {
     pub field: PivotTransformField,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub groupby: ::std::option::Option<PivotTransformGroupby>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub key: ::std::option::Option<PivotTransformKey>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub limit: ::std::option::Option<PivotTransformLimit>,
     #[serde(default = "defaults::pivot_transform_op")]
     pub op: PivotTransformOp,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]
     pub type_: PivotTransformType,
@@ -33627,15 +33044,11 @@ impl ::std::convert::From<Expr> for PivotTransformValue {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectTransform {
-    #[serde(
-        rename = "as",
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
+    #[serde(rename = "as", skip_serializing_if = "::std::option::Option::is_none")]
     pub as_: ::std::option::Option<ProjectTransformAs>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub fields: ::std::option::Option<ProjectTransformFields>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]
     pub type_: ProjectTransformType,
@@ -33762,46 +33175,42 @@ impl ::std::convert::TryFrom<::std::string::String> for ProjectTransformType {
 #[doc = "`Projection`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 pub struct Projection {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub center: ::std::option::Option<ProjectionCenter>,
     #[serde(
         rename = "clipAngle",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub clip_angle: ::std::option::Option<NumberOrSignal>,
     #[serde(
         rename = "clipExtent",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub clip_extent: ::std::option::Option<ProjectionClipExtent>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub extent: ::std::option::Option<ProjectionExtent>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub fit: ::std::option::Option<ProjectionFit>,
     pub name: ::std::string::String,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub parallels: ::std::option::Option<ProjectionParallels>,
     #[serde(
         rename = "pointRadius",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub point_radius: ::std::option::Option<NumberOrSignal>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub precision: ::std::option::Option<NumberOrSignal>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub rotate: ::std::option::Option<ProjectionRotate>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub scale: ::std::option::Option<NumberOrSignal>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub size: ::std::option::Option<ProjectionSize>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub translate: ::std::option::Option<ProjectionTranslate>,
     #[serde(
         rename = "type",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub type_: ::std::option::Option<StringOrSignal>,
@@ -33985,11 +33394,11 @@ pub struct QuantileTransform {
     #[serde(rename = "as", default = "defaults::quantile_transform_as")]
     pub as_: QuantileTransformAs,
     pub field: QuantileTransformField,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub groupby: ::std::option::Option<QuantileTransformGroupby>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub probs: ::std::option::Option<QuantileTransformProbs>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(default = "defaults::quantile_transform_step")]
     pub step: QuantileTransformStep,
@@ -34208,20 +33617,20 @@ impl ::std::convert::TryFrom<::std::string::String> for QuantileTransformType {
 #[serde(deny_unknown_fields)]
 pub struct RadialGradient {
     pub gradient: RadialGradientGradient,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub id: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub r1: ::std::option::Option<f64>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub r2: ::std::option::Option<f64>,
     pub stops: GradientStops,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub x1: ::std::option::Option<f64>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub x2: ::std::option::Option<f64>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub y1: ::std::option::Option<f64>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub y2: ::std::option::Option<f64>,
 }
 #[doc = "`RadialGradientGradient`"]
@@ -34275,23 +33684,19 @@ impl ::std::convert::TryFrom<::std::string::String> for RadialGradientGradient {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct RegressionTransform {
-    #[serde(
-        rename = "as",
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
+    #[serde(rename = "as", skip_serializing_if = "::std::option::Option::is_none")]
     pub as_: ::std::option::Option<RegressionTransformAs>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub extent: ::std::option::Option<RegressionTransformExtent>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub groupby: ::std::option::Option<RegressionTransformGroupby>,
     #[serde(default = "defaults::regression_transform_method")]
     pub method: RegressionTransformMethod,
     #[serde(default = "defaults::regression_transform_order")]
     pub order: RegressionTransformOrder,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub params: ::std::option::Option<RegressionTransformParams>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]
     pub type_: RegressionTransformType,
@@ -34562,7 +33967,7 @@ impl ::std::convert::From<Expr> for RegressionTransformY {
 pub struct ResolvefilterTransform {
     pub filter: ::serde_json::Value,
     pub ignore: ResolvefilterTransformIgnore,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]
     pub type_: ResolvefilterTransformType,
@@ -34634,14 +34039,14 @@ impl ::std::convert::TryFrom<::std::string::String> for ResolvefilterTransformTy
 #[doc = "`Rule`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct Rule {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub test: ::std::option::Option<::std::string::String>,
 }
 #[doc = "`SampleTransform`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct SampleTransform {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(default = "defaults::sample_transform_size")]
     pub size: SampleTransformSize,
@@ -34722,561 +34127,508 @@ impl ::std::convert::TryFrom<::std::string::String> for SampleTransformType {
 #[serde(untagged, deny_unknown_fields)]
 pub enum Scale {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         domain: ::std::option::Option<ScaleVariant0Domain>,
         #[serde(
             rename = "domainMax",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_max: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainMid",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_mid: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainMin",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_min: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainRaw",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_raw: ::std::option::Option<ScaleVariant0DomainRaw>,
         name: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         nice: ::std::option::Option<BooleanOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         reverse: ::std::option::Option<BooleanOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         round: ::std::option::Option<BooleanOrSignal>,
         #[serde(rename = "type")]
         type_: ScaleVariant0Type,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         domain: ::std::option::Option<ScaleVariant1Domain>,
         #[serde(
             rename = "domainImplicit",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_implicit: ::std::option::Option<BooleanOrSignal>,
         #[serde(
             rename = "domainMax",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_max: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainMid",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_mid: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainMin",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_min: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainRaw",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_raw: ::std::option::Option<ScaleVariant1DomainRaw>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         interpolate: ::std::option::Option<ScaleInterpolate>,
         name: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         range: ::std::option::Option<ScaleVariant1Range>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         reverse: ::std::option::Option<BooleanOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         round: ::std::option::Option<BooleanOrSignal>,
         #[serde(rename = "type")]
         type_: ScaleVariant1Type,
     },
     Variant2 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         align: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         domain: ::std::option::Option<ScaleVariant2Domain>,
         #[serde(
             rename = "domainMax",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_max: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainMid",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_mid: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainMin",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_min: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainRaw",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_raw: ::std::option::Option<ScaleVariant2DomainRaw>,
         name: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         padding: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "paddingInner",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         padding_inner: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "paddingOuter",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         padding_outer: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         range: ::std::option::Option<ScaleVariant2Range>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         reverse: ::std::option::Option<BooleanOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         round: ::std::option::Option<BooleanOrSignal>,
         #[serde(rename = "type")]
         type_: ScaleVariant2Type,
     },
     Variant3 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         align: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         domain: ::std::option::Option<ScaleVariant3Domain>,
         #[serde(
             rename = "domainMax",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_max: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainMid",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_mid: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainMin",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_min: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainRaw",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_raw: ::std::option::Option<ScaleVariant3DomainRaw>,
         name: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         padding: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "paddingOuter",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         padding_outer: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         range: ::std::option::Option<ScaleVariant3Range>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         reverse: ::std::option::Option<BooleanOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         round: ::std::option::Option<BooleanOrSignal>,
         #[serde(rename = "type")]
         type_: ScaleVariant3Type,
     },
     Variant4 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         domain: ::std::option::Option<ScaleVariant4Domain>,
         #[serde(
             rename = "domainMax",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_max: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainMid",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_mid: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainMin",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_min: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainRaw",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_raw: ::std::option::Option<ScaleVariant4DomainRaw>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         interpolate: ::std::option::Option<ScaleInterpolate>,
         name: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         nice: ::std::option::Option<ScaleVariant4Nice>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         range: ::std::option::Option<ScaleVariant4Range>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         reverse: ::std::option::Option<BooleanOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         round: ::std::option::Option<BooleanOrSignal>,
         #[serde(rename = "type")]
         type_: ScaleVariant4Type,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         zero: ::std::option::Option<BooleanOrSignal>,
     },
     Variant5 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         domain: ::std::option::Option<ScaleVariant5Domain>,
         #[serde(
             rename = "domainMax",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_max: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainMid",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_mid: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainMin",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_min: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainRaw",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_raw: ::std::option::Option<ScaleVariant5DomainRaw>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         interpolate: ::std::option::Option<ScaleInterpolate>,
         name: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         range: ::std::option::Option<ScaleVariant5Range>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         reverse: ::std::option::Option<BooleanOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         round: ::std::option::Option<BooleanOrSignal>,
         #[serde(rename = "type")]
         type_: ScaleVariant5Type,
     },
     Variant6 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         bins: ::std::option::Option<ScaleBins>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         domain: ::std::option::Option<ScaleVariant6Domain>,
         #[serde(
             rename = "domainMax",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_max: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainMid",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_mid: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainMin",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_min: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainRaw",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_raw: ::std::option::Option<ScaleVariant6DomainRaw>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         interpolate: ::std::option::Option<ScaleInterpolate>,
         name: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         range: ::std::option::Option<ScaleVariant6Range>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         reverse: ::std::option::Option<BooleanOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         round: ::std::option::Option<BooleanOrSignal>,
         #[serde(rename = "type")]
         type_: ScaleVariant6Type,
     },
     Variant7 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         bins: ::std::option::Option<ScaleBins>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         clamp: ::std::option::Option<BooleanOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         domain: ::std::option::Option<ScaleVariant7Domain>,
         #[serde(
             rename = "domainMax",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_max: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainMid",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_mid: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainMin",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_min: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainRaw",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_raw: ::std::option::Option<ScaleVariant7DomainRaw>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         interpolate: ::std::option::Option<ScaleInterpolate>,
         name: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         nice: ::std::option::Option<ScaleVariant7Nice>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         padding: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         range: ::std::option::Option<ScaleVariant7Range>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         reverse: ::std::option::Option<BooleanOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         round: ::std::option::Option<BooleanOrSignal>,
         #[serde(rename = "type")]
         type_: ScaleVariant7Type,
     },
     Variant8 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         bins: ::std::option::Option<ScaleBins>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         clamp: ::std::option::Option<BooleanOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         domain: ::std::option::Option<ScaleVariant8Domain>,
         #[serde(
             rename = "domainMax",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_max: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainMid",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_mid: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainMin",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_min: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainRaw",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_raw: ::std::option::Option<ScaleVariant8DomainRaw>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         interpolate: ::std::option::Option<ScaleInterpolate>,
         name: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         nice: ::std::option::Option<ScaleVariant8Nice>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         padding: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         range: ::std::option::Option<ScaleVariant8Range>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         reverse: ::std::option::Option<BooleanOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         round: ::std::option::Option<BooleanOrSignal>,
         #[serde(
             rename = "type",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         type_: ::std::option::Option<ScaleVariant8Type>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         zero: ::std::option::Option<BooleanOrSignal>,
     },
     Variant9 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         base: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         bins: ::std::option::Option<ScaleBins>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         clamp: ::std::option::Option<BooleanOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         domain: ::std::option::Option<ScaleVariant9Domain>,
         #[serde(
             rename = "domainMax",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_max: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainMid",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_mid: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainMin",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_min: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainRaw",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_raw: ::std::option::Option<ScaleVariant9DomainRaw>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         interpolate: ::std::option::Option<ScaleInterpolate>,
         name: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         nice: ::std::option::Option<ScaleVariant9Nice>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         padding: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         range: ::std::option::Option<ScaleVariant9Range>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         reverse: ::std::option::Option<BooleanOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         round: ::std::option::Option<BooleanOrSignal>,
         #[serde(rename = "type")]
         type_: ScaleVariant9Type,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         zero: ::std::option::Option<BooleanOrSignal>,
     },
     Variant10 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         bins: ::std::option::Option<ScaleBins>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         clamp: ::std::option::Option<BooleanOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         domain: ::std::option::Option<ScaleVariant10Domain>,
         #[serde(
             rename = "domainMax",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_max: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainMid",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_mid: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainMin",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_min: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainRaw",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_raw: ::std::option::Option<ScaleVariant10DomainRaw>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         exponent: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         interpolate: ::std::option::Option<ScaleInterpolate>,
         name: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         nice: ::std::option::Option<ScaleVariant10Nice>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         padding: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         range: ::std::option::Option<ScaleVariant10Range>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         reverse: ::std::option::Option<BooleanOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         round: ::std::option::Option<BooleanOrSignal>,
         #[serde(rename = "type")]
         type_: ScaleVariant10Type,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         zero: ::std::option::Option<BooleanOrSignal>,
     },
     Variant11 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         bins: ::std::option::Option<ScaleBins>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         clamp: ::std::option::Option<BooleanOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         constant: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         domain: ::std::option::Option<ScaleVariant11Domain>,
         #[serde(
             rename = "domainMax",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_max: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainMid",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_mid: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainMin",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_min: ::std::option::Option<NumberOrSignal>,
         #[serde(
             rename = "domainRaw",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         domain_raw: ::std::option::Option<ScaleVariant11DomainRaw>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         interpolate: ::std::option::Option<ScaleInterpolate>,
         name: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         nice: ::std::option::Option<ScaleVariant11Nice>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         padding: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         range: ::std::option::Option<ScaleVariant11Range>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         reverse: ::std::option::Option<BooleanOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         round: ::std::option::Option<BooleanOrSignal>,
         #[serde(rename = "type")]
         type_: ScaleVariant11Type,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         zero: ::std::option::Option<BooleanOrSignal>,
     },
 }
@@ -35286,10 +34638,10 @@ pub enum Scale {
 pub enum ScaleBins {
     Array(::std::vec::Vec<NumberOrSignal>),
     Object {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         start: ::std::option::Option<NumberOrSignal>,
         step: NumberOrSignal,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         stop: ::std::option::Option<NumberOrSignal>,
     },
     SignalRef(SignalRef),
@@ -35311,18 +34663,18 @@ pub enum ScaleData {
     Variant0 {
         data: ::std::string::String,
         field: StringOrSignal,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         sort: ::std::option::Option<ScaleDataVariant0Sort>,
     },
     Variant1 {
         data: ::std::string::String,
         fields: ::std::vec::Vec<StringOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         sort: ::std::option::Option<ScaleDataVariant1Sort>,
     },
     Variant2 {
         fields: ::std::vec::Vec<ScaleDataVariant2FieldsItem>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         sort: ::std::option::Option<ScaleDataVariant2Sort>,
     },
 }
@@ -35332,11 +34684,11 @@ pub enum ScaleData {
 pub enum ScaleDataVariant0Sort {
     Boolean(bool),
     Object {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         field: ::std::option::Option<StringOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         op: ::std::option::Option<StringOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         order: ::std::option::Option<SortOrder>,
     },
 }
@@ -35351,15 +34703,15 @@ impl ::std::convert::From<bool> for ScaleDataVariant0Sort {
 pub enum ScaleDataVariant1Sort {
     Variant0(bool),
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         op: ::std::option::Option<ScaleDataVariant1SortVariant1Op>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         order: ::std::option::Option<SortOrder>,
     },
     Variant2 {
         field: StringOrSignal,
         op: ScaleDataVariant1SortVariant2Op,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         order: ::std::option::Option<SortOrder>,
     },
 }
@@ -35526,15 +34878,15 @@ impl ::std::convert::From<bool> for ScaleDataVariant2FieldsItemArrayItem {
 pub enum ScaleDataVariant2Sort {
     Variant0(bool),
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         op: ::std::option::Option<ScaleDataVariant2SortVariant1Op>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         order: ::std::option::Option<SortOrder>,
     },
     Variant2 {
         field: StringOrSignal,
         op: ScaleDataVariant2SortVariant2Op,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         order: ::std::option::Option<SortOrder>,
     },
 }
@@ -35672,7 +35024,7 @@ pub enum ScaleInterpolate {
     String(::std::string::String),
     SignalRef(SignalRef),
     Object {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         gamma: ::std::option::Option<NumberOrSignal>,
         #[serde(rename = "type")]
         type_: StringOrSignal,
@@ -35904,9 +35256,9 @@ pub enum ScaleVariant10Range {
     Variant0(ScaleVariant10RangeVariant0),
     Variant1(::std::vec::Vec<ScaleVariant10RangeVariant1Item>),
     Variant2 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         count: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         extent: ::std::option::Option<ScaleVariant10RangeVariant2Extent>,
         scheme: ScaleVariant10RangeVariant2Scheme,
     },
@@ -36233,9 +35585,9 @@ pub enum ScaleVariant11Range {
     Variant0(ScaleVariant11RangeVariant0),
     Variant1(::std::vec::Vec<ScaleVariant11RangeVariant1Item>),
     Variant2 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         count: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         extent: ::std::option::Option<ScaleVariant11RangeVariant2Extent>,
         scheme: ScaleVariant11RangeVariant2Scheme,
     },
@@ -36539,9 +35891,9 @@ pub enum ScaleVariant1Range {
     Variant0(ScaleVariant1RangeVariant0),
     Variant1(::std::vec::Vec<ScaleVariant1RangeVariant1Item>),
     Variant2 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         count: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         extent: ::std::option::Option<ScaleVariant1RangeVariant2Extent>,
         scheme: ScaleVariant1RangeVariant2Scheme,
     },
@@ -36730,18 +36082,18 @@ pub enum ScaleVariant1RangeVariant3 {
     Variant0 {
         data: ::std::string::String,
         field: StringOrSignal,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         sort: ::std::option::Option<ScaleVariant1RangeVariant3Variant0Sort>,
     },
     Variant1 {
         data: ::std::string::String,
         fields: ::std::vec::Vec<StringOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         sort: ::std::option::Option<ScaleVariant1RangeVariant3Variant1Sort>,
     },
     Variant2 {
         fields: ::std::vec::Vec<ScaleVariant1RangeVariant3Variant2FieldsItem>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         sort: ::std::option::Option<ScaleVariant1RangeVariant3Variant2Sort>,
     },
 }
@@ -36751,11 +36103,11 @@ pub enum ScaleVariant1RangeVariant3 {
 pub enum ScaleVariant1RangeVariant3Variant0Sort {
     Boolean(bool),
     Object {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         field: ::std::option::Option<StringOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         op: ::std::option::Option<StringOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         order: ::std::option::Option<SortOrder>,
     },
 }
@@ -36770,15 +36122,15 @@ impl ::std::convert::From<bool> for ScaleVariant1RangeVariant3Variant0Sort {
 pub enum ScaleVariant1RangeVariant3Variant1Sort {
     Variant0(bool),
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         op: ::std::option::Option<ScaleVariant1RangeVariant3Variant1SortVariant1Op>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         order: ::std::option::Option<SortOrder>,
     },
     Variant2 {
         field: StringOrSignal,
         op: ScaleVariant1RangeVariant3Variant1SortVariant2Op,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         order: ::std::option::Option<SortOrder>,
     },
 }
@@ -36949,15 +36301,15 @@ impl ::std::convert::From<bool> for ScaleVariant1RangeVariant3Variant2FieldsItem
 pub enum ScaleVariant1RangeVariant3Variant2Sort {
     Variant0(bool),
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         op: ::std::option::Option<ScaleVariant1RangeVariant3Variant2SortVariant1Op>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         order: ::std::option::Option<SortOrder>,
     },
     Variant2 {
         field: StringOrSignal,
         op: ScaleVariant1RangeVariant3Variant2SortVariant2Op,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         order: ::std::option::Option<SortOrder>,
     },
 }
@@ -37719,9 +37071,9 @@ pub enum ScaleVariant4Range {
     Variant0(ScaleVariant4RangeVariant0),
     Variant1(::std::vec::Vec<ScaleVariant4RangeVariant1Item>),
     Variant2 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         count: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         extent: ::std::option::Option<ScaleVariant4RangeVariant2Extent>,
         scheme: ScaleVariant4RangeVariant2Scheme,
     },
@@ -38027,9 +37379,9 @@ pub enum ScaleVariant5Range {
     Variant0(ScaleVariant5RangeVariant0),
     Variant1(::std::vec::Vec<ScaleVariant5RangeVariant1Item>),
     Variant2 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         count: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         extent: ::std::option::Option<ScaleVariant5RangeVariant2Extent>,
         scheme: ScaleVariant5RangeVariant2Scheme,
     },
@@ -38331,9 +37683,9 @@ pub enum ScaleVariant6Range {
     Variant0(ScaleVariant6RangeVariant0),
     Variant1(::std::vec::Vec<ScaleVariant6RangeVariant1Item>),
     Variant2 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         count: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         extent: ::std::option::Option<ScaleVariant6RangeVariant2Extent>,
         scheme: ScaleVariant6RangeVariant2Scheme,
     },
@@ -38636,7 +37988,7 @@ pub enum ScaleVariant7Nice {
     Variant1(ScaleVariant7NiceVariant1),
     Variant2 {
         interval: ScaleVariant7NiceVariant2Interval,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         step: ::std::option::Option<NumberOrSignal>,
     },
 }
@@ -38826,9 +38178,9 @@ pub enum ScaleVariant7Range {
     Variant0(ScaleVariant7RangeVariant0),
     Variant1(::std::vec::Vec<ScaleVariant7RangeVariant1Item>),
     Variant2 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         count: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         extent: ::std::option::Option<ScaleVariant7RangeVariant2Extent>,
         scheme: ScaleVariant7RangeVariant2Scheme,
     },
@@ -39157,9 +38509,9 @@ pub enum ScaleVariant8Range {
     Variant0(ScaleVariant8RangeVariant0),
     Variant1(::std::vec::Vec<ScaleVariant8RangeVariant1Item>),
     Variant2 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         count: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         extent: ::std::option::Option<ScaleVariant8RangeVariant2Extent>,
         scheme: ScaleVariant8RangeVariant2Scheme,
     },
@@ -39492,9 +38844,9 @@ pub enum ScaleVariant9Range {
     Variant0(ScaleVariant9RangeVariant0),
     Variant1(::std::vec::Vec<ScaleVariant9RangeVariant1Item>),
     Variant2 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         count: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         extent: ::std::option::Option<ScaleVariant9RangeVariant2Extent>,
         scheme: ScaleVariant9RangeVariant2Scheme,
     },
@@ -39724,9 +39076,9 @@ pub struct Scope {
     pub axes: ::std::vec::Vec<Axis>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub data: ::std::vec::Vec<Data>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub encode: ::std::option::Option<Encode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub layout: ::std::option::Option<Layout>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub legends: ::std::vec::Vec<Legend>,
@@ -39738,7 +39090,7 @@ pub struct Scope {
     pub scales: ::std::vec::Vec<Scale>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub signals: ::std::vec::Vec<Signal>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<Title>,
     #[serde(default, skip_serializing_if = "::serde_json::Map::is_empty")]
     pub usermeta: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
@@ -39790,15 +39142,15 @@ impl ::std::convert::From<::std::string::String> for Selector {
         Self(value)
     }
 }
+impl ::std::fmt::Display for Selector {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 impl ::std::str::FromStr for Selector {
     type Err = ::std::convert::Infallible;
     fn from_str(value: &str) -> ::std::result::Result<Self, Self::Err> {
         Ok(Self(value.to_string()))
-    }
-}
-impl ::std::fmt::Display for Selector {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        self.0.fmt(f)
     }
 }
 #[doc = "`SequenceTransform`"]
@@ -39807,7 +39159,7 @@ impl ::std::fmt::Display for Selector {
 pub struct SequenceTransform {
     #[serde(rename = "as", default = "defaults::sequence_transform_as")]
     pub as_: SequenceTransformAs,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     pub start: SequenceTransformStart,
     #[serde(default = "defaults::sequence_transform_step")]
@@ -39941,38 +39293,38 @@ impl ::std::convert::TryFrom<::std::string::String> for SequenceTransformType {
 #[serde(untagged, deny_unknown_fields)]
 pub enum Signal {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         description: ::std::option::Option<::std::string::String>,
         name: SignalName,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         on: ::std::option::Option<OnEvents>,
         push: SignalVariant0Push,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         bind: ::std::option::Option<Bind>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         description: ::std::option::Option<::std::string::String>,
         name: SignalName,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         on: ::std::option::Option<OnEvents>,
         #[serde(default = "defaults::default_bool::<true>")]
         react: bool,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         update: ::std::option::Option<ExprString>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         value: ::std::option::Option<::serde_json::Value>,
     },
     Variant2 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         bind: ::std::option::Option<Bind>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         description: ::std::option::Option<::std::string::String>,
         init: ExprString,
         name: SignalName,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         on: ::std::option::Option<OnEvents>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         value: ::std::option::Option<::serde_json::Value>,
     },
 }
@@ -40145,15 +39497,15 @@ impl ::std::convert::TryFrom<::std::string::String> for SortOrderVariant0 {
 pub struct StackTransform {
     #[serde(rename = "as", default = "defaults::stack_transform_as")]
     pub as_: StackTransformAs,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub field: ::std::option::Option<StackTransformField>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub groupby: ::std::option::Option<StackTransformGroupby>,
     #[serde(default = "defaults::stack_transform_offset")]
     pub offset: StackTransformOffset,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub sort: ::std::option::Option<Compare>,
     #[serde(rename = "type")]
     pub type_: StackTransformType,
@@ -40391,7 +39743,7 @@ pub struct StratifyTransform {
     pub key: StratifyTransformKey,
     #[serde(rename = "parentKey")]
     pub parent_key: StratifyTransformParentKey,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]
     pub type_: StratifyTransformType,
@@ -40494,57 +39846,57 @@ impl ::std::convert::TryFrom<::std::string::String> for StratifyTransformType {
 #[serde(untagged)]
 pub enum Stream {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         between: ::std::option::Option<[::std::boxed::Box<Stream>; 2usize]>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         consume: ::std::option::Option<bool>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         debounce: ::std::option::Option<f64>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         filter: ::std::option::Option<StreamVariant0Filter>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         markname: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         marktype: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         source: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         throttle: ::std::option::Option<f64>,
         #[serde(rename = "type")]
         type_: ::std::string::String,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         between: ::std::option::Option<[::std::boxed::Box<Stream>; 2usize]>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         consume: ::std::option::Option<bool>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         debounce: ::std::option::Option<f64>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         filter: ::std::option::Option<StreamVariant1Filter>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         markname: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         marktype: ::std::option::Option<::std::string::String>,
         stream: ::std::boxed::Box<Stream>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         throttle: ::std::option::Option<f64>,
     },
     Variant2 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         between: ::std::option::Option<[::std::boxed::Box<Stream>; 2usize]>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         consume: ::std::option::Option<bool>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         debounce: ::std::option::Option<f64>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         filter: ::std::option::Option<StreamVariant2Filter>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         markname: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         marktype: ::std::option::Option<::std::string::String>,
         merge: ::std::vec::Vec<Stream>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         throttle: ::std::option::Option<f64>,
     },
 }
@@ -40602,7 +39954,7 @@ impl ::std::convert::From<::std::vec::Vec<ExprString>> for StreamVariant2Filter 
 #[doc = "`StringModifiers`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct StringModifiers {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub scale: ::std::option::Option<Field>,
 }
 #[doc = "`StringOrSignal`"]
@@ -40643,7 +39995,7 @@ pub enum StringValueVariant0Item {
     Variant2(StringValueVariant0ItemVariant2),
     Variant3 {
         offset: ::serde_json::Value,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -40667,31 +40019,31 @@ impl ::std::convert::From<StringValueVariant0ItemVariant2> for StringValueVarian
 #[serde(untagged)]
 pub enum StringValueVariant0ItemVariant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
         value: ::std::string::String,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant3 {
         range: StringValueVariant0ItemVariant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -40701,6 +40053,14 @@ pub enum StringValueVariant0ItemVariant0 {
 pub enum StringValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
+}
+impl ::std::fmt::Display for StringValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for StringValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -40728,14 +40088,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for StringValueVariant0ItemVariant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for StringValueVariant0ItemVariant0Variant3Range {
@@ -40807,23 +40159,23 @@ impl ::std::convert::From<StringValueVariant1Variant2> for StringValueVariant1 {
 #[serde(untagged)]
 pub enum StringValueVariant1Variant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         value: ::std::string::String,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
     Variant3 {
         range: StringValueVariant1Variant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
 }
@@ -40833,6 +40185,14 @@ pub enum StringValueVariant1Variant0 {
 pub enum StringValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
+}
+impl ::std::fmt::Display for StringValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for StringValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -40858,14 +40218,6 @@ impl ::std::convert::TryFrom<::std::string::String> for StringValueVariant1Varia
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for StringValueVariant1Variant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for StringValueVariant1Variant0Variant3Range {
@@ -40934,7 +40286,7 @@ pub enum StrokeCapValueVariant0Item {
     Variant2(StrokeCapValueVariant0ItemVariant2),
     Variant3 {
         offset: ::serde_json::Value,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -40958,31 +40310,31 @@ impl ::std::convert::From<StrokeCapValueVariant0ItemVariant2> for StrokeCapValue
 #[serde(untagged)]
 pub enum StrokeCapValueVariant0ItemVariant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
         value: StrokeCapValueVariant0ItemVariant0Variant1Value,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant3 {
         range: StrokeCapValueVariant0ItemVariant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -41050,6 +40402,14 @@ pub enum StrokeCapValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
 }
+impl ::std::fmt::Display for StrokeCapValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for StrokeCapValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -41076,14 +40436,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for StrokeCapValueVariant0ItemVariant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for StrokeCapValueVariant0ItemVariant0Variant3Range {
@@ -41155,23 +40507,23 @@ impl ::std::convert::From<StrokeCapValueVariant1Variant2> for StrokeCapValueVari
 #[serde(untagged)]
 pub enum StrokeCapValueVariant1Variant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         value: StrokeCapValueVariant1Variant0Variant1Value,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
     Variant3 {
         range: StrokeCapValueVariant1Variant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
 }
@@ -41239,6 +40591,14 @@ pub enum StrokeCapValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
 }
+impl ::std::fmt::Display for StrokeCapValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for StrokeCapValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -41265,14 +40625,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for StrokeCapValueVariant1Variant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for StrokeCapValueVariant1Variant0Variant3Range {
@@ -41341,7 +40693,7 @@ pub enum StrokeJoinValueVariant0Item {
     Variant2(StrokeJoinValueVariant0ItemVariant2),
     Variant3 {
         offset: ::serde_json::Value,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -41365,31 +40717,31 @@ impl ::std::convert::From<StrokeJoinValueVariant0ItemVariant2> for StrokeJoinVal
 #[serde(untagged)]
 pub enum StrokeJoinValueVariant0ItemVariant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
         value: StrokeJoinValueVariant0ItemVariant0Variant1Value,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant3 {
         range: StrokeJoinValueVariant0ItemVariant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -41457,6 +40809,14 @@ pub enum StrokeJoinValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
 }
+impl ::std::fmt::Display for StrokeJoinValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for StrokeJoinValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -41483,14 +40843,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for StrokeJoinValueVariant0ItemVariant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for StrokeJoinValueVariant0ItemVariant0Variant3Range {
@@ -41562,23 +40914,23 @@ impl ::std::convert::From<StrokeJoinValueVariant1Variant2> for StrokeJoinValueVa
 #[serde(untagged)]
 pub enum StrokeJoinValueVariant1Variant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         value: StrokeJoinValueVariant1Variant0Variant1Value,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
     Variant3 {
         range: StrokeJoinValueVariant1Variant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
 }
@@ -41646,6 +40998,14 @@ pub enum StrokeJoinValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
 }
+impl ::std::fmt::Display for StrokeJoinValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for StrokeJoinValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -41672,14 +41032,6 @@ impl ::std::convert::TryFrom<::std::string::String>
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for StrokeJoinValueVariant1Variant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for StrokeJoinValueVariant1Variant0Variant3Range {
@@ -41789,7 +41141,7 @@ pub enum TextValueVariant0Item {
     Variant2(TextValueVariant0ItemVariant2),
     Variant3 {
         offset: ::serde_json::Value,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -41813,31 +41165,31 @@ impl ::std::convert::From<TextValueVariant0ItemVariant2> for TextValueVariant0It
 #[serde(untagged)]
 pub enum TextValueVariant0ItemVariant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
         value: TextValueVariant0ItemVariant0Variant1Value,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
     Variant3 {
         range: TextValueVariant0ItemVariant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         test: ::std::option::Option<::std::string::String>,
     },
 }
@@ -41861,6 +41213,14 @@ impl ::std::convert::From<::std::vec::Vec<::std::string::String>>
 pub enum TextValueVariant0ItemVariant0Variant3Range {
     Number(f64),
     Boolean(bool),
+}
+impl ::std::fmt::Display for TextValueVariant0ItemVariant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for TextValueVariant0ItemVariant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -41886,14 +41246,6 @@ impl ::std::convert::TryFrom<::std::string::String> for TextValueVariant0ItemVar
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for TextValueVariant0ItemVariant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for TextValueVariant0ItemVariant0Variant3Range {
@@ -41965,23 +41317,23 @@ impl ::std::convert::From<TextValueVariant1Variant2> for TextValueVariant1 {
 #[serde(untagged)]
 pub enum TextValueVariant1Variant0 {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         signal: ::std::string::String,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
         value: TextValueVariant1Variant0Variant1Value,
     },
     Variant2 {
         field: Field,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
     Variant3 {
         range: TextValueVariant1Variant0Variant3Range,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         scale: ::std::option::Option<Field>,
     },
 }
@@ -42005,6 +41357,14 @@ impl ::std::convert::From<::std::vec::Vec<::std::string::String>>
 pub enum TextValueVariant1Variant0Variant3Range {
     Number(f64),
     Boolean(bool),
+}
+impl ::std::fmt::Display for TextValueVariant1Variant0Variant3Range {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Number(x) => x.fmt(f),
+            Self::Boolean(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for TextValueVariant1Variant0Variant3Range {
     type Err = self::error::ConversionError;
@@ -42030,14 +41390,6 @@ impl ::std::convert::TryFrom<::std::string::String> for TextValueVariant1Variant
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for TextValueVariant1Variant0Variant3Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Number(x) => x.fmt(f),
-            Self::Boolean(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<f64> for TextValueVariant1Variant0Variant3Range {
@@ -42156,7 +41508,7 @@ pub enum TickCount {
     Variant1(TickCountVariant1),
     Variant2 {
         interval: TickCountVariant2Interval,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         step: ::std::option::Option<NumberOrSignal>,
     },
     Variant3(SignalRef),
@@ -42349,14 +41701,14 @@ impl ::std::convert::TryFrom<::std::string::String> for TickCountVariant2Interva
 pub struct TimeunitTransform {
     #[serde(rename = "as", default = "defaults::timeunit_transform_as")]
     pub as_: TimeunitTransformAs,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub extent: ::std::option::Option<TimeunitTransformExtent>,
     pub field: TimeunitTransformField,
     #[serde(default = "defaults::timeunit_transform_interval")]
     pub interval: TimeunitTransformInterval,
     #[serde(default = "defaults::timeunit_transform_maxbins")]
     pub maxbins: TimeunitTransformMaxbins,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(default = "defaults::timeunit_transform_step")]
     pub step: TimeunitTransformStep,
@@ -42364,7 +41716,7 @@ pub struct TimeunitTransform {
     pub timezone: TimeunitTransformTimezone,
     #[serde(rename = "type")]
     pub type_: TimeunitTransformType,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub units: ::std::option::Option<TimeunitTransformUnits>,
 }
 #[doc = "`TimeunitTransformAs`"]
@@ -42780,111 +42132,100 @@ impl ::std::convert::TryFrom<::std::string::String> for TimeunitTransformUnitsAr
 pub enum Title {
     String(::std::string::String),
     Object {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         align: ::std::option::Option<TitleObjectAlign>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         anchor: ::std::option::Option<TitleObjectAnchor>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         angle: ::std::option::Option<TitleObjectAngle>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         aria: ::std::option::Option<bool>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         baseline: ::std::option::Option<TitleObjectBaseline>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         color: ::std::option::Option<TitleObjectColor>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         dx: ::std::option::Option<TitleObjectDx>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         dy: ::std::option::Option<TitleObjectDy>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         encode: ::std::option::Option<TitleObjectEncode>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         font: ::std::option::Option<TitleObjectFont>,
         #[serde(
             rename = "fontSize",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         font_size: ::std::option::Option<TitleObjectFontSize>,
         #[serde(
             rename = "fontStyle",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         font_style: ::std::option::Option<TitleObjectFontStyle>,
         #[serde(
             rename = "fontWeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         font_weight: ::std::option::Option<TitleObjectFontWeight>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         frame: ::std::option::Option<TitleObjectFrame>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         interactive: ::std::option::Option<bool>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         limit: ::std::option::Option<TitleObjectLimit>,
         #[serde(
             rename = "lineHeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         line_height: ::std::option::Option<TitleObjectLineHeight>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         name: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         offset: ::std::option::Option<TitleObjectOffset>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         orient: ::std::option::Option<TitleObjectOrient>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         style: ::std::option::Option<Style>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         subtitle: ::std::option::Option<TextOrSignal>,
         #[serde(
             rename = "subtitleColor",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         subtitle_color: ::std::option::Option<TitleObjectSubtitleColor>,
         #[serde(
             rename = "subtitleFont",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         subtitle_font: ::std::option::Option<TitleObjectSubtitleFont>,
         #[serde(
             rename = "subtitleFontSize",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         subtitle_font_size: ::std::option::Option<TitleObjectSubtitleFontSize>,
         #[serde(
             rename = "subtitleFontStyle",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         subtitle_font_style: ::std::option::Option<TitleObjectSubtitleFontStyle>,
         #[serde(
             rename = "subtitleFontWeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         subtitle_font_weight: ::std::option::Option<TitleObjectSubtitleFontWeight>,
         #[serde(
             rename = "subtitleLineHeight",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         subtitle_line_height: ::std::option::Option<TitleObjectSubtitleLineHeight>,
         #[serde(
             rename = "subtitlePadding",
-            default,
             skip_serializing_if = "::std::option::Option::is_none"
         )]
         subtitle_padding: ::std::option::Option<NumberOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         text: ::std::option::Option<TextOrSignal>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         zindex: ::std::option::Option<f64>,
     },
 }
@@ -43183,19 +42524,11 @@ impl ::std::convert::From<NumberValue> for TitleObjectDy {
 #[doc = "`TitleObjectEncode`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct TitleObjectEncode {
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
+    #[serde(flatten, skip_serializing_if = "::std::option::Option::is_none")]
     pub subtype_0: ::std::option::Option<
         ::std::collections::HashMap<TitleObjectEncodeSubtype0Key, EncodeEntry>,
     >,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
+    #[serde(flatten, skip_serializing_if = "::std::option::Option::is_none")]
     pub subtype_1: ::std::option::Option<TitleObjectEncodeSubtype1>,
 }
 #[doc = "`TitleObjectEncodeSubtype0Key`"]
@@ -43256,11 +42589,11 @@ impl<'de> ::serde::Deserialize<'de> for TitleObjectEncodeSubtype0Key {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct TitleObjectEncodeSubtype1 {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub group: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub subtitle: ::std::option::Option<GuideEncode>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<GuideEncode>,
 }
 #[doc = "`TitleObjectFont`"]
@@ -44110,23 +43443,22 @@ impl ::std::convert::From<WordcloudTransform> for TransformMark {
 pub struct TreeTransform {
     #[serde(rename = "as", default = "defaults::tree_transform_as")]
     pub as_: TreeTransformAs,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub field: ::std::option::Option<TreeTransformField>,
     #[serde(default = "defaults::tree_transform_method")]
     pub method: TreeTransformMethod,
     #[serde(
         rename = "nodeSize",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub node_size: ::std::option::Option<TreeTransformNodeSize>,
     #[serde(default = "defaults::tree_transform_separation")]
     pub separation: TreeTransformSeparation,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub size: ::std::option::Option<TreeTransformSize>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub sort: ::std::option::Option<Compare>,
     #[serde(rename = "type")]
     pub type_: TreeTransformType,
@@ -44407,7 +43739,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TreeTransformType {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct TreelinksTransform {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]
     pub type_: TreelinksTransformType,
@@ -44465,57 +43797,51 @@ impl ::std::convert::TryFrom<::std::string::String> for TreelinksTransformType {
 pub struct TreemapTransform {
     #[serde(rename = "as", default = "defaults::treemap_transform_as")]
     pub as_: TreemapTransformAs,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub field: ::std::option::Option<TreemapTransformField>,
     #[serde(default = "defaults::treemap_transform_method")]
     pub method: TreemapTransformMethod,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub padding: ::std::option::Option<TreemapTransformPadding>,
     #[serde(
         rename = "paddingBottom",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub padding_bottom: ::std::option::Option<TreemapTransformPaddingBottom>,
     #[serde(
         rename = "paddingInner",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub padding_inner: ::std::option::Option<TreemapTransformPaddingInner>,
     #[serde(
         rename = "paddingLeft",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub padding_left: ::std::option::Option<TreemapTransformPaddingLeft>,
     #[serde(
         rename = "paddingOuter",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub padding_outer: ::std::option::Option<TreemapTransformPaddingOuter>,
     #[serde(
         rename = "paddingRight",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub padding_right: ::std::option::Option<TreemapTransformPaddingRight>,
     #[serde(
         rename = "paddingTop",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub padding_top: ::std::option::Option<TreemapTransformPaddingTop>,
     #[serde(default = "defaults::treemap_transform_ratio")]
     pub ratio: TreemapTransformRatio,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub round: ::std::option::Option<TreemapTransformRound>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub size: ::std::option::Option<TreemapTransformSize>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub sort: ::std::option::Option<Compare>,
     #[serde(rename = "type")]
     pub type_: TreemapTransformType,
@@ -44920,9 +44246,9 @@ pub struct VoronoiTransform {
     pub as_: VoronoiTransformAs,
     #[serde(default = "defaults::voronoi_transform_extent")]
     pub extent: VoronoiTransformExtent,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub size: ::std::option::Option<VoronoiTransformSize>,
     #[serde(rename = "type")]
     pub type_: VoronoiTransformType,
@@ -45102,31 +44428,26 @@ impl ::std::convert::From<Expr> for VoronoiTransformY {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct WindowTransform {
-    #[serde(
-        rename = "as",
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
+    #[serde(rename = "as", skip_serializing_if = "::std::option::Option::is_none")]
     pub as_: ::std::option::Option<WindowTransformAs>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub fields: ::std::option::Option<WindowTransformFields>,
     #[serde(default = "defaults::window_transform_frame")]
     pub frame: WindowTransformFrame,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub groupby: ::std::option::Option<WindowTransformGroupby>,
     #[serde(
         rename = "ignorePeers",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub ignore_peers: ::std::option::Option<WindowTransformIgnorePeers>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub ops: ::std::option::Option<WindowTransformOps>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub params: ::std::option::Option<WindowTransformParams>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub sort: ::std::option::Option<Compare>,
     #[serde(rename = "type")]
     pub type_: WindowTransformType,
@@ -45643,17 +44964,17 @@ pub struct WordcloudTransform {
         default = "defaults::wordcloud_transform_font_weight"
     )]
     pub font_weight: WordcloudTransformFontWeight,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub padding: ::std::option::Option<WordcloudTransformPadding>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub rotate: ::std::option::Option<WordcloudTransformRotate>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub signal: ::std::option::Option<::std::string::String>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub size: ::std::option::Option<WordcloudTransformSize>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub spiral: ::std::option::Option<WordcloudTransformSpiral>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub text: ::std::option::Option<WordcloudTransformText>,
     #[serde(rename = "type")]
     pub type_: WordcloudTransformType,
@@ -46040,7 +45361,7 @@ impl ::std::convert::TryFrom<::std::string::String> for WordcloudTransformType {
         value.parse()
     }
 }
-#[doc = r" Generation of default values for serde."]
+#[doc = " Generation of default values for serde."]
 pub mod defaults {
     pub(super) fn default_bool<const V: bool>() -> bool {
         V
@@ -46489,5 +45810,31 @@ pub mod defaults {
     }
     pub(super) fn wordcloud_transform_font_weight() -> super::WordcloudTransformFontWeight {
         super::WordcloudTransformFontWeight::String("normal".to_string())
+    }
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
     }
 }

--- a/typify/tests/schemas/arrays-and-tuples.rs
+++ b/typify/tests/schemas/arrays-and-tuples.rs
@@ -1,30 +1,4 @@
 #![deny(warnings)]
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`ArraySansItems`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(transparent)]
@@ -163,6 +137,32 @@ impl ::std::convert::From<YoloTwoArray> for [::serde_json::Value; 2usize] {
 impl ::std::convert::From<[::serde_json::Value; 2usize]> for YoloTwoArray {
     fn from(value: [::serde_json::Value; 2usize]) -> Self {
         Self(value)
+    }
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
     }
 }
 fn main() {}

--- a/typify/tests/schemas/deny-list.rs
+++ b/typify/tests/schemas/deny-list.rs
@@ -1,30 +1,4 @@
 #![deny(warnings)]
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`TestType`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 pub struct TestType {
@@ -108,7 +82,7 @@ impl<'de> ::serde::Deserialize<'de> for TestTypeWhyNot {
             .map_err(|e| <D::Error as ::serde::de::Error>::custom(e.to_string()))
     }
 }
-#[doc = r" Types for composing complex structures."]
+#[doc = " Types for composing complex structures."]
 pub mod builder {
     #[derive(Clone, Debug)]
     pub struct TestType {
@@ -160,6 +134,32 @@ pub mod builder {
                 where_not: Ok(value.where_not),
                 why_not: Ok(value.why_not),
             }
+        }
+    }
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
         }
     }
 }

--- a/typify/tests/schemas/extraneous-enum.rs
+++ b/typify/tests/schemas/extraneous-enum.rs
@@ -1,34 +1,8 @@
 #![deny(warnings)]
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`LetterBox`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct LetterBox {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub letter: ::std::option::Option<LetterBoxLetter>,
 }
 impl LetterBox {
@@ -87,7 +61,7 @@ impl ::std::convert::TryFrom<::std::string::String> for LetterBoxLetter {
         value.parse()
     }
 }
-#[doc = r" Types for composing complex structures."]
+#[doc = " Types for composing complex structures."]
 pub mod builder {
     #[derive(Clone, Debug)]
     pub struct LetterBox {
@@ -130,6 +104,32 @@ pub mod builder {
             Self {
                 letter: Ok(value.letter),
             }
+        }
+    }
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
         }
     }
 }

--- a/typify/tests/schemas/id-or-name.rs
+++ b/typify/tests/schemas/id-or-name.rs
@@ -1,36 +1,18 @@
 #![deny(warnings)]
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`IdOrName`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum IdOrName {
     Id(::uuid::Uuid),
     Name(Name),
+}
+impl ::std::fmt::Display for IdOrName {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Id(x) => x.fmt(f),
+            Self::Name(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for IdOrName {
     type Err = self::error::ConversionError;
@@ -58,14 +40,6 @@ impl ::std::convert::TryFrom<::std::string::String> for IdOrName {
         value.parse()
     }
 }
-impl ::std::fmt::Display for IdOrName {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Id(x) => x.fmt(f),
-            Self::Name(x) => x.fmt(f),
-        }
-    }
-}
 impl ::std::convert::From<::uuid::Uuid> for IdOrName {
     fn from(value: ::uuid::Uuid) -> Self {
         Self::Id(value)
@@ -82,6 +56,14 @@ impl ::std::convert::From<Name> for IdOrName {
 pub enum IdOrNameRedundant {
     Uuid(::uuid::Uuid),
     String(Name),
+}
+impl ::std::fmt::Display for IdOrNameRedundant {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Uuid(x) => x.fmt(f),
+            Self::String(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for IdOrNameRedundant {
     type Err = self::error::ConversionError;
@@ -109,14 +91,6 @@ impl ::std::convert::TryFrom<::std::string::String> for IdOrNameRedundant {
         value.parse()
     }
 }
-impl ::std::fmt::Display for IdOrNameRedundant {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Uuid(x) => x.fmt(f),
-            Self::String(x) => x.fmt(f),
-        }
-    }
-}
 impl ::std::convert::From<::uuid::Uuid> for IdOrNameRedundant {
     fn from(value: ::uuid::Uuid) -> Self {
         Self::Uuid(value)
@@ -133,6 +107,14 @@ impl ::std::convert::From<Name> for IdOrNameRedundant {
 pub enum IdOrYolo {
     Id(::uuid::Uuid),
     Yolo(IdOrYoloYolo),
+}
+impl ::std::fmt::Display for IdOrYolo {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::Id(x) => x.fmt(f),
+            Self::Yolo(x) => x.fmt(f),
+        }
+    }
 }
 impl ::std::str::FromStr for IdOrYolo {
     type Err = self::error::ConversionError;
@@ -158,14 +140,6 @@ impl ::std::convert::TryFrom<::std::string::String> for IdOrYolo {
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for IdOrYolo {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::Id(x) => x.fmt(f),
-            Self::Yolo(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<::uuid::Uuid> for IdOrYolo {
@@ -286,6 +260,32 @@ impl<'de> ::serde::Deserialize<'de> for Name {
             .map_err(|e: self::error::ConversionError| {
                 <D::Error as ::serde::de::Error>::custom(e.to_string())
             })
+    }
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
     }
 }
 fn main() {}

--- a/typify/tests/schemas/maps.rs
+++ b/typify/tests/schemas/maps.rs
@@ -1,30 +1,4 @@
 #![deny(warnings)]
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`DeadSimple`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(transparent)]
@@ -79,15 +53,15 @@ impl ::std::convert::From<::std::string::String> for Eh {
         Self(value)
     }
 }
+impl ::std::fmt::Display for Eh {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 impl ::std::str::FromStr for Eh {
     type Err = ::std::convert::Infallible;
     fn from_str(value: &str) -> ::std::result::Result<Self, Self::Err> {
         Ok(Self(value.to_string()))
-    }
-}
-impl ::std::fmt::Display for Eh {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        self.0.fmt(f)
     }
 }
 #[doc = "`MapWithDateKeys`"]
@@ -196,15 +170,41 @@ impl ::std::convert::From<::std::string::String> for Value {
         Self(value)
     }
 }
+impl ::std::fmt::Display for Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 impl ::std::str::FromStr for Value {
     type Err = ::std::convert::Infallible;
     fn from_str(value: &str) -> ::std::result::Result<Self, Self::Err> {
         Ok(Self(value.to_string()))
     }
 }
-impl ::std::fmt::Display for Value {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        self.0.fmt(f)
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
     }
 }
 fn main() {}

--- a/typify/tests/schemas/maps_custom.rs
+++ b/typify/tests/schemas/maps_custom.rs
@@ -1,30 +1,4 @@
 #![deny(warnings)]
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`DeadSimple`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(transparent)]
@@ -79,15 +53,15 @@ impl ::std::convert::From<::std::string::String> for Eh {
         Self(value)
     }
 }
+impl ::std::fmt::Display for Eh {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 impl ::std::str::FromStr for Eh {
     type Err = ::std::convert::Infallible;
     fn from_str(value: &str) -> ::std::result::Result<Self, Self::Err> {
         Ok(Self(value.to_string()))
-    }
-}
-impl ::std::fmt::Display for Eh {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        self.0.fmt(f)
     }
 }
 #[doc = "`MapWithDateKeys`"]
@@ -196,15 +170,41 @@ impl ::std::convert::From<::std::string::String> for Value {
         Self(value)
     }
 }
+impl ::std::fmt::Display for Value {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 impl ::std::str::FromStr for Value {
     type Err = ::std::convert::Infallible;
     fn from_str(value: &str) -> ::std::result::Result<Self, Self::Err> {
         Ok(Self(value.to_string()))
     }
 }
-impl ::std::fmt::Display for Value {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        self.0.fmt(f)
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
     }
 }
 fn main() {}

--- a/typify/tests/schemas/merged-schemas.rs
+++ b/typify/tests/schemas/merged-schemas.rs
@@ -1,34 +1,8 @@
 #![deny(warnings)]
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`BarProp`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct BarProp {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub bar: ::std::option::Option<::serde_json::Value>,
 }
 impl BarProp {
@@ -39,7 +13,7 @@ impl BarProp {
 #[doc = "`ButNotThat`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct ButNotThat {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub this: ::std::option::Option<::serde_json::Value>,
 }
 impl ButNotThat {
@@ -50,9 +24,9 @@ impl ButNotThat {
 #[doc = "if we don't see this, we dropped the metadata"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct CommentedTypeMerged {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub x: ::std::option::Option<::serde_json::Value>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub y: ::std::option::Option<::serde_json::Value>,
 }
 impl CommentedTypeMerged {
@@ -65,22 +39,22 @@ impl CommentedTypeMerged {
 #[serde(untagged)]
 pub enum HereAndThere {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         bar: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         foo: ::std::option::Option<::std::string::String>,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         baz: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         foo: ::std::option::Option<::std::string::String>,
     },
 }
 #[doc = "`JsonResponseBase`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct JsonResponseBase {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub result: ::std::option::Option<::std::string::String>,
 }
 impl JsonResponseBase {
@@ -234,6 +208,11 @@ impl ::std::convert::From<f64> for MergeNumberBounds {
         Self(value)
     }
 }
+impl ::std::fmt::Display for MergeNumberBounds {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 impl ::std::str::FromStr for MergeNumberBounds {
     type Err = <f64 as ::std::str::FromStr>::Err;
     fn from_str(value: &str) -> ::std::result::Result<Self, Self::Err> {
@@ -250,11 +229,6 @@ impl ::std::convert::TryFrom<String> for MergeNumberBounds {
     type Error = <f64 as ::std::str::FromStr>::Err;
     fn try_from(value: String) -> ::std::result::Result<Self, Self::Error> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for MergeNumberBounds {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        self.0.fmt(f)
     }
 }
 #[doc = "`MergeStringBounds`"]
@@ -330,6 +304,11 @@ impl ::std::convert::From<::std::num::NonZeroU64> for NarrowNumber {
         Self(value)
     }
 }
+impl ::std::fmt::Display for NarrowNumber {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 impl ::std::str::FromStr for NarrowNumber {
     type Err = <::std::num::NonZeroU64 as ::std::str::FromStr>::Err;
     fn from_str(value: &str) -> ::std::result::Result<Self, Self::Err> {
@@ -348,15 +327,10 @@ impl ::std::convert::TryFrom<String> for NarrowNumber {
         value.parse()
     }
 }
-impl ::std::fmt::Display for NarrowNumber {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        self.0.fmt(f)
-    }
-}
 #[doc = "`OrderDependentMerge`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 pub struct OrderDependentMerge {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub bar: ::std::option::Option<::serde_json::Value>,
     pub baz: bool,
 }
@@ -378,7 +352,7 @@ impl Pickingone {
 #[doc = "`PickingoneInstallation`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct PickingoneInstallation {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub suspended_by: ::std::option::Option<PickingoneUser>,
 }
 impl PickingoneInstallation {
@@ -389,7 +363,7 @@ impl PickingoneInstallation {
 #[doc = "`PickingoneSuspendedBy`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct PickingoneSuspendedBy {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub email: ::std::option::Option<::std::string::String>,
 }
 impl PickingoneSuspendedBy {
@@ -400,7 +374,7 @@ impl PickingoneSuspendedBy {
 #[doc = "`PickingoneUser`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct PickingoneUser {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub email: ::std::option::Option<::std::string::String>,
 }
 impl PickingoneUser {
@@ -592,7 +566,7 @@ pub enum Unsatisfiable3 {}
 #[doc = "`Unsatisfiable3A`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct Unsatisfiable3A {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub action: ::std::option::Option<Unsatisfiable3C>,
 }
 impl Unsatisfiable3A {
@@ -713,7 +687,7 @@ pub enum WeirdEnum {
         pattern_regex: ::std::string::String,
     },
 }
-#[doc = r" Types for composing complex structures."]
+#[doc = " Types for composing complex structures."]
 pub mod builder {
     #[derive(Clone, Debug)]
     pub struct BarProp {
@@ -1356,6 +1330,32 @@ pub mod builder {
             Self {
                 action: Ok(value.action),
             }
+        }
+    }
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
         }
     }
 }

--- a/typify/tests/schemas/more_types.rs
+++ b/typify/tests/schemas/more_types.rs
@@ -1,30 +1,4 @@
 #![deny(warnings)]
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`ObjectWithNoExtra`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
@@ -80,7 +54,7 @@ impl ObjectWithYesExtra {
         Default::default()
     }
 }
-#[doc = r" Types for composing complex structures."]
+#[doc = " Types for composing complex structures."]
 pub mod builder {
     #[derive(Clone, Debug)]
     pub struct ObjectWithNoExtra {
@@ -306,6 +280,32 @@ pub mod builder {
     impl ::std::convert::From<super::ObjectWithYesExtra> for ObjectWithYesExtra {
         fn from(value: super::ObjectWithYesExtra) -> Self {
             Self { foo: Ok(value.foo) }
+        }
+    }
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
         }
     }
 }

--- a/typify/tests/schemas/multiple-instance-types.rs
+++ b/typify/tests/schemas/multiple-instance-types.rs
@@ -1,30 +1,4 @@
 #![deny(warnings)]
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`IntOrStr`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(untagged)]
@@ -124,13 +98,39 @@ impl ::std::convert::From<::serde_json::Value> for SeriouslyAnything {
 pub enum YesNoMaybe {
     Boolean(bool),
     Object {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         value: ::std::option::Option<::std::string::String>,
     },
 }
 impl ::std::convert::From<bool> for YesNoMaybe {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
+    }
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
     }
 }
 fn main() {}

--- a/typify/tests/schemas/noisy-types.rs
+++ b/typify/tests/schemas/noisy-types.rs
@@ -1,30 +1,4 @@
 #![deny(warnings)]
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`ArrayBs`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(transparent)]
@@ -65,6 +39,11 @@ impl ::std::convert::From<u64> for IntegerBs {
         Self(value)
     }
 }
+impl ::std::fmt::Display for IntegerBs {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 impl ::std::str::FromStr for IntegerBs {
     type Err = <u64 as ::std::str::FromStr>::Err;
     fn from_str(value: &str) -> ::std::result::Result<Self, Self::Err> {
@@ -83,15 +62,10 @@ impl ::std::convert::TryFrom<String> for IntegerBs {
         value.parse()
     }
 }
-impl ::std::fmt::Display for IntegerBs {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        self.0.fmt(f)
-    }
-}
 #[doc = "`ObjectBs`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct ObjectBs {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub ok: ::std::option::Option<bool>,
 }
 impl ObjectBs {
@@ -99,7 +73,7 @@ impl ObjectBs {
         Default::default()
     }
 }
-#[doc = r" Types for composing complex structures."]
+#[doc = " Types for composing complex structures."]
 pub mod builder {
     #[derive(Clone, Debug)]
     pub struct ObjectBs {
@@ -133,6 +107,32 @@ pub mod builder {
     impl ::std::convert::From<super::ObjectBs> for ObjectBs {
         fn from(value: super::ObjectBs) -> Self {
             Self { ok: Ok(value.ok) }
+        }
+    }
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
         }
     }
 }

--- a/typify/tests/schemas/property-pattern.rs
+++ b/typify/tests/schemas/property-pattern.rs
@@ -1,30 +1,4 @@
 #![deny(warnings)]
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`TestGrammarForPatternProperties`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
@@ -89,7 +63,7 @@ impl<'de> ::serde::Deserialize<'de> for TestGrammarForPatternPropertiesRulesKey 
             })
     }
 }
-#[doc = r" Types for composing complex structures."]
+#[doc = " Types for composing complex structures."]
 pub mod builder {
     #[derive(Clone, Debug)]
     pub struct TestGrammarForPatternProperties {
@@ -144,6 +118,32 @@ pub mod builder {
             Self {
                 rules: Ok(value.rules),
             }
+        }
+    }
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
         }
     }
 }

--- a/typify/tests/schemas/reflexive.rs
+++ b/typify/tests/schemas/reflexive.rs
@@ -1,36 +1,10 @@
 #![deny(warnings)]
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`Node`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct Node {
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub children: ::std::vec::Vec<Node>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub value: ::std::option::Option<i64>,
 }
 impl Node {
@@ -38,7 +12,7 @@ impl Node {
         Default::default()
     }
 }
-#[doc = r" Types for composing complex structures."]
+#[doc = " Types for composing complex structures."]
 pub mod builder {
     #[derive(Clone, Debug)]
     pub struct Node {
@@ -90,6 +64,32 @@ pub mod builder {
                 children: Ok(value.children),
                 value: Ok(value.value),
             }
+        }
+    }
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
         }
     }
 }

--- a/typify/tests/schemas/rust-collisions.rs
+++ b/typify/tests/schemas/rust-collisions.rs
@@ -1,30 +1,4 @@
 #![deny(warnings)]
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`Box`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 pub struct Box {
@@ -48,7 +22,7 @@ impl Copy {
 #[doc = "`DoubleOptionCollision`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct DoubleOptionCollision {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub option: ::std::option::Option<DoubleOptionCollisionOption>,
 }
 impl DoubleOptionCollision {
@@ -59,7 +33,7 @@ impl DoubleOptionCollision {
 #[doc = "`DoubleOptionCollisionOption`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct DoubleOptionCollisionOption {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub option: ::std::option::Option<::std::string::String>,
 }
 impl DoubleOptionCollisionOption {
@@ -286,7 +260,7 @@ impl ::std::convert::TryFrom<::std::string::String> for MapOfKeywordsKeywordMapV
 #[doc = "`NestedTypeCollisions`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 pub struct NestedTypeCollisions {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub option_type: ::std::option::Option<NestedTypeCollisionsOptionType>,
     #[serde(rename = "type")]
     pub type_: TypeWithOptionField,
@@ -302,7 +276,6 @@ impl NestedTypeCollisions {
 pub struct NestedTypeCollisionsOptionType {
     #[serde(
         rename = "type",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub type_: ::std::option::Option<::std::string::String>,
@@ -680,7 +653,7 @@ impl :: std :: convert :: From < :: serde_json :: Value > for TestSchemaWithVari
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 pub struct TypeWithOptionField {
     pub boxed_field: Box,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub optional_field: ::std::option::Option<::std::string::String>,
 }
 impl TypeWithOptionField {
@@ -698,7 +671,7 @@ impl Vec {
         Default::default()
     }
 }
-#[doc = r" Types for composing complex structures."]
+#[doc = " Types for composing complex structures."]
 pub mod builder {
     #[derive(Clone, Debug)]
     pub struct Box {
@@ -2543,6 +2516,32 @@ pub mod builder {
             Self {
                 items: Ok(value.items),
             }
+        }
+    }
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
         }
     }
 }

--- a/typify/tests/schemas/simple-types.rs
+++ b/typify/tests/schemas/simple-types.rs
@@ -1,30 +1,4 @@
 #![deny(warnings)]
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`AnythingWorks`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 pub struct AnythingWorks {
@@ -38,7 +12,7 @@ impl AnythingWorks {
 #[doc = "`FloatsArentTerribleImTold`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct FloatsArentTerribleImTold {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub flush_timeout: ::std::option::Option<f32>,
 }
 impl FloatsArentTerribleImTold {
@@ -76,15 +50,15 @@ impl ::std::convert::From<::std::string::String> for JustOne {
         Self(value)
     }
 }
+impl ::std::fmt::Display for JustOne {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 impl ::std::str::FromStr for JustOne {
     type Err = ::std::convert::Infallible;
     fn from_str(value: &str) -> ::std::result::Result<Self, Self::Err> {
         Ok(Self(value.to_string()))
-    }
-}
-impl ::std::fmt::Display for JustOne {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        self.0.fmt(f)
     }
 }
 #[doc = "`UintMinimumAndMaximum`"]
@@ -102,7 +76,7 @@ impl UintMinimumAndMaximum {
         Default::default()
     }
 }
-#[doc = r" Types for composing complex structures."]
+#[doc = " Types for composing complex structures."]
 pub mod builder {
     #[derive(Clone, Debug)]
     pub struct AnythingWorks {
@@ -292,6 +266,32 @@ pub mod builder {
                 min_uint_non_zero: Ok(value.min_uint_non_zero),
                 no_bounds: Ok(value.no_bounds),
             }
+        }
+    }
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
         }
     }
 }

--- a/typify/tests/schemas/string-enum-with-default.rs
+++ b/typify/tests/schemas/string-enum-with-default.rs
@@ -1,30 +1,4 @@
 #![deny(warnings)]
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`TestEnum`"]
 #[derive(
     :: serde :: Deserialize,
@@ -83,6 +57,32 @@ impl ::std::convert::TryFrom<::std::string::String> for TestEnum {
 impl ::std::default::Default for TestEnum {
     fn default() -> Self {
         TestEnum::Failure
+    }
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
     }
 }
 fn main() {}

--- a/typify/tests/schemas/type-with-modified-generation.rs
+++ b/typify/tests/schemas/type-with-modified-generation.rs
@@ -1,30 +1,4 @@
 #![deny(warnings)]
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`TestType`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 pub struct TestType {
@@ -65,7 +39,7 @@ impl ::std::convert::From<::std::collections::HashMap<::std::string::String, ::s
         Self(value)
     }
 }
-#[doc = r" Types for composing complex structures."]
+#[doc = " Types for composing complex structures."]
 pub mod builder {
     #[derive(Clone, Debug)]
     pub struct TestType {
@@ -131,6 +105,32 @@ pub mod builder {
                 patched_type: Ok(value.patched_type),
                 replaced_type: Ok(value.replaced_type),
             }
+        }
+    }
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
         }
     }
 }

--- a/typify/tests/schemas/types-with-defaults.rs
+++ b/typify/tests/schemas/types-with-defaults.rs
@@ -1,30 +1,4 @@
 #![deny(warnings)]
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`Doodad`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 pub struct Doodad {
@@ -70,7 +44,7 @@ impl MrDefaultNumbers {
 #[doc = "`OuterThing`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct OuterThing {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub thing: ::std::option::Option<ThingWithDefaults>,
 }
 impl OuterThing {
@@ -103,11 +77,10 @@ impl TestBed {
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct ThingWithDefaults {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub a: ::std::option::Option<::std::string::String>,
     #[serde(
         rename = "type",
-        default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub type_: ::std::option::Option<::std::string::String>,
@@ -145,6 +118,11 @@ impl ::std::convert::From<i64> for UInt {
         Self(value)
     }
 }
+impl ::std::fmt::Display for UInt {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 impl ::std::str::FromStr for UInt {
     type Err = <i64 as ::std::str::FromStr>::Err;
     fn from_str(value: &str) -> ::std::result::Result<Self, Self::Err> {
@@ -161,11 +139,6 @@ impl ::std::convert::TryFrom<String> for UInt {
     type Error = <i64 as ::std::str::FromStr>::Err;
     fn try_from(value: String) -> ::std::result::Result<Self, Self::Error> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for UInt {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        self.0.fmt(f)
     }
 }
 #[doc = "`UIntContainer`"]
@@ -186,7 +159,7 @@ impl UIntContainer {
         Default::default()
     }
 }
-#[doc = r" Types for composing complex structures."]
+#[doc = " Types for composing complex structures."]
 pub mod builder {
     #[derive(Clone, Debug)]
     pub struct Doodad {
@@ -492,7 +465,7 @@ pub mod builder {
         }
     }
 }
-#[doc = r" Generation of default values for serde."]
+#[doc = " Generation of default values for serde."]
 pub mod defaults {
     pub(super) fn default_nzu64<T, const V: u64>() -> T
     where
@@ -522,6 +495,32 @@ pub mod defaults {
     }
     pub(super) fn u_int_container_max_path() -> super::UInt {
         super::UInt(1_i64)
+    }
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
     }
 }
 fn main() {}

--- a/typify/tests/schemas/types-with-more-impls.rs
+++ b/typify/tests/schemas/types-with-more-impls.rs
@@ -1,30 +1,4 @@
 #![deny(warnings)]
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`PatternString`"]
 #[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[serde(transparent)]
@@ -109,6 +83,32 @@ impl<'de> ::serde::Deserialize<'de> for Sub10Primes {
     {
         Self::try_from(<u32>::deserialize(deserializer)?)
             .map_err(|e| <D::Error as ::serde::de::Error>::custom(e.to_string()))
+    }
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
     }
 }
 fn main() {}

--- a/typify/tests/schemas/untyped-enum-with-null.rs
+++ b/typify/tests/schemas/untyped-enum-with-null.rs
@@ -1,33 +1,8 @@
 #![deny(warnings)]
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`TestType`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 pub struct TestType {
+    #[serde(deserialize_with = "::std::option::Option::deserialize")]
     pub value: ::std::option::Option<TestTypeValue>,
 }
 impl TestType {
@@ -90,7 +65,7 @@ impl ::std::convert::TryFrom<::std::string::String> for TestTypeValue {
         value.parse()
     }
 }
-#[doc = r" Types for composing complex structures."]
+#[doc = " Types for composing complex structures."]
 pub mod builder {
     #[derive(Clone, Debug)]
     pub struct TestType {
@@ -131,6 +106,32 @@ pub mod builder {
             Self {
                 value: Ok(value.value),
             }
+        }
+    }
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
         }
     }
 }

--- a/typify/tests/schemas/various-enums-json-schema.rs
+++ b/typify/tests/schemas/various-enums-json-schema.rs
@@ -1,30 +1,4 @@
 #![deny(warnings)]
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`AlternativeEnum`"]
 #[derive(
     :: serde :: Deserialize,
@@ -297,7 +271,7 @@ impl ::std::default::Default for DiskAttachmentState {
     :: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default, schemars :: JsonSchema,
 )]
 pub struct EmptyObject {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub prop: ::std::option::Option<EmptyObjectProp>,
 }
 impl EmptyObject {
@@ -382,6 +356,14 @@ pub enum IpNet {
     V4(Ipv4Net),
     V6(Ipv6Net),
 }
+impl ::std::fmt::Display for IpNet {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::V4(x) => x.fmt(f),
+            Self::V6(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for IpNet {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -406,14 +388,6 @@ impl ::std::convert::TryFrom<::std::string::String> for IpNet {
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for IpNet {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::V4(x) => x.fmt(f),
-            Self::V6(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<Ipv4Net> for IpNet {
@@ -763,17 +737,17 @@ impl ::std::convert::TryFrom<::std::string::String> for NullStringEnumWithUnknow
 #[serde(untagged)]
 pub enum OneOfMissingTitle {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         foo: ::std::option::Option<::std::string::String>,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         bar: ::std::option::Option<i64>,
     },
     Variant2 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         bar: ::std::option::Option<i64>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         baz: ::std::option::Option<i64>,
     },
 }
@@ -961,15 +935,15 @@ impl ::std::convert::From<::std::string::String> for ReferenceDef {
         Self(value)
     }
 }
+impl ::std::fmt::Display for ReferenceDef {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 impl ::std::str::FromStr for ReferenceDef {
     type Err = ::std::convert::Infallible;
     fn from_str(value: &str) -> ::std::result::Result<Self, Self::Err> {
         Ok(Self(value.to_string()))
-    }
-}
-impl ::std::fmt::Display for ReferenceDef {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        self.0.fmt(f)
     }
 }
 #[doc = "issue 280"]
@@ -1056,15 +1030,15 @@ impl ::std::convert::From<::std::string::String> for StringVersion {
         Self(value)
     }
 }
+impl ::std::fmt::Display for StringVersion {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 impl ::std::str::FromStr for StringVersion {
     type Err = ::std::convert::Infallible;
     fn from_str(value: &str) -> ::std::result::Result<Self, Self::Err> {
         Ok(Self(value.to_string()))
-    }
-}
-impl ::std::fmt::Display for StringVersion {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        self.0.fmt(f)
     }
 }
 #[doc = "`VariantsDifferByPunct`"]
@@ -1123,7 +1097,7 @@ impl ::std::convert::TryFrom<::std::string::String> for VariantsDifferByPunct {
         value.parse()
     }
 }
-#[doc = r" Types for composing complex structures."]
+#[doc = " Types for composing complex structures."]
 pub mod builder {
     #[derive(Clone, Debug)]
     pub struct DiskAttachment {
@@ -1218,6 +1192,32 @@ pub mod builder {
             Self {
                 prop: Ok(value.prop),
             }
+        }
+    }
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
         }
     }
 }

--- a/typify/tests/schemas/various-enums.rs
+++ b/typify/tests/schemas/various-enums.rs
@@ -1,30 +1,4 @@
 #![deny(warnings)]
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`AlternativeEnum`"]
 #[derive(
     :: serde :: Deserialize,
@@ -272,7 +246,7 @@ impl ::std::default::Default for DiskAttachmentState {
 #[doc = "`EmptyObject`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct EmptyObject {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub prop: ::std::option::Option<EmptyObjectProp>,
 }
 impl EmptyObject {
@@ -343,6 +317,14 @@ pub enum IpNet {
     V4(Ipv4Net),
     V6(Ipv6Net),
 }
+impl ::std::fmt::Display for IpNet {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::V4(x) => x.fmt(f),
+            Self::V6(x) => x.fmt(f),
+        }
+    }
+}
 impl ::std::str::FromStr for IpNet {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
@@ -367,14 +349,6 @@ impl ::std::convert::TryFrom<::std::string::String> for IpNet {
         value: ::std::string::String,
     ) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
-    }
-}
-impl ::std::fmt::Display for IpNet {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::V4(x) => x.fmt(f),
-            Self::V6(x) => x.fmt(f),
-        }
     }
 }
 impl ::std::convert::From<Ipv4Net> for IpNet {
@@ -678,17 +652,17 @@ impl ::std::convert::TryFrom<::std::string::String> for NullStringEnumWithUnknow
 #[serde(untagged)]
 pub enum OneOfMissingTitle {
     Variant0 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         foo: ::std::option::Option<::std::string::String>,
     },
     Variant1 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         bar: ::std::option::Option<i64>,
     },
     Variant2 {
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         bar: ::std::option::Option<i64>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        #[serde(skip_serializing_if = "::std::option::Option::is_none")]
         baz: ::std::option::Option<i64>,
     },
 }
@@ -875,15 +849,15 @@ impl ::std::convert::From<::std::string::String> for ReferenceDef {
         Self(value)
     }
 }
+impl ::std::fmt::Display for ReferenceDef {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 impl ::std::str::FromStr for ReferenceDef {
     type Err = ::std::convert::Infallible;
     fn from_str(value: &str) -> ::std::result::Result<Self, Self::Err> {
         Ok(Self(value.to_string()))
-    }
-}
-impl ::std::fmt::Display for ReferenceDef {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        self.0.fmt(f)
     }
 }
 #[doc = "issue 280"]
@@ -969,15 +943,15 @@ impl ::std::convert::From<::std::string::String> for StringVersion {
         Self(value)
     }
 }
+impl ::std::fmt::Display for StringVersion {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 impl ::std::str::FromStr for StringVersion {
     type Err = ::std::convert::Infallible;
     fn from_str(value: &str) -> ::std::result::Result<Self, Self::Err> {
         Ok(Self(value.to_string()))
-    }
-}
-impl ::std::fmt::Display for StringVersion {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        self.0.fmt(f)
     }
 }
 #[doc = "`VariantsDifferByPunct`"]
@@ -1035,7 +1009,7 @@ impl ::std::convert::TryFrom<::std::string::String> for VariantsDifferByPunct {
         value.parse()
     }
 }
-#[doc = r" Types for composing complex structures."]
+#[doc = " Types for composing complex structures."]
 pub mod builder {
     #[derive(Clone, Debug)]
     pub struct DiskAttachment {
@@ -1130,6 +1104,32 @@ pub mod builder {
             Self {
                 prop: Ok(value.prop),
             }
+        }
+    }
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
         }
     }
 }

--- a/typify/tests/schemas/x-rust-type.rs
+++ b/typify/tests/schemas/x-rust-type.rs
@@ -1,36 +1,10 @@
 #![deny(warnings)]
-#[doc = r" Error types."]
-pub mod error {
-    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
-    pub struct ConversionError(::std::borrow::Cow<'static, str>);
-    impl ::std::error::Error for ConversionError {}
-    impl ::std::fmt::Display for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Display::fmt(&self.0, f)
-        }
-    }
-    impl ::std::fmt::Debug for ConversionError {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
-            ::std::fmt::Debug::fmt(&self.0, f)
-        }
-    }
-    impl From<&'static str> for ConversionError {
-        fn from(value: &'static str) -> Self {
-            Self(value.into())
-        }
-    }
-    impl From<String> for ConversionError {
-        fn from(value: String) -> Self {
-            Self(value.into())
-        }
-    }
-}
 #[doc = "`AllTheThings`"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug, Default)]
 pub struct AllTheThings {
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub option_marker: ::std::option::Option<::std::option::Option<Marker>>,
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub path: ::std::option::Option<::std::path::PathBuf>,
 }
 impl AllTheThings {
@@ -53,7 +27,7 @@ impl AllTheThings {
 )]
 #[serde(deny_unknown_fields)]
 pub enum Marker {}
-#[doc = r" Types for composing complex structures."]
+#[doc = " Types for composing complex structures."]
 pub mod builder {
     #[derive(Clone, Debug)]
     pub struct AllTheThings {
@@ -113,6 +87,32 @@ pub mod builder {
                 option_marker: Ok(value.option_marker),
                 path: Ok(value.path),
             }
+        }
+    }
+}
+#[doc = " Error types."]
+pub mod error {
+    #[doc = r" Error from a `TryFrom` or `FromStr` implementation."]
+    pub struct ConversionError(::std::borrow::Cow<'static, str>);
+    impl ::std::error::Error for ConversionError {}
+    impl ::std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+    impl ::std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> Result<(), ::std::fmt::Error> {
+            ::std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
         }
     }
 }


### PR DESCRIPTION
- move `mod error` to the end of the file (sort mods alphabetically)
- simplify mod #[doc] attributes
- remove #[serde(default)] from Option types (it's a no-op)
- add #[serde(deserialize_with = "Option::deserialize")] for Option
  fields that are required (without it, they may be absent)
- minor re-ordering of trait impls for consistency

The change for the required `Option` serde annotation is the only functional change: code that was previously relying on the incorrect semantics will break.